### PR TITLE
Cleanup GraphQL coroutines implementation

### DIFF
--- a/build-resources/pom.xml
+++ b/build-resources/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.trib3</groupId>
     <artifactId>build-resources</artifactId>
-    <version>1.5-SNAPSHOT</version>
+    <version>1.6-SNAPSHOT</version>
 
     <name>Build Resources</name>
     <description>Resources for use during the build process</description>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.5-SNAPSHOT</version>
+        <version>1.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.5-SNAPSHOT</version>
+        <version>1.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/graphql/pom.xml
+++ b/graphql/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.5-SNAPSHOT</version>
+        <version>1.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -52,10 +52,6 @@
         <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
         </dependency>
 
         <!-- graphql -->

--- a/graphql/src/main/kotlin/com/trib3/graphql/modules/DefaultGraphQLModule.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/modules/DefaultGraphQLModule.kt
@@ -59,29 +59,25 @@ class DefaultGraphQLModule : GraphQLApplicationModule() {
         @Named(GRAPHQL_SUBSCRIPTIONS_BIND_NAME)
         subscriptions: Set<@JvmSuppressWildcards Any>,
         mapper: ObjectMapper
-    ): GraphQL? {
+    ): GraphQL {
         val hooks = DateTimeHooks()
         val config = SchemaGeneratorConfig(
             graphQLPackages.toList(),
             hooks = hooks,
             dataFetcherFactoryProvider = ObjectMapperKotlinDataFetcherFactoryProvider(mapper, hooks)
         )
-        return if (queries.isNotEmpty()) {
-            GraphQL.newGraphQL(
-                toSchema(
-                    config,
-                    queries.toList().map { TopLevelObject(it) },
-                    mutations.toList().map { TopLevelObject(it) },
-                    subscriptions.toList().map { TopLevelObject(it) }
-                )
+        return GraphQL.newGraphQL(
+            toSchema(
+                config,
+                queries.toList().map { TopLevelObject(it) },
+                mutations.toList().map { TopLevelObject(it) },
+                subscriptions.toList().map { TopLevelObject(it) }
             )
-                .queryExecutionStrategy(AsyncExecutionStrategy(CustomDataFetcherExceptionHandler()))
-                .subscriptionExecutionStrategy(SubscriptionExecutionStrategy(CustomDataFetcherExceptionHandler()))
-                .instrumentation(RequestIdInstrumentation())
-                .build()
-        } else {
-            null
-        }
+        )
+            .queryExecutionStrategy(AsyncExecutionStrategy(CustomDataFetcherExceptionHandler()))
+            .subscriptionExecutionStrategy(SubscriptionExecutionStrategy(CustomDataFetcherExceptionHandler()))
+            .instrumentation(RequestIdInstrumentation())
+            .build()
     }
 
     // allow multiple installations so that multiple other modules can install this one

--- a/graphql/src/main/kotlin/com/trib3/graphql/resources/GraphQLResource.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/resources/GraphQLResource.kt
@@ -7,7 +7,6 @@ import graphql.GraphQL
 import org.eclipse.jetty.http.HttpStatus
 import org.eclipse.jetty.websocket.server.WebSocketServerFactory
 import org.eclipse.jetty.websocket.servlet.WebSocketCreator
-import javax.annotation.Nullable
 import javax.inject.Inject
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
@@ -27,7 +26,7 @@ import javax.ws.rs.core.Response
 @Produces(MediaType.APPLICATION_JSON)
 open class GraphQLResource
 @Inject constructor(
-    @Nullable private val graphQL: GraphQL?,
+    private val graphQL: GraphQL,
     creator: WebSocketCreator
 ) {
     private val webSocketFactory = WebSocketServerFactory().apply {
@@ -42,9 +41,6 @@ open class GraphQLResource
     @Path("/graphql")
     @Timed
     open fun graphQL(query: GraphQLRequest): Response {
-        check(graphQL != null) {
-            "graphQL not configured!"
-        }
         val result = graphQL.execute(
             ExecutionInput.newExecutionInput()
                 .query(query.query)

--- a/graphql/src/main/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketCreator.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketCreator.kt
@@ -3,12 +3,11 @@ package com.trib3.graphql.websocket
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.trib3.graphql.GraphQLConfig
 import graphql.GraphQL
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
 import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest
 import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse
 import org.eclipse.jetty.websocket.servlet.WebSocketCreator
-import javax.annotation.Nullable
 import javax.inject.Inject
 
 /**
@@ -17,7 +16,7 @@ import javax.inject.Inject
  */
 class GraphQLWebSocketCreator
 @Inject constructor(
-    @Nullable val graphQL: GraphQL?,
+    val graphQL: GraphQL,
     val objectMapper: ObjectMapper,
     val graphQLConfig: GraphQLConfig
 ) : WebSocketCreator {
@@ -29,8 +28,10 @@ class GraphQLWebSocketCreator
         resp.acceptedSubProtocol = graphQLConfig.webSocketSubProtocol
         val channel = Channel<OperationMessage<*>>()
         val adapter = GraphQLWebSocketAdapter(channel, objectMapper)
-        val consumer = GraphQLWebSocketConsumer(graphQL, graphQLConfig, channel, adapter, Dispatchers.IO)
-        consumer.launchConsumer()
+        val consumer = GraphQLWebSocketConsumer(graphQL, graphQLConfig, channel, adapter)
+        adapter.launch {
+            consumer.consume(this)
+        }
         return adapter
     }
 }

--- a/graphql/src/test/kotlin/com/trib3/graphql/resources/GraphQLResourceTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/resources/GraphQLResourceTest.kt
@@ -5,10 +5,7 @@ import assertk.assertions.contains
 import assertk.assertions.doesNotContain
 import assertk.assertions.hasRootCause
 import assertk.assertions.isEqualTo
-import assertk.assertions.isFailure
 import assertk.assertions.isInstanceOf
-import assertk.assertions.isNotNull
-import assertk.assertions.message
 import assertk.assertions.prop
 import com.coxautodev.graphql.tools.GraphQLQueryResolver
 import com.expediagroup.graphql.SchemaGeneratorConfig
@@ -60,13 +57,6 @@ class GraphQLResourceTest {
             WebSocketCreator { _, _ -> null }
         )
     val objectMapper = ObjectMapperProvider().get()
-    @Test
-    fun testNotConfigured() {
-        val notConfiguredResource = GraphQLResource(null, WebSocketCreator { _, _ -> null })
-        assertThat {
-            notConfiguredResource.graphQL(GraphQLRequest("", null, null))
-        }.isFailure().message().isNotNull().contains("not configured")
-    }
 
     @Test
     fun testSimpleQuery() {

--- a/graphql/src/test/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketAdapterTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketAdapterTest.kt
@@ -1,0 +1,224 @@
+package com.trib3.graphql.websocket
+
+import assertk.assertThat
+import assertk.assertions.isFalse
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import com.codahale.metrics.annotation.Timed
+import com.trib3.json.ObjectMapperProvider
+import com.trib3.testing.server.JettyWebTestContainerFactory
+import com.trib3.testing.server.ResourceTestBase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import mu.KotlinLogging
+import org.eclipse.jetty.http.HttpStatus
+import org.eclipse.jetty.websocket.api.CloseException
+import org.eclipse.jetty.websocket.api.WebSocketAdapter
+import org.eclipse.jetty.websocket.client.WebSocketClient
+import org.eclipse.jetty.websocket.server.WebSocketServerFactory
+import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest
+import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse
+import org.eclipse.jetty.websocket.servlet.WebSocketCreator
+import org.glassfish.jersey.test.spi.TestContainerFactory
+import org.testng.annotations.Test
+import java.util.concurrent.ConcurrentHashMap
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+import javax.ws.rs.GET
+import javax.ws.rs.Path
+import javax.ws.rs.core.Context
+import javax.ws.rs.core.Response
+
+private val mapper = ObjectMapperProvider().get()
+private val log = KotlinLogging.logger {}
+
+/**
+ * Tests that the [GraphQLWebSocketAdapter] properly shuts down any coroutines
+ * launched via its scope when the websocket closes and/or errors
+ */
+class GraphQLWebSocketAdapterTest : ResourceTestBase<SimpleWebSocketResource>() {
+    val rawResource = SimpleWebSocketResource()
+
+    override fun getResource(): SimpleWebSocketResource {
+        return rawResource
+    }
+
+    override fun getContainerFactory(): TestContainerFactory {
+        return JettyWebTestContainerFactory()
+    }
+
+    /**
+     * Tests that a websocket client can start a child coroutine, have the session
+     * error due to idle timeout, and the main and child coroutines both get cancelled
+     */
+    @Test
+    fun testTimeout() = runBlocking {
+        val client = WebSocketClient()
+        client.start()
+        val session = client.connect(
+            WebSocketAdapter(),
+            resource.target("/websocket").uriBuilder.scheme("ws").queryParam("name", "timeout").build()
+        ).get()
+        session.remote.sendString(
+            mapper.writeValueAsString(
+                OperationMessage(
+                    OperationType.GQL_START,
+                    "launch",
+                    null
+                )
+            )
+        )
+        Thread.sleep(1100) // sleep for longer than the timeout to make sure we get an exception
+        val job = getResource().webSocketCreator.coroutines["name=timeout"]!!
+        val childJob = getResource().webSocketCreator.coroutines["name=timeoutchild"]!!
+        job.join()
+        val potentialError = getResource().webSocketCreator.errors["name=timeout"]!!
+        assertThat(potentialError).isNotNull().isInstanceOf(CloseException::class)
+        for (j in listOf(job, childJob)) {
+            assertThat(j.isActive).isFalse()
+            assertThat(j.isCancelled).isTrue()
+            assertThat(j.isCompleted).isTrue()
+        }
+    }
+
+    /**
+     * Tests that a websocket client can start a child coroutine, disconnect
+     * the session, and the main and child coroutines both get cancelled
+     */
+    @Test
+    fun testClientSendsMessageAndDisconnects() = runBlocking {
+        val client = WebSocketClient()
+        client.start()
+        val session = client.connect(
+            WebSocketAdapter(),
+            resource.target("/websocket").uriBuilder.scheme("ws").queryParam("name", "clientClose").build()
+        ).get()
+        session.remote.sendString(mapper.writeValueAsString(OperationMessage(OperationType.GQL_START, "launch", null)))
+        var maybeJob = getResource().webSocketCreator.coroutines["name=clientClosechild"]
+        // ensure the start message gets processed and starts a child
+        while (maybeJob == null) {
+            delay(10)
+            maybeJob = getResource().webSocketCreator.coroutines["name=clientClosechild"]
+        }
+        session.disconnect()
+        val job = getResource().webSocketCreator.coroutines["name=clientClose"]!!
+        val childJob = getResource().webSocketCreator.coroutines["name=clientClosechild"]!!
+        job.join()
+        assertThat(getResource().webSocketCreator.errors["name=clientClose"]).isNull()
+        for (j in listOf(job, childJob)) {
+            assertThat(j.isActive).isFalse()
+            assertThat(j.isCancelled).isTrue()
+            assertThat(j.isCompleted).isTrue()
+        }
+    }
+
+    /**
+     * Tests that a websocket client can start a child coroutine, have the session
+     * last longer than the idle timeout, and the main and child coroutines both get
+     * cancelled when the client closes the session.
+     */
+    @Test
+    fun testClientSendsMessagesAndCloses() = runBlocking {
+        val client = WebSocketClient()
+        client.start()
+        val session = client.connect(
+            WebSocketAdapter(),
+            resource.target("/websocket").uriBuilder.scheme("ws").queryParam("name", "spin").build()
+        ).get()
+        session.remote.sendString(mapper.writeValueAsString(OperationMessage(OperationType.GQL_START, "launch", null)))
+        GlobalScope.launch(Dispatchers.IO) {
+            for (i in 0..19) {
+                delay(100)
+                log.info("SPIN: $i: $coroutineContext")
+                session.remote.sendString(
+                    mapper.writeValueAsString(
+                        OperationMessage(
+                            OperationType.GQL_START,
+                            "ping",
+                            null
+                        )
+                    )
+                )
+            }
+            session.close()
+        }.join()
+        val job = getResource().webSocketCreator.coroutines["name=spin"]!!
+        val childJob = getResource().webSocketCreator.coroutines["name=spinchild"]!!
+        job.join()
+        assertThat(getResource().webSocketCreator.errors["name=clientClose"]).isNull()
+        for (j in listOf(job, childJob)) {
+            assertThat(j.isActive).isFalse()
+            assertThat(j.isCancelled).isTrue()
+            assertThat(j.isCompleted).isTrue()
+        }
+    }
+}
+
+/**
+ * [WebSocketCreator] implementation that launches coroutines to
+ * process messages from a [GraphQLWebSocketAdapter], and tracks
+ * the coroutines and any errors that happen on the session.
+ */
+class SessionTrackingCreator : WebSocketCreator {
+    val coroutines = ConcurrentHashMap<String, Job>()
+    val errors = ConcurrentHashMap<String, Throwable>()
+    override fun createWebSocket(req: ServletUpgradeRequest, resp: ServletUpgradeResponse): Any {
+        val channel = Channel<OperationMessage<*>>()
+        val adapter = object : GraphQLWebSocketAdapter(channel, mapper) {
+            override fun onWebSocketError(cause: Throwable) {
+                errors[req.queryString] = cause
+                super.onWebSocketError(cause)
+            }
+        }
+        coroutines[req.queryString] = adapter.launch {
+            for (msg in channel) {
+                if (msg.id == "launch") {
+                    coroutines["${req.queryString}child"] = launch {
+                        while (true) {
+                            delay(100)
+                            log.info("CHILD: ${req.queryString}: ping: $coroutineContext")
+                        }
+                    }
+                } else {
+                    log.info("PARENT: ${req.queryString}: pong: ${msg.id}: $coroutineContext")
+                }
+            }
+            log.info("DONE: ${req.queryString}: $coroutineContext")
+        }
+        return adapter
+    }
+}
+
+/**
+ * Resource that does a websocket upgrade with an idle timeout of 1 second on the socket
+ */
+@Path("/")
+class SimpleWebSocketResource {
+
+    val webSocketCreator = SessionTrackingCreator()
+
+    private val webSocketFactory = WebSocketServerFactory().apply {
+        this.policy.idleTimeout = 1000 // timeout after 1 second to cause a WebSocketError
+        this.creator = webSocketCreator
+        this.start()
+    }
+
+    @GET
+    @Path("/websocket")
+    @Timed
+    fun webSocketUpgrade(@Context request: HttpServletRequest, @Context response: HttpServletResponse): Response {
+        if (webSocketFactory.isUpgradeRequest(request, response)) {
+            if (webSocketFactory.acceptWebSocket(request, response)) {
+                return Response.status(HttpStatus.SWITCHING_PROTOCOLS_101).build()
+            }
+        }
+        return Response.status(HttpStatus.METHOD_NOT_ALLOWED_405).build()
+    }
+}

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.5-SNAPSHOT</version>
+        <version>1.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/lambda/pom.xml
+++ b/lambda/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.5-SNAPSHOT</version>
+        <version>1.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.trib3</groupId>
     <artifactId>parent-pom</artifactId>
-    <version>1.5-SNAPSHOT</version>
+    <version>1.6-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Trib3 parent pom</name>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>1.5-SNAPSHOT</version>
+        <version>1.6-SNAPSHOT</version>
         <relativePath>parent-pom/pom.xml</relativePath>
     </parent>
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.5-SNAPSHOT</version>
+        <version>1.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.5-SNAPSHOT</version>
+        <version>1.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Instead of using GlobalScope, have the WebSocketAdapter
implement CoroutineScope and use that to control the
coroutines' lifecycles.  Separate out child coroutines
into their own classes that can only access the channel
and not the websocket for safety.  Also make the injected
graphQL instance non-nullable, as now that graphql is a
separate module services that don't want graphQL will
just not install the module.  Bump version to 1.6.x.