### PR TITLE
Add graphql and jooq converters for java.time.Year

### DIFF
--- a/db/src/main/kotlin/com/trib3/db/converters/YearConverter.kt
+++ b/db/src/main/kotlin/com/trib3/db/converters/YearConverter.kt
@@ -1,0 +1,17 @@
+package com.trib3.db.converters
+
+import org.jooq.impl.AbstractConverter
+import java.time.Year
+
+/**
+ * jOOQ converter for converting from [String] to [Year]
+ */
+class YearConverter : AbstractConverter<String, Year>(String::class.java, Year::class.java) {
+    override fun from(stringYear: String?): Year? {
+        return stringYear?.let(Year::parse)
+    }
+
+    override fun to(year: Year?): String? {
+        return year?.let(Year::toString)
+    }
+}

--- a/db/src/test/kotlin/com/trib3/db/converters/YearConverterTest.kt
+++ b/db/src/test/kotlin/com/trib3/db/converters/YearConverterTest.kt
@@ -1,0 +1,24 @@
+package com.trib3.db.converters
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import org.testng.annotations.Test
+import java.time.Year
+
+class YearConverterTest {
+    val converter = YearConverter()
+    @Test
+    fun testLocalDateToYear() {
+        val date = "2019"
+        assertThat(converter.from(date)).isEqualTo(Year.of(2019))
+        assertThat(converter.from(null)).isNull()
+    }
+
+    @Test
+    fun testYearToLocalDate() {
+        val year = Year.of(2019)
+        assertThat(converter.to(year)).isEqualTo("2019")
+        assertThat(converter.to(null)).isNull()
+    }
+}


### PR DESCRIPTION
Support serializing/deserializing java.time.Year objects
in the graphql and db layers