### PR TITLE
Add mocking utility class

### DIFF
--- a/config/pom.xml
+++ b/config/pom.xml
@@ -58,13 +58,15 @@
             <artifactId>regions</artifactId>
         </dependency>
 
-        <!-- test logging -->
+        <!-- test -->
+        <dependency>
+            <groupId>com.trib3</groupId>
+            <artifactId>testing</artifactId>
+        </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-
 </project>

--- a/config/src/test/kotlin/com/trib3/config/ExtensionTest.kt
+++ b/config/src/test/kotlin/com/trib3/config/ExtensionTest.kt
@@ -2,6 +2,7 @@ package com.trib3.config
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import com.trib3.testing.LeakyMock
 import org.easymock.EasyMock
 import org.testng.annotations.Test
 import software.amazon.awssdk.core.SdkBytes
@@ -15,7 +16,7 @@ class ExtensionTest {
     val loader: ConfigLoader
 
     init {
-        val fakeKms = EasyMock.mock<KmsClient>(KmsClient::class.java)
+        val fakeKms = LeakyMock.mock<KmsClient>()
         EasyMock.expect(fakeKms.decrypt(EasyMock.anyObject(DecryptRequest::class.java)))
             .andReturn(DecryptResponse.builder().plaintext(SdkBytes.fromUtf8String(ASSERT_VAL)).build()).anyTimes()
         EasyMock.replay(fakeKms)

--- a/config/src/test/kotlin/com/trib3/config/KMSStringReaderTest.kt
+++ b/config/src/test/kotlin/com/trib3/config/KMSStringReaderTest.kt
@@ -2,6 +2,7 @@ package com.trib3.config
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import com.trib3.testing.LeakyMock
 import com.typesafe.config.ConfigFactory
 import org.easymock.EasyMock
 import org.testng.annotations.Test
@@ -20,8 +21,8 @@ class KMSStringReaderTest {
 
     @Test
     fun testFakeKMS() {
-        val mockKms = EasyMock.createMock<KmsClient>(KmsClient::class.java)
-        EasyMock.expect(mockKms.decrypt(EasyMock.anyObject(DecryptRequest::class.java)))
+        val mockKms = LeakyMock.mock<KmsClient>()
+        EasyMock.expect(mockKms.decrypt(EasyMock.anyObject<DecryptRequest>()))
             .andReturn(DecryptResponse.builder().plaintext(SdkBytes.fromUtf8String("bleh")).build()).anyTimes()
         EasyMock.replay(mockKms)
         val reader = KMSStringReader(mockKms)

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -965,6 +965,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>com.trib3</groupId>
+                <artifactId>testing</artifactId>
+                <version>${version.leakycauldron}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
                 <version>${version.h2}</version>
@@ -1441,6 +1447,7 @@
                         </argLine>
                         <parallel>methods</parallel>
                         <threadCount>10</threadCount>
+                        <trimStackTrace>false</trimStackTrace>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
     <modules>
         <module>build-resources</module>
         <module>parent-pom</module>
+        <module>testing</module>
         <module>config</module>
         <module>json</module>
         <module>db</module>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -275,6 +275,10 @@
 
         <!-- test -->
         <dependency>
+            <groupId>com.trib3</groupId>
+            <artifactId>testing</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-testing</artifactId>
         </dependency>

--- a/server/src/main/kotlin/com/trib3/server/healthchecks/PingHealthCheck.kt
+++ b/server/src/main/kotlin/com/trib3/server/healthchecks/PingHealthCheck.kt
@@ -5,7 +5,7 @@ import com.codahale.metrics.health.HealthCheck
 /**
  * A simple HealthCheck that always returns healthy
  */
-class PingHealthCheck : HealthCheck() {
+open class PingHealthCheck : HealthCheck() {
     public override fun check(): Result {
         return Result.healthy("pong")
     }

--- a/server/src/main/kotlin/com/trib3/server/healthchecks/VersionHealthCheck.kt
+++ b/server/src/main/kotlin/com/trib3/server/healthchecks/VersionHealthCheck.kt
@@ -9,7 +9,7 @@ private val log = KotlinLogging.logger { }
 /**
  * A simple HealthCheck that returns runtime version information
  */
-class VersionHealthCheck : HealthCheck() {
+open class VersionHealthCheck : HealthCheck() {
     companion object {
         private fun readVersion(): Pair<String, Boolean> {
             return try {

--- a/server/src/test/kotlin/com/trib3/server/TribeApplicationTest.kt
+++ b/server/src/test/kotlin/com/trib3/server/TribeApplicationTest.kt
@@ -14,6 +14,7 @@ import com.trib3.server.filters.AdminAuthFilter
 import com.trib3.server.filters.RequestIdFilter
 import com.trib3.server.healthchecks.PingHealthCheck
 import com.trib3.server.healthchecks.VersionHealthCheck
+import com.trib3.testing.LeakyMock
 import io.dropwizard.Configuration
 import io.dropwizard.jersey.DropwizardResourceConfig
 import io.dropwizard.jersey.setup.JerseyEnvironment
@@ -23,8 +24,6 @@ import io.dropwizard.setup.Bootstrap
 import io.dropwizard.setup.Environment
 import io.swagger.v3.jaxrs2.integration.OpenApiServlet
 import org.easymock.EasyMock
-import org.easymock.EasyMock.anyObject
-import org.easymock.EasyMock.anyString
 import org.eclipse.jetty.servlets.CrossOriginFilter
 import org.testng.annotations.Test
 import javax.servlet.Filter
@@ -77,32 +76,33 @@ class TribeApplicationTest {
 
     @Test
     fun testRun() {
-        val mockConf = EasyMock.mock<Configuration>(Configuration::class.java)
-        val mockEnv = EasyMock.mock<Environment>(Environment::class.java)
-        val mockJersey = EasyMock.niceMock<JerseyEnvironment>(JerseyEnvironment::class.java)
-        val mockAdmin = EasyMock.mock<AdminEnvironment>(AdminEnvironment::class.java)
-        val mockServlet = EasyMock.mock<ServletEnvironment>(ServletEnvironment::class.java)
-        val mockHealthChecks = EasyMock.mock<HealthCheckRegistry>(HealthCheckRegistry::class.java)
+        val mockConf = LeakyMock.mock<Configuration>()
+        val mockEnv = LeakyMock.mock<Environment>()
+        val mockJersey = LeakyMock.niceMock<JerseyEnvironment>()
+        val mockAdmin = LeakyMock.mock<AdminEnvironment>()
+        val mockServlet = LeakyMock.mock<ServletEnvironment>()
+        val mockHealthChecks = LeakyMock.mock<HealthCheckRegistry>()
         val mockServletRegistration =
-            EasyMock.niceMock<ServletRegistration.Dynamic>(ServletRegistration.Dynamic::class.java)
+            LeakyMock.niceMock<ServletRegistration.Dynamic>()
         val mockFilterRegistration =
-            EasyMock.niceMock<FilterRegistration.Dynamic>(FilterRegistration.Dynamic::class.java)
+            LeakyMock.niceMock<FilterRegistration.Dynamic>()
         EasyMock.expect(mockEnv.jersey()).andReturn(mockJersey).anyTimes()
         EasyMock.expect(mockJersey.resourceConfig).andReturn(DropwizardResourceConfig()).anyTimes()
         EasyMock.expect(mockEnv.admin()).andReturn(mockAdmin).anyTimes()
-        EasyMock.expect(mockAdmin.addServlet(anyString(), anyObject<Servlet>()))
+        EasyMock.expect(mockAdmin.addServlet(LeakyMock.anyString(), LeakyMock.anyObject<Servlet>()))
             .andReturn(mockServletRegistration)
             .anyTimes()
         EasyMock.expect(mockEnv.servlets()).andReturn(mockServlet).anyTimes()
         EasyMock.expect(mockEnv.healthChecks()).andReturn(mockHealthChecks).anyTimes()
-        EasyMock.expect(mockServlet.addFilter(anyString(), EasyMock.anyObject<Class<out Filter>>()))
+        EasyMock.expect(mockServlet.addFilter(LeakyMock.anyString(), EasyMock.anyObject<Class<out Filter>>()))
             .andReturn(mockFilterRegistration).anyTimes()
-        EasyMock.expect(mockServlet.addServlet(anyString(), EasyMock.anyObject<Servlet>()))
+        EasyMock.expect(mockServlet.addServlet(LeakyMock.anyString(), LeakyMock.anyObject<Servlet>()))
             .andReturn(mockServletRegistration).anyTimes()
-        EasyMock.expect(mockAdmin.addFilter(anyString(), EasyMock.anyObject<Class<out Filter>>()))
+        EasyMock.expect(mockAdmin.addFilter(LeakyMock.anyString(), EasyMock.anyObject<Class<out Filter>>()))
             .andReturn(mockFilterRegistration).anyTimes()
-        EasyMock.expect(mockHealthChecks.register(anyString(), anyObject<VersionHealthCheck>())).once()
-        EasyMock.expect(mockHealthChecks.register(anyString(), anyObject<PingHealthCheck>())).once()
+        EasyMock.expect(mockHealthChecks.register(LeakyMock.anyString(), LeakyMock.anyObject<VersionHealthCheck>()))
+            .once()
+        EasyMock.expect(mockHealthChecks.register(LeakyMock.anyString(), LeakyMock.anyObject<PingHealthCheck>())).once()
 
         EasyMock.replay(
             mockConf,

--- a/server/src/test/kotlin/com/trib3/server/TribeServerlessTest.kt
+++ b/server/src/test/kotlin/com/trib3/server/TribeServerlessTest.kt
@@ -16,6 +16,7 @@ import com.trib3.server.config.dropwizard.HoconConfigurationFactoryFactory
 import com.trib3.server.filters.RequestIdFilter
 import com.trib3.server.healthchecks.PingHealthCheck
 import com.trib3.server.healthchecks.VersionHealthCheck
+import com.trib3.testing.LeakyMock
 import org.easymock.EasyMock
 import org.eclipse.jetty.servlets.CrossOriginFilter
 import org.testng.annotations.Test
@@ -56,15 +57,15 @@ class TribeServerlessTest {
 
     @Test
     fun testRunAndEntry() {
-        val mockProxyRequest = EasyMock.niceMock<AwsProxyRequestContext>(AwsProxyRequestContext::class.java)
-        val mockRequest = EasyMock.niceMock<AwsProxyRequest>(AwsProxyRequest::class.java)
-        val mockHeaders = EasyMock.niceMock<Headers>(Headers::class.java)
+        val mockProxyRequest = LeakyMock.niceMock<AwsProxyRequestContext>()
+        val mockRequest = LeakyMock.niceMock<AwsProxyRequest>()
+        val mockHeaders = LeakyMock.niceMock<Headers>()
         EasyMock.expect(mockRequest.path).andReturn("/").anyTimes()
         EasyMock.expect(mockRequest.httpMethod).andReturn("GET").anyTimes()
         EasyMock.expect(mockRequest.requestContext).andReturn(mockProxyRequest).anyTimes()
         EasyMock.expect(mockRequest.multiValueHeaders).andReturn(mockHeaders).anyTimes()
         EasyMock.expect(mockHeaders.keys).andReturn(mutableSetOf()).anyTimes()
-        val mockContext = EasyMock.niceMock<Context>(Context::class.java)
+        val mockContext = LeakyMock.niceMock<Context>()
         EasyMock.replay(mockRequest, mockContext, mockProxyRequest, mockHeaders)
         val proxy = instance.proxy
         proxy.setLogFormatter(null)

--- a/server/src/test/kotlin/com/trib3/server/config/dropwizard/FilteredRequestLogTest.kt
+++ b/server/src/test/kotlin/com/trib3/server/config/dropwizard/FilteredRequestLogTest.kt
@@ -6,6 +6,7 @@ import assertk.assertions.isNotEmpty
 import ch.qos.logback.access.spi.IAccessEvent
 import ch.qos.logback.core.AppenderBase
 import com.google.common.collect.ImmutableList
+import com.trib3.testing.LeakyMock
 import io.dropwizard.logging.AppenderFactory
 import org.easymock.EasyMock
 import org.eclipse.jetty.server.Request
@@ -33,8 +34,8 @@ class FilteredRequestLogTest {
                     }.also { it.start() }
                 })
         val logger = factory.build("test")
-        val mockRequest = EasyMock.niceMock<Request>(Request::class.java)
-        val mockResponse = EasyMock.niceMock<Response>(Response::class.java)
+        val mockRequest = LeakyMock.niceMock<Request>()
+        val mockResponse = LeakyMock.niceMock<Response>()
         EasyMock.expect(mockRequest.requestURI).andReturn("/app/ping").anyTimes()
         EasyMock.expect(mockRequest.timeStamp).andReturn(System.currentTimeMillis() + 200).anyTimes()
         EasyMock.expect(mockResponse.status).andReturn(HttpServletResponse.SC_OK).anyTimes()
@@ -62,8 +63,8 @@ class FilteredRequestLogTest {
                     }.also { it.start() }
                 })
         val logger = factory.build("test")
-        val mockRequest = EasyMock.niceMock<Request>(Request::class.java)
-        val mockResponse = EasyMock.niceMock<Response>(Response::class.java)
+        val mockRequest = LeakyMock.niceMock<Request>()
+        val mockResponse = LeakyMock.niceMock<Response>()
         EasyMock.expect(mockRequest.requestURI).andReturn("/app/ping").anyTimes()
         EasyMock.expect(mockRequest.timeStamp).andReturn(System.currentTimeMillis() - 300).anyTimes()
         EasyMock.expect(mockResponse.status).andReturn(HttpServletResponse.SC_OK).anyTimes()
@@ -91,8 +92,8 @@ class FilteredRequestLogTest {
                     }.also { it.start() }
                 })
         val logger = factory.build("test")
-        val mockRequest = EasyMock.niceMock<Request>(Request::class.java)
-        val mockResponse = EasyMock.niceMock<Response>(Response::class.java)
+        val mockRequest = LeakyMock.niceMock<Request>()
+        val mockResponse = LeakyMock.niceMock<Response>()
         EasyMock.expect(mockRequest.requestURI).andReturn("/app/ping").anyTimes()
         EasyMock.expect(mockRequest.timeStamp).andReturn(System.currentTimeMillis() + 200).anyTimes()
         EasyMock.expect(mockResponse.status).andReturn(HttpServletResponse.SC_SERVICE_UNAVAILABLE).anyTimes()
@@ -120,8 +121,8 @@ class FilteredRequestLogTest {
                     }.also { it.start() }
                 })
         val logger = factory.build("test")
-        val mockRequest = EasyMock.niceMock<Request>(Request::class.java)
-        val mockResponse = EasyMock.niceMock<Response>(Response::class.java)
+        val mockRequest = LeakyMock.niceMock<Request>()
+        val mockResponse = LeakyMock.niceMock<Response>()
         EasyMock.replay(mockRequest, mockResponse)
         logger.log(mockRequest, mockResponse)
         assertThat(events).isNotEmpty()

--- a/server/src/test/kotlin/com/trib3/server/filters/AdminAuthFilterTest.kt
+++ b/server/src/test/kotlin/com/trib3/server/filters/AdminAuthFilterTest.kt
@@ -6,6 +6,7 @@ import assertk.assertions.isFailure
 import assertk.assertions.isFalse
 import assertk.assertions.isSuccess
 import assertk.assertions.isTrue
+import com.trib3.testing.LeakyMock
 import org.easymock.EasyMock
 import org.testng.annotations.Test
 import java.util.Base64
@@ -16,8 +17,8 @@ import javax.servlet.http.HttpServletResponse
 class AdminAuthFilterTest {
     @Test
     fun testUnconfiguredFilter() {
-        val mockRequest = EasyMock.niceMock<HttpServletRequest>(HttpServletRequest::class.java)
-        val mockResponse = EasyMock.niceMock<HttpServletResponse>(HttpServletResponse::class.java)
+        val mockRequest = LeakyMock.niceMock<HttpServletRequest>()
+        val mockResponse = LeakyMock.niceMock<HttpServletResponse>()
         val filter = AdminAuthFilter()
         filter.init(null)
         var proceeded = false
@@ -31,9 +32,9 @@ class AdminAuthFilterTest {
     @Test
     fun testTokenConfiguredFilterGoodPass() {
         val base64 = Base64.getEncoder()
-        val mockRequest = EasyMock.niceMock<HttpServletRequest>(HttpServletRequest::class.java)
-        val mockResponse = EasyMock.niceMock<HttpServletResponse>(HttpServletResponse::class.java)
-        val mockFilterConfig = EasyMock.niceMock<FilterConfig>(FilterConfig::class.java)
+        val mockRequest = LeakyMock.niceMock<HttpServletRequest>()
+        val mockResponse = LeakyMock.niceMock<HttpServletResponse>()
+        val mockFilterConfig = LeakyMock.niceMock<FilterConfig>()
         val base64pass = String(base64.encode("abc:123".toByteArray()))
         EasyMock.expect(mockRequest.getHeader(EasyMock.eq("Authorization")))
             .andReturn("Basic $base64pass").anyTimes()
@@ -53,8 +54,8 @@ class AdminAuthFilterTest {
     @Test
     fun testTokenConfiguredFilterBadPassCustomRealm() {
         val base64 = Base64.getEncoder()
-        val mockRequest = EasyMock.niceMock<HttpServletRequest>(HttpServletRequest::class.java)
-        val mockResponse = EasyMock.niceMock<HttpServletResponse>(HttpServletResponse::class.java)
+        val mockRequest = LeakyMock.niceMock<HttpServletRequest>()
+        val mockResponse = LeakyMock.niceMock<HttpServletResponse>()
         EasyMock.expect(mockResponse.sendError(EasyMock.eq(HttpServletResponse.SC_UNAUTHORIZED))).once()
         EasyMock.expect(
             mockResponse.setHeader(
@@ -62,7 +63,7 @@ class AdminAuthFilterTest {
                 EasyMock.eq("Basic realm=\"trib3\"")
             )
         ).once()
-        val mockFilterConfig = EasyMock.niceMock<FilterConfig>(FilterConfig::class.java)
+        val mockFilterConfig = LeakyMock.niceMock<FilterConfig>()
         val base64pass = String(base64.encode("abc:456".toByteArray()))
         EasyMock.expect(mockRequest.getHeader(EasyMock.eq("Authorization")))
             .andReturn("Basic $base64pass").anyTimes()
@@ -84,8 +85,8 @@ class AdminAuthFilterTest {
 
     @Test
     fun testTokenConfiguredFilterBadSchemeDefaultRealm() {
-        val mockRequest = EasyMock.niceMock<HttpServletRequest>(HttpServletRequest::class.java)
-        val mockResponse = EasyMock.niceMock<HttpServletResponse>(HttpServletResponse::class.java)
+        val mockRequest = LeakyMock.niceMock<HttpServletRequest>()
+        val mockResponse = LeakyMock.niceMock<HttpServletResponse>()
         EasyMock.expect(mockResponse.sendError(EasyMock.eq(HttpServletResponse.SC_UNAUTHORIZED))).once()
         EasyMock.expect(
             mockResponse.setHeader(
@@ -93,7 +94,7 @@ class AdminAuthFilterTest {
                 EasyMock.eq("Basic realm=\"Realm\"")
             )
         ).once()
-        val mockFilterConfig = EasyMock.niceMock<FilterConfig>(FilterConfig::class.java)
+        val mockFilterConfig = LeakyMock.niceMock<FilterConfig>()
         EasyMock.expect(mockRequest.getHeader(EasyMock.eq("Authorization")))
             .andReturn("Raw abc:1213").anyTimes()
         EasyMock.expect(mockFilterConfig.getInitParameter(EasyMock.eq("token"))).andReturn("123").anyTimes()
@@ -112,8 +113,8 @@ class AdminAuthFilterTest {
 
     @Test
     fun testTokenConfiguredFilterNoPassDefaultRealm() {
-        val mockRequest = EasyMock.niceMock<HttpServletRequest>(HttpServletRequest::class.java)
-        val mockResponse = EasyMock.niceMock<HttpServletResponse>(HttpServletResponse::class.java)
+        val mockRequest = LeakyMock.niceMock<HttpServletRequest>()
+        val mockResponse = LeakyMock.niceMock<HttpServletResponse>()
         EasyMock.expect(mockResponse.sendError(EasyMock.eq(HttpServletResponse.SC_UNAUTHORIZED))).once()
         EasyMock.expect(
             mockResponse.setHeader(
@@ -121,7 +122,7 @@ class AdminAuthFilterTest {
                 EasyMock.eq("Basic realm=\"Realm\"")
             )
         ).once()
-        val mockFilterConfig = EasyMock.niceMock<FilterConfig>(FilterConfig::class.java)
+        val mockFilterConfig = LeakyMock.niceMock<FilterConfig>()
         EasyMock.expect(mockFilterConfig.getInitParameter(EasyMock.eq("token"))).andReturn("123").anyTimes()
         EasyMock.replay(mockRequest, mockResponse, mockFilterConfig)
         val filter = AdminAuthFilter()

--- a/server/src/test/kotlin/com/trib3/server/filters/RequestIdFilterTest.kt
+++ b/server/src/test/kotlin/com/trib3/server/filters/RequestIdFilterTest.kt
@@ -5,6 +5,7 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEmpty
 import assertk.assertions.isNull
 import assertk.assertions.isTrue
+import com.trib3.testing.LeakyMock
 import org.easymock.EasyMock
 import org.slf4j.MDC
 import org.testng.annotations.AfterClass
@@ -31,9 +32,9 @@ class RequestIdFilterTest {
 
     @Test
     fun testLoggingFilter() {
-        val mockRequest = EasyMock.mock<HttpServletRequest>(HttpServletRequest::class.java)
-        val mockResponse = EasyMock.mock<HttpServletResponse>(HttpServletResponse::class.java)
-        EasyMock.expect(mockResponse.setHeader(EasyMock.eq(RequestIdFilter.REQUEST_ID_HEADER), EasyMock.anyString()))
+        val mockRequest = LeakyMock.mock<HttpServletRequest>()
+        val mockResponse = LeakyMock.mock<HttpServletResponse>()
+        EasyMock.expect(mockResponse.setHeader(EasyMock.eq(RequestIdFilter.REQUEST_ID_HEADER), LeakyMock.anyString()))
             .once()
         EasyMock.replay(mockRequest, mockResponse)
         filter.doFilter(mockRequest, mockResponse) { _, _ ->
@@ -47,8 +48,8 @@ class RequestIdFilterTest {
         val requestId = UUID.randomUUID().toString()
         MDC.put(RequestIdFilter.REQUEST_ID_KEY, requestId)
         try {
-            val mockRequest = EasyMock.mock<HttpServletRequest>(HttpServletRequest::class.java)
-            val mockResponse = EasyMock.mock<HttpServletResponse>(HttpServletResponse::class.java)
+            val mockRequest = LeakyMock.mock<HttpServletRequest>()
+            val mockResponse = LeakyMock.mock<HttpServletResponse>()
             EasyMock.expect(
                 mockResponse.setHeader(
                     EasyMock.eq(RequestIdFilter.REQUEST_ID_HEADER),
@@ -67,8 +68,8 @@ class RequestIdFilterTest {
 
     @Test
     fun testLoggingFilterWithRawServletReqResp() {
-        val mockRequest = EasyMock.mock<ServletRequest>(ServletRequest::class.java)
-        val mockResponse = EasyMock.mock<ServletResponse>(ServletResponse::class.java)
+        val mockRequest = LeakyMock.mock<ServletRequest>()
+        val mockResponse = LeakyMock.mock<ServletResponse>()
         EasyMock.replay(mockRequest, mockResponse)
         filter.doFilter(mockRequest, mockResponse) { _, _ ->
             assertThat(MDC.get(RequestIdFilter.REQUEST_ID_KEY)).isNotEmpty()

--- a/server/src/test/kotlin/com/trib3/server/graphql/GraphQLWebSocketCreatorTest.kt
+++ b/server/src/test/kotlin/com/trib3/server/graphql/GraphQLWebSocketCreatorTest.kt
@@ -6,6 +6,7 @@ import assertk.assertions.isInstanceOf
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.trib3.config.ConfigLoader
 import com.trib3.config.KMSStringSelectReader
+import com.trib3.testing.LeakyMock
 import graphql.GraphQL
 import org.easymock.EasyMock
 import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest
@@ -15,15 +16,15 @@ import org.testng.annotations.Test
 class GraphQLWebSocketCreatorTest {
     @Test
     fun testSocketCreation() {
-        val graphQL = EasyMock.mock<GraphQL>(GraphQL::class.java)
+        val graphQL = LeakyMock.mock<GraphQL>()
         val mapper = ObjectMapper()
         val creator = GraphQLWebSocketCreator(graphQL, mapper, GraphQLConfig(ConfigLoader(KMSStringSelectReader(null))))
         assertThat(creator.graphQL).isEqualTo(graphQL)
         assertThat(creator.objectMapper).isEqualTo(mapper)
         assertThat(creator.graphQLConfig.keepAliveIntervalSeconds).isEqualTo(GraphQLConfigTest.DEFAULT_KEEPALIVE)
 
-        val request = EasyMock.mock<ServletUpgradeRequest>(ServletUpgradeRequest::class.java)
-        val response = EasyMock.mock<ServletUpgradeResponse>(ServletUpgradeResponse::class.java)
+        val request = LeakyMock.mock<ServletUpgradeRequest>()
+        val response = LeakyMock.mock<ServletUpgradeResponse>()
         EasyMock.expect(response.setAcceptedSubProtocol("graphql-ws")).once()
         EasyMock.replay(graphQL, request, response)
         val socket = creator.createWebSocket(request, response)

--- a/server/src/test/kotlin/com/trib3/server/graphql/GraphQLWebSocketTest.kt
+++ b/server/src/test/kotlin/com/trib3/server/graphql/GraphQLWebSocketTest.kt
@@ -12,6 +12,7 @@ import com.expedia.graphql.toSchema
 import com.trib3.config.ConfigLoader
 import com.trib3.config.KMSStringSelectReader
 import com.trib3.json.ObjectMapperProvider
+import com.trib3.testing.LeakyMock
 import graphql.ExecutionInput
 import graphql.GraphQL
 import io.reactivex.Scheduler
@@ -114,25 +115,25 @@ class GraphQLWebSocketTest {
     @Test
     fun testSocketQuery() {
         val socket = getSocket()
-        val mockRemote = EasyMock.mock<WebSocketRemoteEndpoint>(WebSocketRemoteEndpoint::class.java)
-        val mockSession = EasyMock.mock<Session>(Session::class.java)
+        val mockRemote = LeakyMock.mock<WebSocketRemoteEndpoint>()
+        val mockSession = LeakyMock.mock<Session>()
         EasyMock.expect(mockSession.remote).andReturn(mockRemote).anyTimes()
         EasyMock.expect(
             mockRemote.sendString(
-                EasyMock.and(
-                    EasyMock.contains(""""q" : [ "1", "2", "3" ]"""),
-                    EasyMock.and(
-                        EasyMock.contains(""""type" : "data""""),
-                        EasyMock.contains(""""id" : "simplequery"""")
+                LeakyMock.and(
+                    LeakyMock.contains(""""q" : [ "1", "2", "3" ]"""),
+                    LeakyMock.and(
+                        LeakyMock.contains(""""type" : "data""""),
+                        LeakyMock.contains(""""id" : "simplequery"""")
                     )
                 )
             )
         ).once()
         EasyMock.expect(
             mockRemote.sendString(
-                EasyMock.and(
-                    EasyMock.contains(""""type" : "complete""""),
-                    EasyMock.contains(""""id" : "simplequery"""")
+                LeakyMock.and(
+                    LeakyMock.contains(""""type" : "complete""""),
+                    LeakyMock.contains(""""id" : "simplequery"""")
                 )
             )
         ).once()
@@ -148,25 +149,25 @@ class GraphQLWebSocketTest {
     @Test
     fun testSocketVariableQuery() {
         val socket = getSocket()
-        val mockRemote = EasyMock.mock<WebSocketRemoteEndpoint>(WebSocketRemoteEndpoint::class.java)
-        val mockSession = EasyMock.mock<Session>(Session::class.java)
+        val mockRemote = LeakyMock.mock<WebSocketRemoteEndpoint>()
+        val mockSession = LeakyMock.mock<Session>()
         EasyMock.expect(mockSession.remote).andReturn(mockRemote).anyTimes()
         EasyMock.expect(
             mockRemote.sendString(
-                EasyMock.and(
-                    EasyMock.contains(""""v" : [ "1", "2", "3" ]"""),
-                    EasyMock.and(
-                        EasyMock.contains(""""type" : "data""""),
-                        EasyMock.contains(""""id" : "simplequery"""")
+                LeakyMock.and(
+                    LeakyMock.contains(""""v" : [ "1", "2", "3" ]"""),
+                    LeakyMock.and(
+                        LeakyMock.contains(""""type" : "data""""),
+                        LeakyMock.contains(""""id" : "simplequery"""")
                     )
                 )
             )
         ).once()
         EasyMock.expect(
             mockRemote.sendString(
-                EasyMock.and(
-                    EasyMock.contains(""""type" : "complete""""),
-                    EasyMock.contains(""""id" : "simplequery"""")
+                LeakyMock.and(
+                    LeakyMock.contains(""""type" : "complete""""),
+                    LeakyMock.contains(""""id" : "simplequery"""")
                 )
             )
         ).once()
@@ -186,16 +187,16 @@ class GraphQLWebSocketTest {
     @Test
     fun testSocketQueryError() {
         val socket = getSocket()
-        val mockRemote = EasyMock.mock<WebSocketRemoteEndpoint>(WebSocketRemoteEndpoint::class.java)
-        val mockSession = EasyMock.mock<Session>(Session::class.java)
+        val mockRemote = LeakyMock.mock<WebSocketRemoteEndpoint>()
+        val mockSession = LeakyMock.mock<Session>()
         EasyMock.expect(mockSession.remote).andReturn(mockRemote).anyTimes()
         val errorCapture = EasyMock.newCapture<String>()
         EasyMock.expect(mockRemote.sendString(EasyMock.capture(errorCapture))).once()
         EasyMock.expect(
             mockRemote.sendString(
-                EasyMock.and(
-                    EasyMock.contains(""""type" : "complete""""),
-                    EasyMock.contains(""""id" : "errorquery"""")
+                LeakyMock.and(
+                    LeakyMock.contains(""""type" : "complete""""),
+                    LeakyMock.contains(""""id" : "errorquery"""")
                 )
             )
         ).once()
@@ -209,18 +210,18 @@ class GraphQLWebSocketTest {
 
     @Test
     fun testSocketExecutionError() {
-        val mockGraphQL = EasyMock.mock<GraphQL>(GraphQL::class.java)
+        val mockGraphQL = LeakyMock.mock<GraphQL>()
         val socket = getSocket(mockGraphQL)
-        val mockRemote = EasyMock.mock<WebSocketRemoteEndpoint>(WebSocketRemoteEndpoint::class.java)
-        val mockSession = EasyMock.mock<Session>(Session::class.java)
+        val mockRemote = LeakyMock.mock<WebSocketRemoteEndpoint>()
+        val mockSession = LeakyMock.mock<Session>()
         EasyMock.expect(mockSession.remote).andReturn(mockRemote).anyTimes()
-        EasyMock.expect(mockGraphQL.execute(EasyMock.anyObject<ExecutionInput>()))
+        EasyMock.expect(mockGraphQL.execute(LeakyMock.anyObject<ExecutionInput>()))
             .andThrow(IllegalStateException("ExecutionError"))
         EasyMock.expect(
             mockRemote.sendString(
-                EasyMock.and(
-                    EasyMock.contains(""""type" : "error""""),
-                    EasyMock.contains(""""id" : "executionerror"""")
+                LeakyMock.and(
+                    LeakyMock.contains(""""type" : "error""""),
+                    LeakyMock.contains(""""id" : "executionerror"""")
                 )
             )
         ).once()
@@ -236,47 +237,47 @@ class GraphQLWebSocketTest {
     @Test
     fun testSocketSubscription() {
         val socket = getSocket()
-        val mockRemote = EasyMock.mock<WebSocketRemoteEndpoint>(WebSocketRemoteEndpoint::class.java)
-        val mockSession = EasyMock.mock<Session>(Session::class.java)
+        val mockRemote = LeakyMock.mock<WebSocketRemoteEndpoint>()
+        val mockSession = LeakyMock.mock<Session>()
         EasyMock.expect(mockSession.remote).andReturn(mockRemote).anyTimes()
         EasyMock.expect(
             mockRemote.sendString(
-                EasyMock.and(
-                    EasyMock.contains(""""s" : "1""""),
-                    EasyMock.and(
-                        EasyMock.contains(""""type" : "data""""),
-                        EasyMock.contains(""""id" : "simplesubscription"""")
+                LeakyMock.and(
+                    LeakyMock.contains(""""s" : "1""""),
+                    LeakyMock.and(
+                        LeakyMock.contains(""""type" : "data""""),
+                        LeakyMock.contains(""""id" : "simplesubscription"""")
                     )
                 )
             )
         ).once()
         EasyMock.expect(
             mockRemote.sendString(
-                EasyMock.and(
-                    EasyMock.contains(""""s" : "2""""),
-                    EasyMock.and(
-                        EasyMock.contains(""""type" : "data""""),
-                        EasyMock.contains(""""id" : "simplesubscription"""")
+                LeakyMock.and(
+                    LeakyMock.contains(""""s" : "2""""),
+                    LeakyMock.and(
+                        LeakyMock.contains(""""type" : "data""""),
+                        LeakyMock.contains(""""id" : "simplesubscription"""")
                     )
                 )
             )
         ).once()
         EasyMock.expect(
             mockRemote.sendString(
-                EasyMock.and(
-                    EasyMock.contains(""""s" : "3""""),
-                    EasyMock.and(
-                        EasyMock.contains(""""type" : "data""""),
-                        EasyMock.contains(""""id" : "simplesubscription"""")
+                LeakyMock.and(
+                    LeakyMock.contains(""""s" : "3""""),
+                    LeakyMock.and(
+                        LeakyMock.contains(""""type" : "data""""),
+                        LeakyMock.contains(""""id" : "simplesubscription"""")
                     )
                 )
             )
         ).once()
         EasyMock.expect(
             mockRemote.sendString(
-                EasyMock.and(
-                    EasyMock.contains(""""type" : "complete""""),
-                    EasyMock.contains(""""id" : "simplesubscription"""")
+                LeakyMock.and(
+                    LeakyMock.contains(""""type" : "complete""""),
+                    LeakyMock.contains(""""id" : "simplesubscription"""")
                 )
             )
         ).once()
@@ -295,36 +296,36 @@ class GraphQLWebSocketTest {
     @Test
     fun testSocketSubscriptionError() {
         val socket = getSocket()
-        val mockRemote = EasyMock.mock<WebSocketRemoteEndpoint>(WebSocketRemoteEndpoint::class.java)
-        val mockSession = EasyMock.mock<Session>(Session::class.java)
+        val mockRemote = LeakyMock.mock<WebSocketRemoteEndpoint>()
+        val mockSession = LeakyMock.mock<Session>()
         EasyMock.expect(mockSession.remote).andReturn(mockRemote).anyTimes()
         EasyMock.expect(
             mockRemote.sendString(
-                EasyMock.and(
-                    EasyMock.contains(""""e" : "1""""),
-                    EasyMock.and(
-                        EasyMock.contains(""""type" : "data""""),
-                        EasyMock.contains(""""id" : "errorsubscription"""")
+                LeakyMock.and(
+                    LeakyMock.contains(""""e" : "1""""),
+                    LeakyMock.and(
+                        LeakyMock.contains(""""type" : "data""""),
+                        LeakyMock.contains(""""id" : "errorsubscription"""")
                     )
                 )
             )
         ).once()
         EasyMock.expect(
             mockRemote.sendString(
-                EasyMock.and(
-                    EasyMock.contains(""""e" : "2""""),
-                    EasyMock.and(
-                        EasyMock.contains(""""type" : "data""""),
-                        EasyMock.contains(""""id" : "errorsubscription"""")
+                LeakyMock.and(
+                    LeakyMock.contains(""""e" : "2""""),
+                    LeakyMock.and(
+                        LeakyMock.contains(""""type" : "data""""),
+                        LeakyMock.contains(""""id" : "errorsubscription"""")
                     )
                 )
             )
         ).once()
         EasyMock.expect(
             mockRemote.sendString(
-                EasyMock.and(
-                    EasyMock.contains(""""type" : "error""""),
-                    EasyMock.contains(""""id" : "errorsubscription"""")
+                LeakyMock.and(
+                    LeakyMock.contains(""""type" : "error""""),
+                    LeakyMock.contains(""""id" : "errorsubscription"""")
                 )
             )
         ).once()
@@ -346,52 +347,52 @@ class GraphQLWebSocketTest {
         assertThat(socket.scheduler).isEqualTo(Schedulers.trampoline())
         assertThat(socket.keepAliveScheduler).isEqualTo(Schedulers.computation())
         assertThat(socket.graphQLConfig).isEqualTo(config)
-        val mockRemote = EasyMock.mock<WebSocketRemoteEndpoint>(WebSocketRemoteEndpoint::class.java)
-        val mockSession = EasyMock.mock<Session>(Session::class.java)
+        val mockRemote = LeakyMock.mock<WebSocketRemoteEndpoint>()
+        val mockSession = LeakyMock.mock<Session>()
         EasyMock.expect(mockSession.remote).andReturn(mockRemote).anyTimes()
         EasyMock.expect(
             mockRemote.sendString(
-                EasyMock.and(
-                    EasyMock.contains(""""type" : "error""""),
-                    EasyMock.contains(""""id" : "unknownoperation"""")
+                LeakyMock.and(
+                    LeakyMock.contains(""""type" : "error""""),
+                    LeakyMock.contains(""""id" : "unknownoperation"""")
                 )
             )
         ).once()
         EasyMock.expect(
             mockRemote.sendString(
-                EasyMock.and(
-                    EasyMock.contains(""""type" : "error""""),
-                    EasyMock.and(
-                        EasyMock.contains(""""id" : "unconfiguredquery""""),
-                        EasyMock.contains("not configured")
+                LeakyMock.and(
+                    LeakyMock.contains(""""type" : "error""""),
+                    LeakyMock.and(
+                        LeakyMock.contains(""""id" : "unconfiguredquery""""),
+                        LeakyMock.contains("not configured")
                     )
                 )
             )
         ).once()
         EasyMock.expect(
             mockRemote.sendString(
-                EasyMock.and(
-                    EasyMock.contains(""""type" : "error""""),
-                    EasyMock.and(
-                        EasyMock.contains(""""id" : "invalidtype""""),
-                        EasyMock.contains(""""payload" : "Unknown message type"""")
+                LeakyMock.and(
+                    LeakyMock.contains(""""type" : "error""""),
+                    LeakyMock.and(
+                        LeakyMock.contains(""""id" : "invalidtype""""),
+                        LeakyMock.contains(""""payload" : "Unknown message type"""")
                     )
                 )
             )
         ).once()
         EasyMock.expect(
             mockRemote.sendString(
-                EasyMock.and(
-                    EasyMock.contains(""""type" : "error""""),
-                    EasyMock.and(
-                        EasyMock.contains(""""id" : "badpayload""""),
-                        EasyMock.contains(""""payload" : "Invalid payload for query"""")
+                LeakyMock.and(
+                    LeakyMock.contains(""""type" : "error""""),
+                    LeakyMock.and(
+                        LeakyMock.contains(""""id" : "badpayload""""),
+                        LeakyMock.contains(""""payload" : "Invalid payload for query"""")
                     )
                 )
             )
         ).once()
-        EasyMock.expect(mockSession.close(EasyMock.eq(StatusCode.SERVER_ERROR), EasyMock.contains("boom"))).once()
-        EasyMock.expect(mockSession.close(EasyMock.anyInt(), EasyMock.anyString())).anyTimes()
+        EasyMock.expect(mockSession.close(EasyMock.eq(StatusCode.SERVER_ERROR), LeakyMock.contains("boom"))).once()
+        EasyMock.expect(mockSession.close(EasyMock.anyInt(), LeakyMock.anyString())).anyTimes()
 
         EasyMock.replay(mockRemote, mockSession)
 
@@ -422,40 +423,40 @@ class GraphQLWebSocketTest {
     fun testConnectAckAndKeepAlive() {
         val testScheduler = TestScheduler()
         val socket = getSocket(keepAliveScheduler = testScheduler)
-        val mockRemote = EasyMock.mock<WebSocketRemoteEndpoint>(WebSocketRemoteEndpoint::class.java)
-        val mockSession = EasyMock.mock<Session>(Session::class.java)
+        val mockRemote = LeakyMock.mock<WebSocketRemoteEndpoint>()
+        val mockSession = LeakyMock.mock<Session>()
         EasyMock.expect(mockSession.remote).andReturn(mockRemote).anyTimes()
         EasyMock.expect(
             mockRemote.sendString(
-                EasyMock.and(
-                    EasyMock.contains(""""type" : "connection_ack""""),
-                    EasyMock.contains(""""id" : "connect"""")
+                LeakyMock.and(
+                    LeakyMock.contains(""""type" : "connection_ack""""),
+                    LeakyMock.contains(""""id" : "connect"""")
                 )
             )
         ).once()
         EasyMock.expect(
             mockRemote.sendString(
-                EasyMock.and(
-                    EasyMock.contains(""""type" : "ka""""),
-                    EasyMock.contains(""""id" : "connect"""")
+                LeakyMock.and(
+                    LeakyMock.contains(""""type" : "ka""""),
+                    LeakyMock.contains(""""id" : "connect"""")
                 )
             )
         ).once()
         EasyMock.expect(
             mockRemote.sendString(
-                EasyMock.and(
-                    EasyMock.contains(""""type" : "ka""""),
-                    EasyMock.contains(""""id" : "connect"""")
+                LeakyMock.and(
+                    LeakyMock.contains(""""type" : "ka""""),
+                    LeakyMock.contains(""""id" : "connect"""")
                 )
             )
         ).once()
         EasyMock.expect(
             mockRemote.sendString(
-                EasyMock.and(
-                    EasyMock.contains(""""payload" : "Already connected!""""),
-                    EasyMock.and(
-                        EasyMock.contains(""""type" : "connection_error""""),
-                        EasyMock.contains(""""id" : "connect2"""")
+                LeakyMock.and(
+                    LeakyMock.contains(""""payload" : "Already connected!""""),
+                    LeakyMock.and(
+                        LeakyMock.contains(""""type" : "connection_error""""),
+                        LeakyMock.contains(""""id" : "connect2"""")
                     )
                 )
             )
@@ -472,8 +473,8 @@ class GraphQLWebSocketTest {
     @Test
     fun testRequestTerminate() {
         val socket = getSocket()
-        val mockRemote = EasyMock.mock<WebSocketRemoteEndpoint>(WebSocketRemoteEndpoint::class.java)
-        val mockSession = EasyMock.mock<Session>(Session::class.java)
+        val mockRemote = LeakyMock.mock<WebSocketRemoteEndpoint>()
+        val mockSession = LeakyMock.mock<Session>()
         EasyMock.expect(mockSession.remote).andReturn(mockRemote).anyTimes()
         EasyMock.expect(
             mockSession.close(StatusCode.NORMAL, "Termination Requested")
@@ -490,10 +491,10 @@ class GraphQLWebSocketTest {
         // use Schedulers.computation() since we're using the infinite subscription stream
         // and want to be able to call `onWebSocketClose` while the query is running
         val socket = getSocket(scheduler = Schedulers.computation())
-        val mockRemote = EasyMock.mock<WebSocketRemoteEndpoint>(WebSocketRemoteEndpoint::class.java)
-        val mockSession = EasyMock.mock<Session>(Session::class.java)
+        val mockRemote = LeakyMock.mock<WebSocketRemoteEndpoint>()
+        val mockSession = LeakyMock.mock<Session>()
         EasyMock.expect(mockSession.remote).andReturn(mockRemote).anyTimes()
-        EasyMock.expect(mockRemote.sendString(EasyMock.anyString())).anyTimes()
+        EasyMock.expect(mockRemote.sendString(LeakyMock.anyString())).anyTimes()
         EasyMock.replay(mockRemote, mockSession)
         socket.adapter.onWebSocketConnect(mockSession)
         socket.adapter.onWebSocketText("""{"type": "connection_init", "id": "connect", "payload":null}""")
@@ -509,8 +510,8 @@ class GraphQLWebSocketTest {
     fun testStopQuery() {
         // and use Schedulers.computation() since we're using the infinite subscription stream
         val socket = getSocket(scheduler = Schedulers.computation())
-        val mockRemote = EasyMock.mock<WebSocketRemoteEndpoint>(WebSocketRemoteEndpoint::class.java)
-        val mockSession = EasyMock.mock<Session>(Session::class.java)
+        val mockRemote = LeakyMock.mock<WebSocketRemoteEndpoint>()
+        val mockSession = LeakyMock.mock<Session>()
         // use these to signal the test that certain steps have been accomplished
         val data = CountDownLatch(1)
         val secondQueryErrored = CountDownLatch(1)
@@ -518,31 +519,31 @@ class GraphQLWebSocketTest {
         EasyMock.expect(mockSession.remote).andReturn(mockRemote).anyTimes()
         EasyMock.expect(
             mockRemote.sendString(
-                EasyMock.and(
-                    EasyMock.contains(""""inf" : """"),
-                    EasyMock.and(
-                        EasyMock.contains(""""type" : "data""""),
-                        EasyMock.contains(""""id" : "longsubscription"""")
+                LeakyMock.and(
+                    LeakyMock.contains(""""inf" : """"),
+                    LeakyMock.and(
+                        LeakyMock.contains(""""type" : "data""""),
+                        LeakyMock.contains(""""id" : "longsubscription"""")
                     )
                 )
             )
         ).andAnswer { data.countDown() }.atLeastOnce() // notify that data has been sent
         EasyMock.expect(
             mockRemote.sendString(
-                EasyMock.and(
-                    EasyMock.contains("""already running"""),
-                    EasyMock.and(
-                        EasyMock.contains(""""type" : "error""""),
-                        EasyMock.contains(""""id" : "longsubscription"""")
+                LeakyMock.and(
+                    LeakyMock.contains("""already running"""),
+                    LeakyMock.and(
+                        LeakyMock.contains(""""type" : "error""""),
+                        LeakyMock.contains(""""id" : "longsubscription"""")
                     )
                 )
             )
         ).andAnswer { secondQueryErrored.countDown() }.once()
         EasyMock.expect(
             mockRemote.sendString(
-                EasyMock.and(
-                    EasyMock.contains(""""type" : "complete""""),
-                    EasyMock.contains(""""id" : "longsubscription"""")
+                LeakyMock.and(
+                    LeakyMock.contains(""""type" : "complete""""),
+                    LeakyMock.contains(""""id" : "longsubscription"""")
                 )
             )
         ).andAnswer { complete.countDown() }.once() // notify that complete has been sent
@@ -577,14 +578,14 @@ class GraphQLWebSocketTest {
     @Test
     fun testStopWrongQuery() {
         val socket = getSocket()
-        val mockRemote = EasyMock.mock<WebSocketRemoteEndpoint>(WebSocketRemoteEndpoint::class.java)
-        val mockSession = EasyMock.mock<Session>(Session::class.java)
+        val mockRemote = LeakyMock.mock<WebSocketRemoteEndpoint>()
+        val mockSession = LeakyMock.mock<Session>()
         EasyMock.expect(mockSession.remote).andReturn(mockRemote).anyTimes()
         EasyMock.expect(
             mockRemote.sendString(
-                EasyMock.and(
-                    EasyMock.contains(""""type" : "error""""),
-                    EasyMock.contains(""""id" : "unknownquery"""")
+                LeakyMock.and(
+                    LeakyMock.contains(""""type" : "error""""),
+                    LeakyMock.contains(""""id" : "unknownquery"""")
                 )
             )
         ).once()
@@ -603,14 +604,14 @@ class GraphQLWebSocketTest {
     @Test
     fun testStartWithoutId() {
         val socket = getSocket()
-        val mockRemote = EasyMock.mock<WebSocketRemoteEndpoint>(WebSocketRemoteEndpoint::class.java)
-        val mockSession = EasyMock.mock<Session>(Session::class.java)
+        val mockRemote = LeakyMock.mock<WebSocketRemoteEndpoint>()
+        val mockSession = LeakyMock.mock<Session>()
         EasyMock.expect(mockSession.remote).andReturn(mockRemote).anyTimes()
         EasyMock.expect(
             mockRemote.sendString(
-                EasyMock.and(
-                    EasyMock.contains(""""type" : "error""""),
-                    EasyMock.contains(""""payload" : "Must pass a message id""")
+                LeakyMock.and(
+                    LeakyMock.contains(""""type" : "error""""),
+                    LeakyMock.contains(""""payload" : "Must pass a message id""")
                 )
             )
         ).once()
@@ -629,14 +630,14 @@ class GraphQLWebSocketTest {
     @Test
     fun testBadMessage() {
         val socket = getSocket()
-        val mockRemote = EasyMock.mock<WebSocketRemoteEndpoint>(WebSocketRemoteEndpoint::class.java)
-        val mockSession = EasyMock.mock<Session>(Session::class.java)
+        val mockRemote = LeakyMock.mock<WebSocketRemoteEndpoint>()
+        val mockSession = LeakyMock.mock<Session>()
         EasyMock.expect(mockSession.remote).andReturn(mockRemote).anyTimes()
         EasyMock.expect(
             mockRemote.sendString(
-                EasyMock.and(
-                    EasyMock.contains(""""type" : "error""""),
-                    EasyMock.contains(""""payload" : "Unrecognized token""")
+                LeakyMock.and(
+                    LeakyMock.contains(""""type" : "error""""),
+                    LeakyMock.contains(""""payload" : "Unrecognized token""")
                 )
             )
         ).once()

--- a/testing/README.md
+++ b/testing/README.md
@@ -1,0 +1,26 @@
+testing
+=======
+Classes that enhance writing unit tests.
+
+#### LeakyMock
+Enhancements to [EasyMock](http://easymock.org/) for a more usable kotlin experience.  Makes mock
+creation more concise, and provides a number of matchers that return non-null values to work better
+with kotlin's nullability checks.
+
+Create mocks with type inference (Avoid this [issue](https://github.com/easymock/easymock/issues/239)):
+```kotlin
+// all these options also work for niceMock
+val mock = LeakyMock.mock<ClassToMock>() // mock will be inferred to be of type ClassToMock
+val mock2 = LeakyMock.mock(ClassToMock::class.java) // mock2 will also be of type ClassToMock
+val mock3: ClassToMock = LeakyMock.mock() // mock3 will also be of type ClassToMock
+val support = EasyMockSupport()
+val mock4 = support.mock<ClassToMock>() // mock 4 is a ClassToMock, and tracked by support
+// compare this with:
+val nonLeakyMock = EasyMock.mock<ClassToMock>(ClassToMock::class.java)
+```
+Match on objects without violating kotlin null checks (Avoid `EasyMock.anyObject() must not be null`):
+```kotlin
+EasyMock.expect(mock.doSomethingWithNonNullable(LeakyMock.anyObject())).and ...
+// compare this with:
+EasyMock.expect(mock.doSomethingWithNonNullable(EasyMock.anyObject() ?: instance)).and ...
+```

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.trib3</groupId>
+        <artifactId>leakycauldron</artifactId>
+        <version>1.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <groupId>com.trib3</groupId>
+    <artifactId>testing</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.easymock</groupId>
+            <artifactId>easymock</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/testing/src/main/kotlin/com/trib3/testing/LeakyMock.kt
+++ b/testing/src/main/kotlin/com/trib3/testing/LeakyMock.kt
@@ -1,0 +1,193 @@
+package com.trib3.testing
+
+import org.easymock.Capture
+import org.easymock.EasyMock
+import org.easymock.EasyMockSupport
+
+/**
+ * Extension function to add a `mock<T>()` method to [EasyMockSupport]
+ * for less repetition when creating mocks.
+ */
+inline fun <reified T> EasyMockSupport.mock(name: String? = null): T {
+    return mock(name, T::class.java)
+}
+
+/**
+ * Extension function to add a `niceMock<T>()` method to [EasyMockSupport]
+ * for less repetition when creating nice mocks.
+ */
+inline fun <reified T> EasyMockSupport.niceMock(name: String? = null): T {
+    return niceMock(name, T::class.java)
+}
+
+/**
+ * Collection of static methods to use with EasyMock for a more
+ * usable kotlin experience.  Provides type-inference friendly mock()
+ * methods as well as matchers that return non-null values for passing
+ * to non-nullable methods.  Can be intermixed with [EasyMock] methods
+ * when the [LeakyMock] implementation is missing or not desired.
+ *
+ * Note that any matchers that return a mock must be used on open/non-final
+ * classes, as EasyMock can't create mock instances of closed/final classes.
+ * In those cases, the EasyMock version of the matcher can be used if the
+ * method being called accepts null arguments.
+ */
+class LeakyMock {
+    companion object {
+        /**
+         * Create a mock object of the specified type
+         */
+        inline fun <reified T> mock(name: String? = null): T {
+            return EasyMock.mock(name, T::class.java)
+        }
+
+        /**
+         * Create a mock object of the specified type
+         */
+        fun <T> mock(clazz: Class<T>): T {
+            return EasyMock.mock(clazz)
+        }
+
+        /**
+         * Create a named mock object of the specified type
+         */
+        fun <T> mock(name: String, clazz: Class<T>): T {
+            return EasyMock.mock(name, clazz)
+        }
+
+        /**
+         * Create a nice mock object of the specified type
+         */
+        inline fun <reified T> niceMock(name: String? = null): T {
+            return EasyMock.niceMock(name, T::class.java)
+        }
+
+        /**
+         * Create a nice mock object of the specified type
+         */
+        fun <T> niceMock(clazz: Class<T>): T {
+            return EasyMock.niceMock(clazz)
+        }
+
+        /**
+         * Create a named nice mock object of the specified type
+         */
+        fun <T> niceMock(name: String, clazz: Class<T>): T {
+            return EasyMock.niceMock(name, clazz)
+        }
+
+        /**
+         * Expect any object of the specified type and return a mock
+         */
+        inline fun <reified T> anyObject(): T {
+            EasyMock.anyObject<T>()
+            return mock()
+        }
+
+        /**
+         * Expect any object of the specified type and return a mock
+         */
+        inline fun <reified T> anyObject(clazz: Class<T>): T {
+            EasyMock.anyObject(clazz)
+            return mock()
+        }
+
+        /**
+         * Expect any string and return an empty string
+         */
+        fun anyString(): String {
+            EasyMock.anyString()
+            return ""
+        }
+
+        /**
+         * Expect an instance of the specified type and return a mock
+         */
+        inline fun <reified T> isA(): T {
+            EasyMock.isA(T::class.java)
+            return mock()
+        }
+
+        /**
+         * Expect an instance of the specified type and return a mock
+         */
+        fun <T> isA(clazz: Class<T>): T {
+            EasyMock.isA(clazz)
+            return mock(clazz)
+        }
+
+        /**
+         * Expect a string that contains [substring] and return an empty string
+         */
+        fun contains(substring: String): String {
+            EasyMock.contains(substring)
+            return ""
+        }
+
+        /**
+         * Expect an object that matches both given expectations, and return the first one
+         */
+        fun <T> and(first: T, second: T): T {
+            EasyMock.and(first, second)
+            return first
+        }
+
+        /**
+         * Expect an object that matches either of the given expectations, and return the first one
+         */
+        fun <T> or(first: T, second: T): T {
+            EasyMock.or(first, second)
+            return first
+        }
+
+        /**
+         * Expect an object that does not match the given expectation, and return the expectation
+         */
+        fun <T> not(first: T): T {
+            EasyMock.not(first)
+            return first
+        }
+
+        // skip isNull() and notNull() matchers -- if using them the method likely accepts nullable args
+
+        /**
+         * Expect a string that contains a substring that matches [regex] and return an empty string
+         */
+        fun find(regex: String): String {
+            EasyMock.find(regex)
+            return ""
+        }
+
+        /**
+         * Expect a string that matches [regex] and return an empty string
+         */
+        fun matches(regex: String): String {
+            EasyMock.matches(regex)
+            return ""
+        }
+
+        /**
+         * Expect a string that starts with [prefix] and return an empty string
+         */
+        fun startsWtih(prefix: String): String {
+            EasyMock.startsWith(prefix)
+            return ""
+        }
+
+        /**
+         * Expect a string that ends with [suffix] and return an empty string
+         */
+        fun endsWith(suffix: String): String {
+            EasyMock.endsWith(suffix)
+            return ""
+        }
+
+        /**
+         * Expect any object, but capture it for later use, and return a mock
+         */
+        inline fun <reified T> capture(captured: Capture<T>): T {
+            EasyMock.capture(captured)
+            return mock()
+        }
+    }
+}

--- a/testing/src/test/kotlin/com/trib3/testing/LeakyMockTest.kt
+++ b/testing/src/test/kotlin/com/trib3/testing/LeakyMockTest.kt
@@ -1,0 +1,132 @@
+package com.trib3.testing
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFailure
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.assertions.isSuccess
+import assertk.assertions.message
+import org.easymock.EasyMock
+import org.easymock.EasyMockSupport
+import org.testng.annotations.Test
+
+interface Thing
+
+interface TestClass {
+    fun manipulateString(str: String): String
+    fun manipulateThing(thing: Thing): Thing
+    fun processThing(thing: Thing)
+    fun getThing(): Thing
+}
+
+open class RealThing(val instance: Int) : Thing {
+    override fun equals(other: Any?): Boolean {
+        if (other is RealThing) {
+            return instance == other.instance
+        }
+        return false
+    }
+
+    override fun hashCode(): Int {
+        return instance.hashCode()
+    }
+}
+
+class LeakyMockTest {
+    @Test
+    fun testMockSupportAndStringMatchers() {
+        val support = EasyMockSupport()
+        val mock = support.mock<TestClass>()
+        EasyMock.expect(mock.manipulateString(LeakyMock.anyString())).andReturn("bah!").once()
+        EasyMock.expect(mock.manipulateString(LeakyMock.contains("foo"))).andReturn("bar!").once()
+        EasyMock.expect(
+            mock.manipulateString(
+                LeakyMock.and(
+                    LeakyMock.contains("foo"),
+                    LeakyMock.contains("bar")
+                )
+            )
+        ).andReturn("baz!").once()
+        EasyMock.expect(
+            mock.manipulateString(
+                LeakyMock.or(
+                    LeakyMock.contains("foo"),
+                    LeakyMock.contains("bar")
+                )
+            )
+        ).andReturn("bash!").times(2)
+        EasyMock.expect(mock.manipulateString(LeakyMock.not(LeakyMock.contains("foo")))).andReturn("bar!").once()
+        EasyMock.expect(mock.manipulateString(LeakyMock.find("\\d+"))).andReturn("nums!").once()
+        EasyMock.expect(mock.manipulateString(LeakyMock.matches("\\d+"))).andReturn("matchnums!").once()
+        EasyMock.expect(mock.manipulateString(LeakyMock.startsWtih("foo"))).andReturn("starts!").once()
+        EasyMock.expect(mock.manipulateString(LeakyMock.endsWith("foo"))).andReturn("ends!").once()
+        support.replayAll()
+        assertThat(mock.manipulateString("blee")).isEqualTo("bah!")
+        assertThat(mock.manipulateString("lalafoolala")).isEqualTo("bar!")
+        assertThat(mock.manipulateString("lalabarlalafoolala")).isEqualTo("baz!")
+        assertThat(mock.manipulateString("lalafoolala")).isEqualTo("bash!")
+        assertThat(mock.manipulateString("lalabarlala")).isEqualTo("bash!")
+        assertThat(mock.manipulateString("not_any_f_O_o")).isEqualTo("bar!")
+        assertThat(mock.manipulateString("numbers 123 are here")).isEqualTo("nums!")
+        assertThat(mock.manipulateString("123")).isEqualTo("matchnums!")
+        assertThat(mock.manipulateString("foolala")).isEqualTo("starts!")
+        assertThat(mock.manipulateString("lalalafoo")).isEqualTo("ends!")
+        support.verifyAll()
+    }
+
+    @Test
+    fun testMockAndObjectMatchers() {
+        val mock = LeakyMock.mock(TestClass::class.java)
+        val mockedThing = LeakyMock.mock<Thing>()
+        EasyMock.expect(mock.getThing()).andReturn(RealThing(1)).once()
+        EasyMock.expect(mock.manipulateThing(LeakyMock.anyObject(Thing::class.java))).andReturn(mockedThing).once()
+        EasyMock.expect(mock.processThing(LeakyMock.anyObject())).once()
+        EasyMock.expect(mock.processThing(LeakyMock.isA<RealThing>())).once()
+        EasyMock.expect(mock.processThing(LeakyMock.isA(RealThing::class.java))).once()
+        EasyMock.replay(mock, mockedThing)
+        assertThat(mock.getThing()).isEqualTo(RealThing(1))
+        assertThat(mock.manipulateThing(mockedThing)).isEqualTo(mockedThing)
+        assertThat { mock.processThing(mockedThing) }.isSuccess()
+        assertThat { mock.processThing(RealThing(2)) }.isSuccess()
+        assertThat { mock.processThing(RealThing(3)) }.isSuccess()
+        EasyMock.verify(mock, mockedThing)
+    }
+
+    @Test
+    fun testNiceMocks() {
+        val niceMock = LeakyMock.niceMock<TestClass>()
+        val otherNiceMock = LeakyMock.niceMock(TestClass::class.java)
+        EasyMock.expect(niceMock.getThing()).andReturn(RealThing(1)).once()
+        EasyMock.expect(otherNiceMock.getThing()).andReturn(RealThing(2)).once()
+        EasyMock.replay(niceMock, otherNiceMock)
+        assertThat(niceMock.getThing()).isEqualTo(RealThing(1))
+        assertThat(otherNiceMock.getThing()).isEqualTo(RealThing(2))
+        assertThat(niceMock.getThing()).isNull()
+        assertThat(otherNiceMock.getThing()).isNull()
+        EasyMock.verify(niceMock, otherNiceMock)
+    }
+
+    @Test
+    fun testCapture() {
+        val capture = EasyMock.newCapture<Thing>()
+        val mock = LeakyMock.mock("namedMock", TestClass::class.java)
+        EasyMock.expect(mock.manipulateThing(LeakyMock.capture(capture))).andReturn(RealThing(1))
+        EasyMock.replay(mock)
+        assertThat(mock.manipulateThing(RealThing(2))).isEqualTo(RealThing(1))
+        assertThat(capture.value).isEqualTo(RealThing(2))
+        EasyMock.verify(mock)
+    }
+
+    @Test
+    fun showNullProblems() {
+        val mock = LeakyMock.niceMock("namedNiceMock", TestClass::class.java)
+        assertThat {
+            EasyMock.expect(mock.manipulateThing(EasyMock.anyObject()))
+        }.isFailure().message().isNotNull().contains("EasyMock.anyObject() must not be null")
+        assertThat {
+            EasyMock.expect(mock.manipulateString(EasyMock.anyString()))
+        }.isFailure().message().isNotNull().contains("EasyMock.anyString() must not be null")
+    }
+}


### PR DESCRIPTION
Add support for mocking without having to type the class
name twice using inline functions.  Also add support for
mock argument matchers that return non-null values to
avoid issues with mocked arguments to methods that don't
accept null arguments; this bit is more fragile as it
only works for open/non-final classes, but can help avoid
some of the `anyObject() ?: defaultValue` blocks that
show up in tests.

Also configure surefire to print stack traces when tests fail.