### PR TITLE
Bump version.jetty from 9.4.19.v20190610 to 9.4.20.v20190813

### DIFF
--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -52,7 +52,7 @@
         <version.config4k>0.4.1</version.config4k>
         <version.detekt>1.0.1</version.detekt>
         <version.dokka>0.9.18</version.dokka>
-        <version.dropwizard>2.0.0-rc5</version.dropwizard>
+        <version.dropwizard>2.0.0-rc9</version.dropwizard>
         <version.dropwizard.hocon>0.5.1</version.dropwizard.hocon>
         <version.dropwizard.metrics>4.1.0</version.dropwizard.metrics>
         <version.dropwizard.metrics.guice>4.0.0</version.dropwizard.metrics.guice>
@@ -77,7 +77,7 @@
         <version.jaxrs>2.1.5</version.jaxrs>
         <version.jersey>2.29</version.jersey>
         <version.jetbrains.annotations>13.0</version.jetbrains.annotations>
-        <version.jetty>9.4.19.v20190610</version.jetty>
+        <version.jetty>9.4.20.v20190813</version.jetty>
         <version.jooq>3.11.12</version.jooq>
         <version.jsr305>3.0.2</version.jsr305>
         <version.kotlin>1.3.50</version.kotlin>


### PR DESCRIPTION
Bumps `version.jetty` from 9.4.19.v20190610 to 9.4.20.v20190813.
Bumps `version.dropwizard` from 2.0.0-rc5 to 2.0.0-rc9.

Updates `dropwizard` from 2.0.0-rc5 to 2.0.0-rc9
- [Release notes](https://github.com/dropwizard/dropwizard/releases)
- [Commits](https://github.com/dropwizard/dropwizard/compare/v2.0.0-rc5...v2.0.0-rc9)

Updates `jetty-servlets` from 9.4.19.v20190610 to 9.4.20.v20190813
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-9.4.19.v20190610...jetty-9.4.20.v20190813)

Updates `jetty-server` from 9.4.19.v20190610 to 9.4.20.v20190813
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-9.4.19.v20190610...jetty-9.4.20.v20190813)

Updates `websocket-api` from 9.4.19.v20190610 to 9.4.20.v20190813

Updates `websocket-common` from 9.4.19.v20190610 to 9.4.20.v20190813

Updates `websocket-client` from 9.4.19.v20190610 to 9.4.20.v20190813

Updates `websocket-server` from 9.4.19.v20190610 to 9.4.20.v20190813

Updates `websocket-servlet` from 9.4.19.v20190610 to 9.4.20.v20190813

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>