### PR TITLE
Implement the apollo graphql subscription protocol

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -164,6 +164,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.reactivex.rxjava2</groupId>
+            <artifactId>rxjava</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.graphql-java</groupId>
             <artifactId>graphql-java-tools</artifactId>
             <scope>test</scope>

--- a/server/src/main/kotlin/com/trib3/server/filters/RequestIdFilter.kt
+++ b/server/src/main/kotlin/com/trib3/server/filters/RequestIdFilter.kt
@@ -32,8 +32,8 @@ class RequestIdFilter : Filter {
          * @param requestId the RequestId to set, defaults to a new random UUID
          * @param block the block of code to execute
          */
-        fun <T> withRequestId(requestId: String = UUID.randomUUID().toString(), block: () -> T): T {
-            val createdId = createRequestId(requestId)
+        fun <T> withRequestId(requestId: String? = null, block: () -> T): T {
+            val createdId = createRequestId(requestId ?: UUID.randomUUID().toString())
             try {
                 return block()
             } finally {

--- a/server/src/main/kotlin/com/trib3/server/graphql/GraphQLQuerySubscriber.kt
+++ b/server/src/main/kotlin/com/trib3/server/graphql/GraphQLQuerySubscriber.kt
@@ -1,0 +1,51 @@
+package com.trib3.server.graphql
+
+import com.trib3.server.filters.RequestIdFilter
+import graphql.ExecutionResult
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
+
+/**
+ * Reactive subscriber for consuming published graphql streaming events and sending them to the socket
+ *
+ * @param socket the websocket to communicate data to
+ * @param messageId the message id that started the query
+ * @param loggingRequestId requestId value for logging
+ */
+class GraphQLQuerySubscriber(val socket: GraphQLWebSocket, val messageId: String?, val loggingRequestId: String) :
+    Subscriber<ExecutionResult> {
+
+    private lateinit var subscription: Subscription
+
+    override fun onComplete() {
+        RequestIdFilter.withRequestId(loggingRequestId) {
+            socket.onQueryFinished(this)
+        }
+    }
+
+    override fun onSubscribe(subscription: Subscription) {
+        RequestIdFilter.withRequestId(loggingRequestId) {
+            this.subscription = subscription
+            subscription.request(1)
+        }
+    }
+
+    override fun onNext(result: ExecutionResult) {
+        RequestIdFilter.withRequestId(loggingRequestId) {
+            val instrumentedResult = RequestIdInstrumentation()
+                .instrumentExecutionResult(result, null).get()
+            socket.sendMessage(OperationType.GQL_DATA, messageId, instrumentedResult)
+            subscription.request(1)
+        }
+    }
+
+    override fun onError(cause: Throwable) {
+        RequestIdFilter.withRequestId(loggingRequestId) {
+            socket.onQueryFinished(this, cause)
+        }
+    }
+
+    fun unsubscribe() {
+        subscription.cancel()
+    }
+}

--- a/server/src/main/kotlin/com/trib3/server/graphql/GraphQLWebSocket.kt
+++ b/server/src/main/kotlin/com/trib3/server/graphql/GraphQLWebSocket.kt
@@ -1,6 +1,7 @@
 package com.trib3.server.graphql
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
 import com.trib3.server.filters.RequestIdFilter
 import graphql.ExecutionInput
 import graphql.ExecutionResult
@@ -9,9 +10,8 @@ import mu.KotlinLogging
 import org.eclipse.jetty.websocket.api.StatusCode
 import org.eclipse.jetty.websocket.api.WebSocketAdapter
 import org.reactivestreams.Publisher
-import org.reactivestreams.Subscriber
-import org.reactivestreams.Subscription
-import java.util.UUID
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 
 private val log = KotlinLogging.logger { }
 
@@ -22,75 +22,160 @@ private val log = KotlinLogging.logger { }
  *
  * Implements https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md
  */
-class GraphQLWebSocket(
+open class GraphQLWebSocket(
     val graphQL: GraphQL?,
     val objectMapper: ObjectMapper
 ) : WebSocketAdapter() {
     val objectWriter = objectMapper.writerWithDefaultPrettyPrinter()
-    override fun onWebSocketText(message: String) {
+
+    private val runningQueryLock = ReentrantLock()
+    @Volatile
+    private var runningQuerySubscriber: GraphQLQuerySubscriber? = null
+
+    /**
+     * Launch a new query if one is not already running
+     */
+    private fun handleQueryStart(unparsed: String) {
         check(graphQL != null) {
             "graphQL not configured!"
         }
-        RequestIdFilter.withRequestId {
+        runningQueryLock.withLock {
+            check(runningQuerySubscriber == null) {
+                "Query ${runningQuerySubscriber?.loggingRequestId} is already running!"
+            }
+            val message = objectMapper.readValue<OperationMessage<GraphRequest>>(unparsed)
+            check(message.id != null) {
+                "Must pass a message id to start a query"
+            }
+            val payload = message.payload!!
             val result = graphQL.execute(
                 ExecutionInput.newExecutionInput()
-                    .query(message)
+                    .query(payload.query)
+                    .variables(payload.variables ?: mapOf())
+                    .operationName(payload.operationName)
                     .build()
             )
+
             val publisherData = try {
                 result.getData<Publisher<ExecutionResult>>()
             } catch (e: Exception) {
                 null
             }
             if (publisherData == null) {
-                remote.sendString(objectWriter.writeValueAsString(result))
-                if (result.errors.isEmpty()) {
-                    session.close(StatusCode.NORMAL, "End of results")
-                } else {
-                    session.close(StatusCode.SERVER_ERROR, "Error in results")
-                }
+                sendMessage(OperationType.GQL_DATA, message.id, result)
+                sendMessage(OperationType.GQL_COMPLETE, message.id)
             } else {
-                val loggingRequestId = RequestIdFilter.getRequestId() ?: UUID.randomUUID().toString()
-                publisherData.subscribe(object : Subscriber<ExecutionResult> {
-                    lateinit var subscription: Subscription
-                    override fun onComplete() {
-                        session.close(StatusCode.NORMAL, "End of results")
-                        RequestIdFilter.withRequestId(loggingRequestId) {
-                            log.info("End of results")
-                        }
-                    }
-
-                    override fun onSubscribe(s: Subscription) {
-                        s.request(1)
-                        this.subscription = s
-                    }
-
-                    override fun onNext(result: ExecutionResult) {
-                        RequestIdFilter.withRequestId(loggingRequestId) {
-                            subscription.request(1)
-                            val instrumentedResult = RequestIdInstrumentation()
-                                .instrumentExecutionResult(result, null)
-                            remote.sendString(
-                                objectWriter.writeValueAsString(
-                                    instrumentedResult.get()
-                                )
-                            )
-                        }
-                    }
-
-                    override fun onError(cause: Throwable) {
-                        session.close(StatusCode.SERVER_ERROR, cause.message)
-                        RequestIdFilter.withRequestId(loggingRequestId) {
-                            log.error("Error in result stream: ${cause.message}", cause)
-                        }
-                    }
-                })
+                val loggingRequestId = RequestIdFilter.getRequestId()!!
+                val subscriber = GraphQLQuerySubscriber(this, message.id, loggingRequestId)
+                this.runningQuerySubscriber = subscriber
+                publisherData.subscribe(subscriber)
             }
         }
     }
 
+    /**
+     * Stop a query identified by messageId
+     */
+    private fun handleQueryStop(message: OperationMessage<*>) {
+        runningQueryLock.withLock {
+            check(runningQuerySubscriber?.messageId == message.id) {
+                "Tried to cancel query ${message.id} but it's not running"
+            }
+            runningQuerySubscriber?.unsubscribe()
+            runningQuerySubscriber = null
+            sendMessage(OperationType.GQL_COMPLETE, message.id)
+        }
+    }
+
+    /**
+     * Respond to connection initialization by acknowledging
+     */
+    private fun handleConnectionInit(message: OperationMessage<*>) {
+        sendMessage(OperationType.GQL_CONNECTION_ACK, message.id)
+    }
+
+    /**
+     * Stop any running query and terminate the connection
+     */
+    private fun handleConnectionTermination() {
+        runningQueryLock.withLock {
+            runningQuerySubscriber?.unsubscribe()
+            runningQuerySubscriber = null
+            session.close(StatusCode.NORMAL, "Termination Requested")
+        }
+    }
+
+    /**
+     * Error out
+     */
+    private fun handleUnknownMessage(message: OperationMessage<*>) {
+        sendMessage(OperationType.GQL_CONNECTION_ERROR, message.id)
+    }
+
+    /**
+     * Receive a message from the websocket and process it according to its type
+     */
+    override fun onWebSocketText(message: String) {
+        try {
+            RequestIdFilter.withRequestId {
+                val operation = objectMapper.readValue<OperationMessage<*>>(message)
+                try {
+                    when (operation.type) {
+                        OperationType.GQL_START -> handleQueryStart(message)
+                        OperationType.GQL_CONNECTION_INIT -> handleConnectionInit(operation)
+                        OperationType.GQL_STOP -> handleQueryStop(operation)
+                        OperationType.GQL_CONNECTION_TERMINATE -> handleConnectionTermination()
+                        else -> handleUnknownMessage(operation)
+                    }
+                } catch (e: Exception) {
+                    log.error("Error processing parsed message: ${e.message}", e)
+                    sendMessage(OperationType.GQL_ERROR, operation.id, e.message)
+                }
+            }
+        } catch (e: Exception) {
+            log.error("Error parsing message: ${e.message}", e)
+            sendMessage(OperationType.GQL_ERROR, null, e.message)
+        }
+    }
+
+    /**
+     * On error, close connection
+     */
     override fun onWebSocketError(cause: Throwable) {
         session.close(StatusCode.SERVER_ERROR, cause.message)
         log.error("Error in websocket: ${cause.message}", cause)
+    }
+
+    /**
+     * Allow a running query to notify the socket that it has completed, with or without error
+     */
+    internal open fun onQueryFinished(subscriber: GraphQLQuerySubscriber, cause: Throwable? = null) {
+        runningQueryLock.withLock {
+            check(runningQuerySubscriber == subscriber) {
+                "Query ${subscriber.messageId} but we don't think it's running"
+            }
+            if (cause == null) {
+                log.info("Query ${subscriber.messageId} finished")
+                sendMessage(OperationType.GQL_COMPLETE, subscriber.messageId)
+            } else {
+                log.error("Error in subscription ${subscriber.messageId}: ${cause.message}", cause)
+                sendMessage(OperationType.GQL_ERROR, subscriber.messageId, cause.message)
+            }
+            this.runningQuerySubscriber = null
+        }
+    }
+
+    /**
+     * Convenience method for writing an [OperationMessage] back to the client in json format
+     */
+    internal open fun sendMessage(message: OperationMessage<*>) {
+        remote.sendString(objectWriter.writeValueAsString(message))
+    }
+
+    /**
+     * Convenience method for writing the components of an [OperationMessage] back to the client in json format
+     */
+    internal fun <T : Any> sendMessage(type: OperationType<T>, id: String?, payload: T? = null) {
+        sendMessage(OperationMessage(type, id, payload))
     }
 }

--- a/server/src/main/kotlin/com/trib3/server/graphql/GraphQLWebSocketCreator.kt
+++ b/server/src/main/kotlin/com/trib3/server/graphql/GraphQLWebSocketCreator.kt
@@ -16,7 +16,8 @@ class GraphQLWebSocketCreator
     @Nullable val graphQL: GraphQL?,
     val objectMapper: ObjectMapper
 ) : WebSocketCreator {
-    override fun createWebSocket(req: ServletUpgradeRequest?, resp: ServletUpgradeResponse?): Any {
+    override fun createWebSocket(req: ServletUpgradeRequest, resp: ServletUpgradeResponse): Any {
+        resp.acceptedSubProtocol = "graphql-ws"
         return GraphQLWebSocket(graphQL, objectMapper)
     }
 }

--- a/server/src/main/kotlin/com/trib3/server/graphql/GraphQLWebSocketProtocol.kt
+++ b/server/src/main/kotlin/com/trib3/server/graphql/GraphQLWebSocketProtocol.kt
@@ -1,0 +1,54 @@
+package com.trib3.server.graphql
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonValue
+import graphql.ExecutionResult
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty1
+import kotlin.reflect.full.memberProperties
+
+/**
+ * Model for a message in the graphql websocket protocol
+ *
+ * https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md
+ */
+data class OperationMessage<T : Any>(
+    val type: OperationType<T>?,
+    val id: String?,
+    val payload: T? = null
+)
+
+/**
+ * Captures the mapping from operation type to payload type for the messages in the protocol
+ */
+data class OperationType<T : Any>(
+    @get:JsonValue val type: String,
+    val payloadType: KClass<T>
+) {
+    companion object {
+        // client -> server
+        val GQL_CONNECTION_INIT = OperationType("connection_init", Nothing::class)
+        val GQL_START = OperationType("start", GraphRequest::class)
+        val GQL_STOP = OperationType("stop", Nothing::class)
+        val GQL_CONNECTION_TERMINATE = OperationType("connection_terminate", Nothing::class)
+        // server -> client
+        val GQL_CONNECTION_ERROR = OperationType("error", Nothing::class)
+        val GQL_CONNECTION_ACK = OperationType("connection_ack", Nothing::class)
+        val GQL_DATA = OperationType("data", ExecutionResult::class)
+        val GQL_ERROR = OperationType("error", String::class)
+        val GQL_COMPLETE = OperationType("complete", Nothing::class)
+        val GQL_CONNECTION_KEEP_ALIVE = OperationType("ka", Nothing::class)
+
+        /**
+         * Factory method for converting the string type to an [OperationType] instance
+         */
+        @JvmStatic
+        @JsonCreator
+        fun getOperationType(type: String): OperationType<*>? {
+            return Companion::class.memberProperties
+                .filterIsInstance<KProperty1<Companion, OperationType<*>>>()
+                .map { it.get(Companion) }
+                .find { it.type == type }
+        }
+    }
+}

--- a/server/src/test/kotlin/com/trib3/server/graphql/GraphQLWebSocketCreatorTest.kt
+++ b/server/src/test/kotlin/com/trib3/server/graphql/GraphQLWebSocketCreatorTest.kt
@@ -6,6 +6,8 @@ import assertk.assertions.isInstanceOf
 import com.fasterxml.jackson.databind.ObjectMapper
 import graphql.GraphQL
 import org.easymock.EasyMock
+import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest
+import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse
 import org.testng.annotations.Test
 
 class GraphQLWebSocketCreatorTest {
@@ -16,7 +18,13 @@ class GraphQLWebSocketCreatorTest {
         val creator = GraphQLWebSocketCreator(graphQL, mapper)
         assertThat(creator.graphQL).isEqualTo(graphQL)
         assertThat(creator.objectMapper).isEqualTo(mapper)
-        val socket = creator.createWebSocket(null, null)
+
+        val request = EasyMock.mock<ServletUpgradeRequest>(ServletUpgradeRequest::class.java)
+        val response = EasyMock.mock<ServletUpgradeResponse>(ServletUpgradeResponse::class.java)
+        EasyMock.expect(response.setAcceptedSubProtocol("graphql-ws")).once()
+        EasyMock.replay(graphQL, request, response)
+        val socket = creator.createWebSocket(request, response)
+        EasyMock.verify(response)
         assertThat(socket).isInstanceOf(GraphQLWebSocket::class)
         assertThat((socket as GraphQLWebSocket).graphQL).isEqualTo(graphQL)
         assertThat(socket.objectMapper).isEqualTo(mapper)

--- a/server/src/test/kotlin/com/trib3/server/graphql/GraphQLWebSocketProtocolTest.kt
+++ b/server/src/test/kotlin/com/trib3/server/graphql/GraphQLWebSocketProtocolTest.kt
@@ -1,0 +1,55 @@
+package com.trib3.server.graphql
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotNull
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.trib3.json.ObjectMapperProvider
+import org.testng.annotations.Test
+
+class GraphQLWebSocketProtocolTest {
+    val mapper = ObjectMapperProvider().get()
+    @Test
+    fun testOperationTypeRawDeserialization() {
+        val start = OperationType.getOperationType("start")
+        assertThat(start).isEqualTo(OperationType.GQL_START)
+        assertThat(start?.payloadType).isEqualTo(GraphRequest::class)
+    }
+
+    @Test
+    fun testOperationTypeJsonDeserialization() {
+        val start = mapper.readValue<OperationType<*>>("\"start\"")
+        assertThat(start).isEqualTo(OperationType.GQL_START)
+    }
+
+    @Test
+    fun testOperationTypeJsonSerialization() {
+        val stringified = mapper.writeValueAsString(OperationType.GQL_START)
+        assertThat(stringified).isEqualTo("\"start\"")
+    }
+
+    @Test
+    fun testOperationMessageJsonDeserialization() {
+        val start = mapper.readValue<OperationMessage<GraphRequest>>(
+            """
+            {
+                "type": "start",
+                "id": "123",
+                "payload": {
+                    "query": "hi",
+                    "variables": {},
+                    "operationName": "boo"
+                }
+            }
+        """.trimIndent()
+        )
+        assertThat(start.type).isEqualTo(OperationType.GQL_START)
+        assertThat(start.id).isEqualTo("123")
+        assertThat(start.payload).isNotNull().isInstanceOf(GraphRequest::class)
+        assertThat((start.payload as GraphRequest).query).isEqualTo("hi")
+        assertThat((start.payload as GraphRequest).variables).isNotNull().isInstanceOf(Map::class)
+            .isEqualTo(mapOf<String, Any?>())
+        assertThat((start.payload as GraphRequest).operationName).isEqualTo("boo")
+    }
+}

--- a/server/src/test/kotlin/com/trib3/server/graphql/GraphQLWebSocketTest.kt
+++ b/server/src/test/kotlin/com/trib3/server/graphql/GraphQLWebSocketTest.kt
@@ -3,26 +3,35 @@ package com.trib3.server.graphql
 import assertk.assertThat
 import assertk.assertions.contains
 import assertk.assertions.hasSize
+import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotNull
 import assertk.assertions.message
 import com.expedia.graphql.SchemaGeneratorConfig
 import com.expedia.graphql.TopLevelObject
 import com.expedia.graphql.toSchema
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import com.trib3.json.ObjectMapperProvider
 import graphql.GraphQL
 import io.reactivex.rxkotlin.toFlowable
+import io.reactivex.schedulers.Schedulers
 import org.easymock.EasyMock
 import org.eclipse.jetty.websocket.api.Session
 import org.eclipse.jetty.websocket.api.StatusCode
 import org.eclipse.jetty.websocket.common.WebSocketRemoteEndpoint
 import org.reactivestreams.Publisher
 import org.testng.annotations.Test
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 
 class SocketQuery {
     fun q(): List<String> {
         return listOf("1", "2", "3")
+    }
+
+    fun v(len: Int): List<String> {
+        return (1..len).toList().map(Int::toString)
     }
 
     fun e(): List<String> {
@@ -32,7 +41,7 @@ class SocketQuery {
 
 class SocketSubscription {
     fun s(): Publisher<String> {
-        return listOf("1", "2", "3").toFlowable()
+        return listOf("1", "2", "3").toFlowable().subscribeOn(Schedulers.io())
     }
 
     fun e(): Publisher<String> {
@@ -47,7 +56,22 @@ class SocketSubscription {
                 value += 1
                 return if (toReturn == "3") throw IllegalStateException("forced exception") else toReturn
             }
-        }.toFlowable()
+        }.toFlowable().subscribeOn(Schedulers.io())
+    }
+
+    fun inf(): Publisher<String> {
+        return object : Iterator<String> {
+            var value = 1
+            override fun hasNext(): Boolean {
+                return true
+            }
+
+            override fun next(): String {
+                val toReturn = value.toString()
+                value += 1
+                return toReturn
+            }
+        }.toFlowable().subscribeOn(Schedulers.io())
     }
 }
 
@@ -61,37 +85,103 @@ class GraphQLWebSocketTest {
             listOf(TopLevelObject(SocketSubscription()))
         )
     ).build()
+    val mapper = ObjectMapperProvider().get()
 
     @Test
     fun testSocketQuery() {
-        val socket = GraphQLWebSocket(graphQL, ObjectMapper())
+        val socket = GraphQLWebSocket(graphQL, mapper)
         val mockRemote = EasyMock.mock<WebSocketRemoteEndpoint>(WebSocketRemoteEndpoint::class.java)
         val mockSession = EasyMock.mock<Session>(Session::class.java)
         EasyMock.expect(mockSession.remote).andReturn(mockRemote).anyTimes()
-        EasyMock.expect(mockRemote.sendString(EasyMock.contains(""""q" : [ "1", "2", "3" ]"""))).once()
-        EasyMock.expect(mockSession.close(EasyMock.eq(StatusCode.NORMAL), EasyMock.anyString())).once()
+        EasyMock.expect(
+            mockRemote.sendString(
+                EasyMock.and(
+                    EasyMock.contains(""""q" : [ "1", "2", "3" ]"""),
+                    EasyMock.and(
+                        EasyMock.contains(""""type" : "data""""),
+                        EasyMock.contains(""""id" : "simplequery"""")
+                    )
+                )
+            )
+        ).once()
+        EasyMock.expect(
+            mockRemote.sendString(
+                EasyMock.and(
+                    EasyMock.contains(""""type" : "complete""""),
+                    EasyMock.contains(""""id" : "simplequery"""")
+                )
+            )
+        ).once()
 
         EasyMock.replay(mockRemote, mockSession)
         socket.onWebSocketConnect(mockSession)
-        socket.onWebSocketText("query { q }")
+        socket.onWebSocketText("""{"type": "start", "id": "simplequery", "payload": {"query": "query { q }"}}""")
+        EasyMock.verify(mockRemote, mockSession)
+    }
+
+    @Test
+    fun testSocketVariableQuery() {
+        val socket = GraphQLWebSocket(graphQL, mapper)
+        val mockRemote = EasyMock.mock<WebSocketRemoteEndpoint>(WebSocketRemoteEndpoint::class.java)
+        val mockSession = EasyMock.mock<Session>(Session::class.java)
+        EasyMock.expect(mockSession.remote).andReturn(mockRemote).anyTimes()
+        EasyMock.expect(
+            mockRemote.sendString(
+                EasyMock.and(
+                    EasyMock.contains(""""v" : [ "1", "2", "3" ]"""),
+                    EasyMock.and(
+                        EasyMock.contains(""""type" : "data""""),
+                        EasyMock.contains(""""id" : "simplequery"""")
+                    )
+                )
+            )
+        ).once()
+        EasyMock.expect(
+            mockRemote.sendString(
+                EasyMock.and(
+                    EasyMock.contains(""""type" : "complete""""),
+                    EasyMock.contains(""""id" : "simplequery"""")
+                )
+            )
+        ).once()
+
+        EasyMock.replay(mockRemote, mockSession)
+        socket.onWebSocketConnect(mockSession)
+        socket.onWebSocketText(
+            """
+            {"type": "start", 
+            "id": "simplequery", 
+            "payload": {"query": "query(${'$'}len:Int!) { v(len: ${'$'}len) }", 
+                        "variables": {"len": 3}}}""".trimIndent()
+        )
         EasyMock.verify(mockRemote, mockSession)
     }
 
     @Test
     fun testSocketQueryError() {
-        val socket = GraphQLWebSocket(graphQL, ObjectMapper())
+        val socket = GraphQLWebSocket(graphQL, mapper)
         val mockRemote = EasyMock.mock<WebSocketRemoteEndpoint>(WebSocketRemoteEndpoint::class.java)
         val mockSession = EasyMock.mock<Session>(Session::class.java)
         EasyMock.expect(mockSession.remote).andReturn(mockRemote).anyTimes()
         val errorCapture = EasyMock.newCapture<String>()
         EasyMock.expect(mockRemote.sendString(EasyMock.capture(errorCapture))).once()
-        EasyMock.expect(mockSession.close(EasyMock.eq(StatusCode.SERVER_ERROR), EasyMock.anyString())).once()
+        EasyMock.expect(
+            mockRemote.sendString(
+                EasyMock.and(
+                    EasyMock.contains(""""type" : "complete""""),
+                    EasyMock.contains(""""id" : "errorquery"""")
+                )
+            )
+        ).once()
 
         EasyMock.replay(mockRemote, mockSession)
         socket.onWebSocketConnect(mockSession)
-        socket.onWebSocketText("query { e }")
+        socket.onWebSocketText("""{"type": "start", "id": "errorquery", "payload": {"query": "query { e }"}}""")
         EasyMock.verify(mockRemote, mockSession)
-        val error = ObjectMapper().readValue<Map<String, Any>>(errorCapture.value)
+        val errorMessage = mapper.readValue<OperationMessage<Map<*, *>>>(errorCapture.value)
+        assertThat(errorMessage.type).isEqualTo(OperationType.GQL_DATA)
+        assertThat(errorMessage.id).isEqualTo("errorquery")
+        val error = errorMessage.payload!!
         assertThat(error["errors"]).isNotNull().isInstanceOf(List::class)
         assertThat(error["errors"] as List<*>).hasSize(1)
         val firstError = (error["errors"] as List<*>)[0]
@@ -103,52 +193,363 @@ class GraphQLWebSocketTest {
 
     @Test
     fun testSocketSubscription() {
-        val socket = GraphQLWebSocket(graphQL, ObjectMapper())
+        val lock = ReentrantLock()
+        val condition = lock.newCondition()
+        // override the socket to signal the test that it's complete
+        val socket = object : GraphQLWebSocket(graphQL, mapper) {
+            override fun onQueryFinished(subscriber: GraphQLQuerySubscriber, cause: Throwable?) {
+                super.onQueryFinished(subscriber, cause)
+                lock.withLock {
+                    condition.signal()
+                }
+            }
+        }
         val mockRemote = EasyMock.mock<WebSocketRemoteEndpoint>(WebSocketRemoteEndpoint::class.java)
         val mockSession = EasyMock.mock<Session>(Session::class.java)
         EasyMock.expect(mockSession.remote).andReturn(mockRemote).anyTimes()
-        EasyMock.expect(mockRemote.sendString(EasyMock.contains(""""s" : "1"""))).once()
-        EasyMock.expect(mockRemote.sendString(EasyMock.contains(""""s" : "2"""))).once()
-        EasyMock.expect(mockRemote.sendString(EasyMock.contains(""""s" : "3"""))).once()
-        EasyMock.expect(mockSession.close(EasyMock.eq(StatusCode.NORMAL), EasyMock.anyString())).once()
+        EasyMock.expect(
+            mockRemote.sendString(
+                EasyMock.and(
+                    EasyMock.contains(""""s" : "1""""),
+                    EasyMock.and(
+                        EasyMock.contains(""""type" : "data""""),
+                        EasyMock.contains(""""id" : "simplesubscription"""")
+                    )
+                )
+            )
+        ).once()
+        EasyMock.expect(
+            mockRemote.sendString(
+                EasyMock.and(
+                    EasyMock.contains(""""s" : "2""""),
+                    EasyMock.and(
+                        EasyMock.contains(""""type" : "data""""),
+                        EasyMock.contains(""""id" : "simplesubscription"""")
+                    )
+                )
+            )
+        ).once()
+        EasyMock.expect(
+            mockRemote.sendString(
+                EasyMock.and(
+                    EasyMock.contains(""""s" : "3""""),
+                    EasyMock.and(
+                        EasyMock.contains(""""type" : "data""""),
+                        EasyMock.contains(""""id" : "simplesubscription"""")
+                    )
+                )
+            )
+        ).once()
+        EasyMock.expect(
+            mockRemote.sendString(
+                EasyMock.and(
+                    EasyMock.contains(""""type" : "complete""""),
+                    EasyMock.contains(""""id" : "simplesubscription"""")
+                )
+            )
+        ).once()
 
         EasyMock.replay(mockRemote, mockSession)
-        socket.onWebSocketConnect(mockSession)
-        socket.onWebSocketText("subscription { s }")
+        lock.withLock {
+            socket.onWebSocketConnect(mockSession)
+            socket.onWebSocketText(
+                """
+                {"type": "start",
+                 "id": "simplesubscription", 
+                 "payload": {"query": "subscription { s }"}}""".trimIndent()
+            )
+            condition.await(1, TimeUnit.SECONDS)
+        }
         EasyMock.verify(mockRemote, mockSession)
     }
 
     @Test
     fun testSocketSubscriptionError() {
-        val socket = GraphQLWebSocket(graphQL, ObjectMapper())
+        val lock = ReentrantLock()
+        val condition = lock.newCondition()
+        // override the socket to signal the test that it's complete
+        val socket = object : GraphQLWebSocket(graphQL, mapper) {
+            override fun onQueryFinished(subscriber: GraphQLQuerySubscriber, cause: Throwable?) {
+                super.onQueryFinished(subscriber, cause)
+                lock.withLock {
+                    condition.signal()
+                }
+            }
+        }
         val mockRemote = EasyMock.mock<WebSocketRemoteEndpoint>(WebSocketRemoteEndpoint::class.java)
         val mockSession = EasyMock.mock<Session>(Session::class.java)
         EasyMock.expect(mockSession.remote).andReturn(mockRemote).anyTimes()
-        EasyMock.expect(mockRemote.sendString(EasyMock.contains(""""e" : "1"""))).once()
-        EasyMock.expect(mockRemote.sendString(EasyMock.contains(""""e" : "2"""))).once()
-        EasyMock.expect(mockSession.close(EasyMock.eq(StatusCode.SERVER_ERROR), EasyMock.anyString())).once()
+        EasyMock.expect(
+            mockRemote.sendString(
+                EasyMock.and(
+                    EasyMock.contains(""""e" : "1""""),
+                    EasyMock.and(
+                        EasyMock.contains(""""type" : "data""""),
+                        EasyMock.contains(""""id" : "errorsubscription"""")
+                    )
+                )
+            )
+        ).once()
+        EasyMock.expect(
+            mockRemote.sendString(
+                EasyMock.and(
+                    EasyMock.contains(""""e" : "2""""),
+                    EasyMock.and(
+                        EasyMock.contains(""""type" : "data""""),
+                        EasyMock.contains(""""id" : "errorsubscription"""")
+                    )
+                )
+            )
+        ).once()
+        EasyMock.expect(
+            mockRemote.sendString(
+                EasyMock.and(
+                    EasyMock.contains(""""type" : "error""""),
+                    EasyMock.contains(""""id" : "errorsubscription"""")
+                )
+            )
+        ).once()
 
         EasyMock.replay(mockRemote, mockSession)
-        socket.onWebSocketConnect(mockSession)
-        socket.onWebSocketText("subscription { e }")
+        lock.withLock {
+            socket.onWebSocketConnect(mockSession)
+            socket.onWebSocketText(
+                """
+                {"type": "start", 
+                 "id": "errorsubscription", 
+                 "payload": {"query": "subscription { e }"}}""".trimIndent()
+            )
+            condition.await(1, TimeUnit.SECONDS)
+        }
         EasyMock.verify(mockRemote, mockSession)
     }
 
     @Test
     fun testGenericErrors() {
-        val socket = GraphQLWebSocket(null, ObjectMapper())
+        val socket = GraphQLWebSocket(null, mapper)
         val mockRemote = EasyMock.mock<WebSocketRemoteEndpoint>(WebSocketRemoteEndpoint::class.java)
         val mockSession = EasyMock.mock<Session>(Session::class.java)
         EasyMock.expect(mockSession.remote).andReturn(mockRemote).anyTimes()
+        EasyMock.expect(
+            mockRemote.sendString(
+                EasyMock.and(
+                    EasyMock.contains(""""type" : "error""""),
+                    EasyMock.contains(""""id" : "unknownoperation"""")
+                )
+            )
+        ).once()
         EasyMock.expect(mockSession.close(EasyMock.eq(StatusCode.SERVER_ERROR), EasyMock.contains("boom"))).once()
 
         EasyMock.replay(mockRemote, mockSession)
 
         socket.onWebSocketConnect(mockSession)
-        assertThat {
-            socket.onWebSocketText("query")
-        }.thrownError { message().isNotNull().contains("not configured") }
+        socket.onWebSocketText(
+            """
+            {"type": "unknown",
+             "id": "unknownoperation"}
+        """.trimIndent()
+        )
         socket.onWebSocketError(IllegalStateException("boom"))
+        EasyMock.verify(mockRemote, mockSession)
+
+        assertThat {
+            socket.onWebSocketText(
+                """
+                {"type": "start", 
+                 "id": "unconfiguredquery", 
+                 "payload": {"query": "query { q }"}}""".trimIndent()
+            )
+        }.thrownError { message().isNotNull().contains("not configured") }
+    }
+
+    @Test
+    fun testConnectAck() {
+        val socket = GraphQLWebSocket(graphQL, mapper)
+        val mockRemote = EasyMock.mock<WebSocketRemoteEndpoint>(WebSocketRemoteEndpoint::class.java)
+        val mockSession = EasyMock.mock<Session>(Session::class.java)
+        EasyMock.expect(mockSession.remote).andReturn(mockRemote).anyTimes()
+        EasyMock.expect(
+            mockRemote.sendString(
+                EasyMock.and(
+                    EasyMock.contains(""""type" : "connection_ack""""),
+                    EasyMock.contains(""""id" : "connect"""")
+                )
+            )
+        ).once()
+
+        EasyMock.replay(mockRemote, mockSession)
+        socket.onWebSocketConnect(mockSession)
+        socket.onWebSocketText("""{"type": "connection_init", "id": "connect"}""")
+
+        EasyMock.verify(mockRemote, mockSession)
+    }
+
+    @Test
+    fun testRequestTerminate() {
+        val socket = GraphQLWebSocket(graphQL, mapper)
+        val mockRemote = EasyMock.mock<WebSocketRemoteEndpoint>(WebSocketRemoteEndpoint::class.java)
+        val mockSession = EasyMock.mock<Session>(Session::class.java)
+        EasyMock.expect(mockSession.remote).andReturn(mockRemote).anyTimes()
+        EasyMock.expect(
+            mockSession.close(StatusCode.NORMAL, "Termination Requested")
+        ).once()
+
+        EasyMock.replay(mockRemote, mockSession)
+        socket.onWebSocketConnect(mockSession)
+        socket.onWebSocketText("""{"type": "connection_terminate", "id": "terminate"}""")
+
+        EasyMock.verify(mockRemote, mockSession)
+    }
+
+    @Test
+    fun testStopQuery() {
+        val lock = ReentrantLock()
+        val condition = lock.newCondition()
+        // override the socket to signal the test that it's sent at least one data message
+        val socket = object : GraphQLWebSocket(graphQL, mapper) {
+            override fun sendMessage(message: OperationMessage<*>) {
+                super.sendMessage(message)
+                if (message.type == OperationType.GQL_DATA) {
+                    lock.withLock {
+                        condition.signal()
+                    }
+                }
+            }
+        }
+        val mockRemote = EasyMock.mock<WebSocketRemoteEndpoint>(WebSocketRemoteEndpoint::class.java)
+        val mockSession = EasyMock.mock<Session>(Session::class.java)
+        EasyMock.expect(mockSession.remote).andReturn(mockRemote).anyTimes()
+        EasyMock.expect(
+            mockRemote.sendString(
+                EasyMock.and(
+                    EasyMock.contains(""""inf" : """"),
+                    EasyMock.and(
+                        EasyMock.contains(""""type" : "data""""),
+                        EasyMock.contains(""""id" : "longsubscription"""")
+                    )
+                )
+            )
+        ).anyTimes()
+        EasyMock.expect(
+            mockRemote.sendString(
+                EasyMock.and(
+                    EasyMock.contains(""""type" : "error""""),
+                    EasyMock.contains(""""id" : "secondquery"""")
+                )
+            )
+        ).once()
+        EasyMock.expect(
+            mockRemote.sendString(
+                EasyMock.and(
+                    EasyMock.contains(""""inf" : """"),
+                    EasyMock.and(
+                        EasyMock.contains(""""type" : "data""""),
+                        EasyMock.contains(""""id" : "longsubscription"""")
+                    )
+                )
+            )
+        ).anyTimes()
+        EasyMock.expect(
+            mockRemote.sendString(
+                EasyMock.and(
+                    EasyMock.contains(""""type" : "complete""""),
+                    EasyMock.contains(""""id" : "longsubscription"""")
+                )
+            )
+        ).once()
+        EasyMock.replay(mockRemote, mockSession)
+        socket.onWebSocketConnect(mockSession)
+        lock.withLock {
+            socket.onWebSocketText(
+                """
+                {"type": "start", 
+                 "id": "longsubscription", 
+                 "payload": {"query": "subscription { inf }"}}""".trimIndent()
+            )
+            socket.onWebSocketText(
+                """
+                {"type": "start",
+                 "id": "secondquery",
+                 "payload": {"query": "subscription { s }"}}""".trimIndent()
+            )
+            condition.await(1, TimeUnit.SECONDS)
+        }
+        socket.onWebSocketText(
+            """
+            {"type": "stop", 
+             "id": "longsubscription"}""".trimIndent()
+        )
+        EasyMock.verify(mockRemote, mockSession)
+    }
+
+    @Test
+    fun testStopWrongQuery() {
+        val socket = GraphQLWebSocket(graphQL, mapper)
+        val mockRemote = EasyMock.mock<WebSocketRemoteEndpoint>(WebSocketRemoteEndpoint::class.java)
+        val mockSession = EasyMock.mock<Session>(Session::class.java)
+        EasyMock.expect(mockSession.remote).andReturn(mockRemote).anyTimes()
+        EasyMock.expect(
+            mockRemote.sendString(
+                EasyMock.and(
+                    EasyMock.contains(""""type" : "error""""),
+                    EasyMock.contains(""""id" : "unknownquery"""")
+                )
+            )
+        ).once()
+
+        EasyMock.replay(mockRemote, mockSession)
+        socket.onWebSocketConnect(mockSession)
+        socket.onWebSocketText(
+            """
+            {"type": "stop",
+             "id": "unknownquery"}""".trimIndent()
+        )
+        EasyMock.verify(mockRemote, mockSession)
+    }
+
+    @Test
+    fun testStartWithoutId() {
+        val socket = GraphQLWebSocket(graphQL, mapper)
+        val mockRemote = EasyMock.mock<WebSocketRemoteEndpoint>(WebSocketRemoteEndpoint::class.java)
+        val mockSession = EasyMock.mock<Session>(Session::class.java)
+        EasyMock.expect(mockSession.remote).andReturn(mockRemote).anyTimes()
+        EasyMock.expect(
+            mockRemote.sendString(
+                EasyMock.and(
+                    EasyMock.contains(""""type" : "error""""),
+                    EasyMock.contains(""""payload" : "Must pass a message id""")
+                )
+            )
+        ).once()
+
+        EasyMock.replay(mockRemote, mockSession)
+        socket.onWebSocketConnect(mockSession)
+        socket.onWebSocketText(
+            """
+            {"type": "start",
+             "id": null}""".trimIndent()
+        )
+        EasyMock.verify(mockRemote, mockSession)
+    }
+
+    @Test
+    fun testBadMessage() {
+        val socket = GraphQLWebSocket(graphQL, mapper)
+        val mockRemote = EasyMock.mock<WebSocketRemoteEndpoint>(WebSocketRemoteEndpoint::class.java)
+        val mockSession = EasyMock.mock<Session>(Session::class.java)
+        EasyMock.expect(mockSession.remote).andReturn(mockRemote).anyTimes()
+        EasyMock.expect(
+            mockRemote.sendString(
+                EasyMock.and(
+                    EasyMock.contains(""""type" : "error""""),
+                    EasyMock.contains(""""payload" : "Unrecognized token""")
+                )
+            )
+        ).once()
+
+        EasyMock.replay(mockRemote, mockSession)
+        socket.onWebSocketConnect(mockSession)
+        socket.onWebSocketText("not json!")
         EasyMock.verify(mockRemote, mockSession)
     }
 }


### PR DESCRIPTION
Support the apollo protocol to allow starting and
stopping queries and reuse of the websocket for multiple
queries.  Have the websocket track the running query and
try to execute only one at a time.  Skip implementing
keepalive heartbeats for now.

https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md

Tested in https://github.com/prisma/graphql-playground