### PR TITLE
Ensure RequestId comes back on subsription data events

### DIFF
--- a/graphql/src/main/kotlin/com/trib3/graphql/execution/CustomDataFetcherExceptionHandler.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/execution/CustomDataFetcherExceptionHandler.kt
@@ -19,7 +19,7 @@ class CustomDataFetcherExceptionHandler : DataFetcherExceptionHandler {
         val sourceLocation = handlerParameters.sourceLocation
         val path = handlerParameters.path
         val error: GraphQLError = SanitizedGraphQLError(path, exception, sourceLocation)
-        log.warn(error.message, exception)
+        log.error("Error in data fetching: ${error.message}", exception)
         return DataFetcherExceptionHandlerResult.newResult().error(error).build()
     }
 }

--- a/graphql/src/test/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketTest.kt
@@ -259,7 +259,8 @@ class GraphQLWebSocketTest {
                 LeakyMock.and(
                     LeakyMock.contains(""""s" : "1""""),
                     LeakyMock.contains(""""type" : "data""""),
-                    LeakyMock.contains(""""id" : "simplesubscription"""")
+                    LeakyMock.contains(""""id" : "simplesubscription""""),
+                    LeakyMock.contains(""""RequestId" : "simplesubscription"""")
                 )
             )
         ).once()
@@ -268,7 +269,8 @@ class GraphQLWebSocketTest {
                 LeakyMock.and(
                     LeakyMock.contains(""""s" : "2""""),
                     LeakyMock.contains(""""type" : "data""""),
-                    LeakyMock.contains(""""id" : "simplesubscription"""")
+                    LeakyMock.contains(""""id" : "simplesubscription""""),
+                    LeakyMock.contains(""""RequestId" : "simplesubscription"""")
                 )
             )
         ).once()
@@ -277,7 +279,8 @@ class GraphQLWebSocketTest {
                 LeakyMock.and(
                     LeakyMock.contains(""""s" : "3""""),
                     LeakyMock.contains(""""type" : "data""""),
-                    LeakyMock.contains(""""id" : "simplesubscription"""")
+                    LeakyMock.contains(""""id" : "simplesubscription""""),
+                    LeakyMock.contains(""""RequestId" : "simplesubscription"""")
                 )
             )
         ).once()


### PR DESCRIPTION
Subscription data events were missing the requestId extension
that we install.  Manually add them in to ensure we can trace
execution more easily.

https://trello.com/c/DHzkp35u