### PR TITLE
Add Frequently Used HikariCP options to DbConfig

### DIFF
--- a/db/src/main/kotlin/com/trib3/db/config/DbConfig.kt
+++ b/db/src/main/kotlin/com/trib3/db/config/DbConfig.kt
@@ -35,6 +35,12 @@ class DbConfig
         val username = config.extract("user") ?: "tribe"
         val password = config.extract<String?>("password")
         val autoCommit = config.extract("autocommit") ?: false
+        val connectionTimeout = config.extract<Long?>("connectionTimeout")
+        val idleTimeout = config.extract<Long?>("idleTimeout")
+        val maxLifetime = config.extract<Long?>("maxLifetime")
+        val connectionTestQuery = config.extract<String?>("connectionTestQuery")
+        val minimumIdle = config.extract<Int?>("minimumIdle")
+        val maximumPoolSize = config.extract<Int?>("maximumPoolSize")
 
         val hds = HikariDataSource()
         hds.poolName = configPath
@@ -45,6 +51,24 @@ class DbConfig
         hds.healthCheckRegistry = healthCheckRegistry
         hds.metricRegistry = metricRegistry
         hds.isAutoCommit = autoCommit
+        if (connectionTimeout != null) {
+            hds.connectionTimeout = connectionTimeout
+        }
+        if (idleTimeout != null) {
+            hds.idleTimeout = idleTimeout
+        }
+        if (maxLifetime != null) {
+            hds.maxLifetime = maxLifetime
+        }
+        if (connectionTestQuery != null) {
+            hds.connectionTestQuery = connectionTestQuery
+        }
+        if (minimumIdle != null) {
+            hds.minimumIdle = minimumIdle
+        }
+        if (maximumPoolSize != null) {
+            hds.maximumPoolSize = maximumPoolSize
+        }
 
         dataSource = hds
 

--- a/db/src/test/kotlin/com/trib3/db/modules/DbModuleTest.kt
+++ b/db/src/test/kotlin/com/trib3/db/modules/DbModuleTest.kt
@@ -42,6 +42,13 @@ class DbModuleTest
         assertThat(dataSource.healthCheckRegistry).isNotNull()
         assertThat(dataSource.metricRegistry).isNotNull()
         assertThat(dataSource.isAutoCommit).isFalse()
+        // these settings are set in config to be slightly different than hikariCP defaults
+        assertThat(dataSource.connectionTimeout).isEqualTo(30001)
+        assertThat(dataSource.idleTimeout).isEqualTo(600001)
+        assertThat(dataSource.maxLifetime).isEqualTo(1800001)
+        assertThat(dataSource.connectionTestQuery).isEqualTo("select 1")
+        assertThat(dataSource.minimumIdle).isEqualTo(11)
+        assertThat(dataSource.maximumPoolSize).isEqualTo(11)
     }
 
     @Test

--- a/db/src/test/resources/application.conf
+++ b/db/src/test/resources/application.conf
@@ -5,3 +5,13 @@ test {
 test2 {
   host: test2
 }
+
+db {
+  // configure these slightly different than hikariCP defaults
+  connectionTimeout: 30001
+  idleTimeout: 600001
+  maxLifetime: 1800001
+  connectionTestQuery: "select 1"
+  minimumIdle: 11
+  maximumPoolSize: 11
+}


### PR DESCRIPTION
Add the frequently used options from
https://github.com/brettwooldridge/HikariCP/#frequently-used
to DbConfig so that they can be set by application config