### PR TITLE
Add vararg for LeakyMock.and() and or()

### DIFF
--- a/graphql/src/test/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketTest.kt
@@ -137,10 +137,8 @@ class GraphQLWebSocketTest {
             mockRemote.sendString(
                 LeakyMock.and(
                     LeakyMock.contains(""""q" : [ "1", "2", "3" ]"""),
-                    LeakyMock.and(
-                        LeakyMock.contains(""""type" : "data""""),
-                        LeakyMock.contains(""""id" : "simplequery"""")
-                    )
+                    LeakyMock.contains(""""type" : "data""""),
+                    LeakyMock.contains(""""id" : "simplequery"""")
                 )
             )
         ).once()
@@ -171,10 +169,8 @@ class GraphQLWebSocketTest {
             mockRemote.sendString(
                 LeakyMock.and(
                     LeakyMock.contains(""""v" : [ "1", "2", "3" ]"""),
-                    LeakyMock.and(
-                        LeakyMock.contains(""""type" : "data""""),
-                        LeakyMock.contains(""""id" : "simplequery"""")
-                    )
+                    LeakyMock.contains(""""type" : "data""""),
+                    LeakyMock.contains(""""id" : "simplequery"""")
                 )
             )
         ).once()
@@ -259,10 +255,8 @@ class GraphQLWebSocketTest {
             mockRemote.sendString(
                 LeakyMock.and(
                     LeakyMock.contains(""""s" : "1""""),
-                    LeakyMock.and(
-                        LeakyMock.contains(""""type" : "data""""),
-                        LeakyMock.contains(""""id" : "simplesubscription"""")
-                    )
+                    LeakyMock.contains(""""type" : "data""""),
+                    LeakyMock.contains(""""id" : "simplesubscription"""")
                 )
             )
         ).once()
@@ -270,10 +264,8 @@ class GraphQLWebSocketTest {
             mockRemote.sendString(
                 LeakyMock.and(
                     LeakyMock.contains(""""s" : "2""""),
-                    LeakyMock.and(
-                        LeakyMock.contains(""""type" : "data""""),
-                        LeakyMock.contains(""""id" : "simplesubscription"""")
-                    )
+                    LeakyMock.contains(""""type" : "data""""),
+                    LeakyMock.contains(""""id" : "simplesubscription"""")
                 )
             )
         ).once()
@@ -281,10 +273,8 @@ class GraphQLWebSocketTest {
             mockRemote.sendString(
                 LeakyMock.and(
                     LeakyMock.contains(""""s" : "3""""),
-                    LeakyMock.and(
-                        LeakyMock.contains(""""type" : "data""""),
-                        LeakyMock.contains(""""id" : "simplesubscription"""")
-                    )
+                    LeakyMock.contains(""""type" : "data""""),
+                    LeakyMock.contains(""""id" : "simplesubscription"""")
                 )
             )
         ).once()
@@ -318,10 +308,8 @@ class GraphQLWebSocketTest {
             mockRemote.sendString(
                 LeakyMock.and(
                     LeakyMock.contains(""""e" : "1""""),
-                    LeakyMock.and(
-                        LeakyMock.contains(""""type" : "data""""),
-                        LeakyMock.contains(""""id" : "errorsubscription"""")
-                    )
+                    LeakyMock.contains(""""type" : "data""""),
+                    LeakyMock.contains(""""id" : "errorsubscription"""")
                 )
             )
         ).once()
@@ -329,10 +317,8 @@ class GraphQLWebSocketTest {
             mockRemote.sendString(
                 LeakyMock.and(
                     LeakyMock.contains(""""e" : "2""""),
-                    LeakyMock.and(
-                        LeakyMock.contains(""""type" : "data""""),
-                        LeakyMock.contains(""""id" : "errorsubscription"""")
-                    )
+                    LeakyMock.contains(""""type" : "data""""),
+                    LeakyMock.contains(""""id" : "errorsubscription"""")
                 )
             )
         ).once()
@@ -377,10 +363,8 @@ class GraphQLWebSocketTest {
             mockRemote.sendString(
                 LeakyMock.and(
                     LeakyMock.contains(""""type" : "error""""),
-                    LeakyMock.and(
-                        LeakyMock.contains(""""id" : "unconfiguredquery""""),
-                        LeakyMock.contains("not configured")
-                    )
+                    LeakyMock.contains(""""id" : "unconfiguredquery""""),
+                    LeakyMock.contains("not configured")
                 )
             )
         ).once()
@@ -388,10 +372,8 @@ class GraphQLWebSocketTest {
             mockRemote.sendString(
                 LeakyMock.and(
                     LeakyMock.contains(""""type" : "error""""),
-                    LeakyMock.and(
-                        LeakyMock.contains(""""id" : "invalidtype""""),
-                        LeakyMock.contains(""""payload" : "Unknown message type"""")
-                    )
+                    LeakyMock.contains(""""id" : "invalidtype""""),
+                    LeakyMock.contains(""""payload" : "Unknown message type"""")
                 )
             )
         ).once()
@@ -399,10 +381,8 @@ class GraphQLWebSocketTest {
             mockRemote.sendString(
                 LeakyMock.and(
                     LeakyMock.contains(""""type" : "error""""),
-                    LeakyMock.and(
-                        LeakyMock.contains(""""id" : "badpayload""""),
-                        LeakyMock.contains(""""payload" : "Invalid payload for query"""")
-                    )
+                    LeakyMock.contains(""""id" : "badpayload""""),
+                    LeakyMock.contains(""""payload" : "Invalid payload for query"""")
                 )
             )
         ).once()
@@ -473,10 +453,8 @@ class GraphQLWebSocketTest {
             mockRemote.sendString(
                 LeakyMock.and(
                     LeakyMock.contains(""""payload" : "Already connected!""""),
-                    LeakyMock.and(
-                        LeakyMock.contains(""""type" : "connection_error""""),
-                        LeakyMock.contains(""""id" : "connect2"""")
-                    )
+                    LeakyMock.contains(""""type" : "connection_error""""),
+                    LeakyMock.contains(""""id" : "connect2"""")
                 )
             )
         ).once()
@@ -540,10 +518,8 @@ class GraphQLWebSocketTest {
             mockRemote.sendString(
                 LeakyMock.and(
                     LeakyMock.contains(""""inf" : """"),
-                    LeakyMock.and(
-                        LeakyMock.contains(""""type" : "data""""),
-                        LeakyMock.contains(""""id" : "longsubscription"""")
-                    )
+                    LeakyMock.contains(""""type" : "data""""),
+                    LeakyMock.contains(""""id" : "longsubscription"""")
                 )
             )
         ).andAnswer { data.countDown() }.atLeastOnce() // notify that data has been sent
@@ -551,10 +527,8 @@ class GraphQLWebSocketTest {
             mockRemote.sendString(
                 LeakyMock.and(
                     LeakyMock.contains("""already running"""),
-                    LeakyMock.and(
-                        LeakyMock.contains(""""type" : "error""""),
-                        LeakyMock.contains(""""id" : "longsubscription"""")
-                    )
+                    LeakyMock.contains(""""type" : "error""""),
+                    LeakyMock.contains(""""id" : "longsubscription"""")
                 )
             )
         ).andAnswer { secondQueryErrored.countDown() }.once()

--- a/testing/src/main/kotlin/com/trib3/testing/LeakyMock.kt
+++ b/testing/src/main/kotlin/com/trib3/testing/LeakyMock.kt
@@ -3,6 +3,7 @@ package com.trib3.testing
 import org.easymock.Capture
 import org.easymock.EasyMock
 import org.easymock.EasyMockSupport
+import org.easymock.internal.LastControl
 
 /**
  * Extension function to add a `mock<T>()` method to [EasyMockSupport]
@@ -125,19 +126,21 @@ class LeakyMock {
         }
 
         /**
-         * Expect an object that matches both given expectations, and return the first one
+         * Expect an object that matches all given expectations, and return the first one
          */
-        fun <T> and(first: T, second: T): T {
-            EasyMock.and(first, second)
-            return first
+        fun <T> and(vararg args: T): T {
+            check(args.isNotEmpty()) { "Must pass at least one argument to LeakyMock.and()" }
+            LastControl.reportAnd(args.size)
+            return args.first()
         }
 
         /**
-         * Expect an object that matches either of the given expectations, and return the first one
+         * Expect an object that matches any of the given expectations, and return the first one
          */
-        fun <T> or(first: T, second: T): T {
-            EasyMock.or(first, second)
-            return first
+        fun <T> or(vararg args: T): T {
+            check(args.isNotEmpty()) { "Must pass at least one argument to LeakyMock.or()" }
+            LastControl.reportOr(args.size)
+            return args.first()
         }
 
         /**

--- a/testing/src/test/kotlin/com/trib3/testing/LeakyMockTest.kt
+++ b/testing/src/test/kotlin/com/trib3/testing/LeakyMockTest.kt
@@ -51,12 +51,30 @@ class LeakyMockTest {
         ).andReturn("baz!").once()
         EasyMock.expect(
             mock.manipulateString(
+                LeakyMock.and(
+                    LeakyMock.contains("foo"),
+                    LeakyMock.contains("bar"),
+                    LeakyMock.contains("baz")
+                )
+            )
+        ).andReturn("bazh!").once()
+        EasyMock.expect(
+            mock.manipulateString(
                 LeakyMock.or(
                     LeakyMock.contains("foo"),
                     LeakyMock.contains("bar")
                 )
             )
         ).andReturn("bash!").times(2)
+        EasyMock.expect(
+            mock.manipulateString(
+                LeakyMock.or(
+                    LeakyMock.contains("foo"),
+                    LeakyMock.contains("bar"),
+                    LeakyMock.contains("baz")
+                )
+            )
+        ).andReturn("bazh!!!").times(3)
         EasyMock.expect(mock.manipulateString(LeakyMock.not(LeakyMock.contains("foo")))).andReturn("bar!").once()
         EasyMock.expect(mock.manipulateString(LeakyMock.find("\\d+"))).andReturn("nums!").once()
         EasyMock.expect(mock.manipulateString(LeakyMock.matches("\\d+"))).andReturn("matchnums!").once()
@@ -66,8 +84,12 @@ class LeakyMockTest {
         assertThat(mock.manipulateString("blee")).isEqualTo("bah!")
         assertThat(mock.manipulateString("lalafoolala")).isEqualTo("bar!")
         assertThat(mock.manipulateString("lalabarlalafoolala")).isEqualTo("baz!")
+        assertThat(mock.manipulateString("lbazalabarlalafoolala")).isEqualTo("bazh!")
         assertThat(mock.manipulateString("lalafoolala")).isEqualTo("bash!")
         assertThat(mock.manipulateString("lalabarlala")).isEqualTo("bash!")
+        assertThat(mock.manipulateString("lalafoolala")).isEqualTo("bazh!!!")
+        assertThat(mock.manipulateString("lalabarlala")).isEqualTo("bazh!!!")
+        assertThat(mock.manipulateString("lalabazlala")).isEqualTo("bazh!!!")
         assertThat(mock.manipulateString("not_any_f_O_o")).isEqualTo("bar!")
         assertThat(mock.manipulateString("numbers 123 are here")).isEqualTo("nums!")
         assertThat(mock.manipulateString("123")).isEqualTo("matchnums!")
@@ -128,5 +150,15 @@ class LeakyMockTest {
         assertThat {
             EasyMock.expect(mock.manipulateString(EasyMock.anyString()))
         }.isFailure().message().isNotNull().contains("EasyMock.anyString() must not be null")
+    }
+
+    @Test
+    fun testInvalidAndOr() {
+        assertThat {
+            LeakyMock.and<Boolean>()
+        }.isFailure().message().isNotNull().contains("at least one argument")
+        assertThat {
+            LeakyMock.or<Boolean>()
+        }.isFailure().message().isNotNull().contains("at least one argument")
     }
 }


### PR DESCRIPTION
Instead of requiring nested calls to and/or together
more than two expectations, use varargs to allow
for a call with multiple expectations at once.

(see GraphQLWebSocketTest for usage changes)