### PR TITLE
Implement keepalive for graphql websockets

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -23,7 +23,9 @@ and have:
   * java8 time and threeten-extra [Scalars](https://github.com/trib3/leakycauldron/blob/master/server/src/main/kotlin/com/trib3/server/graphql/DateTimeHooks.kt)
   * [Request Ids](https://github.com/trib3/leakycauldron/blob/master/server/src/main/kotlin/com/trib3/server/graphql/RequestIdInstrumentation.kt) 
     attached to the GraphQL response extensions
-  * Any guice bound Query or Mutation Resolvers
+  * Any guice bound Query, Subscription or Mutation Resolvers
+  * Supports websockets using the [Apollo Protocol](https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md)
+  * Supports subscriptions via [ReactiveX](http://reactivex.io/) for any Resolvers that return a `Publisher<T>`
 * Admin:
   * The dropwizard `/admin` servlet will be [password protected](https://github.com/trib3/leakycauldron/blob/master/server/src/main/kotlin/com/trib3/server/filters/AdminAuthFilter.kt)
     with a password set from the `application.adminAuthToken` configuration variable 
@@ -67,19 +69,20 @@ class ExampleApplicationModule : TribeApplicationModule() {
 ##### GraphQL Resolvers
 [`TribeApplicationModule`](https://github.com/trib3/leakycauldron/blob/master/server/src/main/kotlin/com/trib3/server/modules/TribeApplicationModule.kt)
 provides methods that expose multi-binders for configuring GraphQL resolvers.  Any model
-classes must be added to the `graphqlPackagesBinder()` to allow [GraphQL Kotlin](https://github.com/ExpediaDotCom/graphql-kotlin/)
-to use them.  Query Resolver implementations can be added to the `graphqlQueriesBinder()`
-and Mutations to the `graphqlMutationsBinder()` 
+classes must be added to the `graphQLPackagesBinder()` to allow [GraphQL Kotlin](https://github.com/ExpediaDotCom/graphql-kotlin/)
+to use them.  Query Resolver implementations can be added to the `graphQLQueriesBinder()`
+, Subscriptions to the `graphQLSubscriptionsBinder()`, and Mutations to the `graphQLMutationsBinder()` 
 
 ```kotlin
 class ExampleApplicationModule : TribeApplicationModule() {
     override fun configure() {
         // ...
-        graphqlPackagesBinder().addBinding().toInstance("com.example.api")
-        graphqlPackagesBinder().addBinding().toInstance("com.example.server.graphql")
+        graphQLPackagesBinder().addBinding().toInstance("com.example.api")
+        graphQLPackagesBinder().addBinding().toInstance("com.example.server.graphql")
 
-        graphqlQueriesBinder().addBinding().to<com.example.server.graphql.Query>()
-        graphqlMutationsBinder().addBinding().to<com.example.server.graphql.Mutation>()
+        graphQLQueriesBinder().addBinding().to<com.example.server.graphql.Query>()
+        graphQLMutationsBinder().addBinding().to<com.example.server.graphql.Mutation>()
+        graphQLSubscriptionsBinder().addBinding().to<com.example.server.graphql.Subscription>()
         // ...
     }
 }

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -160,12 +160,11 @@
         </dependency>
         <dependency>
             <groupId>io.reactivex.rxjava2</groupId>
-            <artifactId>rxkotlin</artifactId>
-            <scope>test</scope>
+            <artifactId>rxjava</artifactId>
         </dependency>
         <dependency>
             <groupId>io.reactivex.rxjava2</groupId>
-            <artifactId>rxjava</artifactId>
+            <artifactId>rxkotlin</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/server/src/main/kotlin/com/trib3/server/graphql/GraphQLConfig.kt
+++ b/server/src/main/kotlin/com/trib3/server/graphql/GraphQLConfig.kt
@@ -1,0 +1,17 @@
+package com.trib3.server.graphql
+
+import com.trib3.config.ConfigLoader
+import com.trib3.config.extract
+import javax.inject.Inject
+
+class GraphQLConfig
+@Inject constructor(loader: ConfigLoader) {
+    val keepAliveIntervalSeconds: Long
+    val webSocketSubProtocol: String
+
+    init {
+        val config = loader.load()
+        keepAliveIntervalSeconds = config.extract("graphQL.keepAliveIntervalSeconds")
+        webSocketSubProtocol = config.extract("graphQL.webSocketSubProtocol")
+    }
+}

--- a/server/src/main/kotlin/com/trib3/server/graphql/GraphQLWebSocketCreator.kt
+++ b/server/src/main/kotlin/com/trib3/server/graphql/GraphQLWebSocketCreator.kt
@@ -14,10 +14,11 @@ import javax.inject.Inject
 class GraphQLWebSocketCreator
 @Inject constructor(
     @Nullable val graphQL: GraphQL?,
-    val objectMapper: ObjectMapper
+    val objectMapper: ObjectMapper,
+    val graphQLConfig: GraphQLConfig
 ) : WebSocketCreator {
     override fun createWebSocket(req: ServletUpgradeRequest, resp: ServletUpgradeResponse): Any {
-        resp.acceptedSubProtocol = "graphql-ws"
-        return GraphQLWebSocket(graphQL, objectMapper)
+        resp.acceptedSubProtocol = graphQLConfig.webSocketSubProtocol
+        return GraphQLWebSocket(graphQL, objectMapper, graphQLConfig.keepAliveIntervalSeconds)
     }
 }

--- a/server/src/main/resources/reference.conf
+++ b/server/src/main/resources/reference.conf
@@ -45,6 +45,11 @@ metrics {
   reporters: []
 }
 
+graphQL {
+  keepAliveIntervalSeconds: 15
+  webSocketSubProtocol: "graphql-ws"
+}
+
 # Don't use file appenders in lambda
 lambda {
   logging {

--- a/server/src/test/kotlin/com/trib3/server/graphql/GraphQLConfigTest.kt
+++ b/server/src/test/kotlin/com/trib3/server/graphql/GraphQLConfigTest.kt
@@ -1,0 +1,16 @@
+package com.trib3.server.graphql
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.trib3.config.ConfigLoader
+import com.trib3.config.KMSStringSelectReader
+import org.testng.annotations.Test
+
+class GraphQLConfigTest {
+    @Test
+    fun testConfig() {
+        val config = GraphQLConfig(ConfigLoader(KMSStringSelectReader(null)))
+        assertThat(config.keepAliveIntervalSeconds).isEqualTo(15L)
+        assertThat(config.webSocketSubProtocol).isEqualTo("graphql-ws")
+    }
+}

--- a/server/src/test/kotlin/com/trib3/server/graphql/GraphQLWebSocketCreatorTest.kt
+++ b/server/src/test/kotlin/com/trib3/server/graphql/GraphQLWebSocketCreatorTest.kt
@@ -4,6 +4,8 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.trib3.config.ConfigLoader
+import com.trib3.config.KMSStringSelectReader
 import graphql.GraphQL
 import org.easymock.EasyMock
 import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest
@@ -15,7 +17,7 @@ class GraphQLWebSocketCreatorTest {
     fun testSocketCreation() {
         val graphQL = EasyMock.mock<GraphQL>(GraphQL::class.java)
         val mapper = ObjectMapper()
-        val creator = GraphQLWebSocketCreator(graphQL, mapper)
+        val creator = GraphQLWebSocketCreator(graphQL, mapper, GraphQLConfig(ConfigLoader(KMSStringSelectReader(null))))
         assertThat(creator.graphQL).isEqualTo(graphQL)
         assertThat(creator.objectMapper).isEqualTo(mapper)
 
@@ -28,6 +30,7 @@ class GraphQLWebSocketCreatorTest {
         assertThat(socket).isInstanceOf(GraphQLWebSocket::class)
         assertThat((socket as GraphQLWebSocket).graphQL).isEqualTo(graphQL)
         assertThat(socket.objectMapper).isEqualTo(mapper)
+        assertThat(socket.keepAliveIntervalSeconds).isEqualTo(creator.graphQLConfig.keepAliveIntervalSeconds)
         // mapper writes without pretty printing, writer writes with pretty printing
         assertThat(socket.objectMapper.writeValueAsString(mapOf("a" to "b"))).isEqualTo("""{"a":"b"}""")
         assertThat(socket.objectWriter.writeValueAsString(mapOf("a" to "b"))).isEqualTo(


### PR DESCRIPTION
To prevent long running queries from timing out the socket,
send a keepalive packet every 15 seconds.
Execute the graphQL query within the rx context so that we
free up the webserver threads and don't hold locks for long.