### PR TITLE
Allow configuration of websocket policy items

### DIFF
--- a/build-resources/pom.xml
+++ b/build-resources/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.trib3</groupId>
     <artifactId>build-resources</artifactId>
-    <version>1.6-SNAPSHOT</version>
+    <version>1.7-SNAPSHOT</version>
 
     <name>Build Resources</name>
     <description>Resources for use during the build process</description>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.6-SNAPSHOT</version>
+        <version>1.7-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/config/src/test/kotlin/com/trib3/config/ConfigLoaderTest.kt
+++ b/config/src/test/kotlin/com/trib3/config/ConfigLoaderTest.kt
@@ -8,7 +8,7 @@ import com.typesafe.config.ConfigFactory
 import org.testng.annotations.Test
 
 class ConfigLoaderTest {
-    val loader = ConfigLoader(KMSStringSelectReader(null))
+    val loader = ConfigLoader()
 
     @Test
     fun testDefaultLoad() {
@@ -53,6 +53,15 @@ class ConfigLoaderTest {
         assertThat(env).isEqualTo("test")
         assertThat(testval).isEqualTo("override")
         assertThat(devtest).isNull()
+        assertThat(overridefinal).isEqualTo("zzz")
+    }
+
+    @Test
+    fun testDefaultPathOverrideLoad() {
+        val config = ConfigLoader("test").load()
+        val testval = config.extract<String?>("testval")
+        val overridefinal = config.extract<String?>("final")
+        assertThat(testval).isEqualTo("override")
         assertThat(overridefinal).isEqualTo("zzz")
     }
 

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.6-SNAPSHOT</version>
+        <version>1.7-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/graphql/pom.xml
+++ b/graphql/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.6-SNAPSHOT</version>
+        <version>1.7-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/graphql/src/main/kotlin/com/trib3/graphql/GraphQLConfig.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/GraphQLConfig.kt
@@ -8,10 +8,18 @@ class GraphQLConfig
 @Inject constructor(loader: ConfigLoader) {
     val keepAliveIntervalSeconds: Long
     val webSocketSubProtocol: String
+    val asyncWriteTimeout: Long?
+    val idleTimeout: Long?
+    val maxBinaryMessageSize: Int?
+    val maxTextMessageSize: Int?
 
     init {
-        val config = loader.load()
-        keepAliveIntervalSeconds = config.extract("graphQL.keepAliveIntervalSeconds")
-        webSocketSubProtocol = config.extract("graphQL.webSocketSubProtocol")
+        val config = loader.load("graphQL")
+        keepAliveIntervalSeconds = config.extract("keepAliveIntervalSeconds")
+        webSocketSubProtocol = config.extract("webSocketSubProtocol")
+        asyncWriteTimeout = config.extract("asyncWriteTimeout")
+        idleTimeout = config.extract("idleTimeout")
+        maxBinaryMessageSize = config.extract("maxBinaryMessageSize")
+        maxTextMessageSize = config.extract("maxTextMessageSize")
     }
 }

--- a/graphql/src/main/kotlin/com/trib3/graphql/resources/GraphQLResource.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/resources/GraphQLResource.kt
@@ -1,6 +1,7 @@
 package com.trib3.graphql.resources
 
 import com.codahale.metrics.annotation.Timed
+import com.trib3.graphql.GraphQLConfig
 import com.trib3.graphql.execution.GraphQLRequest
 import graphql.ExecutionInput
 import graphql.GraphQL
@@ -27,10 +28,23 @@ import javax.ws.rs.core.Response
 open class GraphQLResource
 @Inject constructor(
     private val graphQL: GraphQL,
+    private val graphQLConfig: GraphQLConfig,
     creator: WebSocketCreator
 ) {
-    private val webSocketFactory = WebSocketServerFactory().apply {
+    internal val webSocketFactory = WebSocketServerFactory().apply {
         this.creator = creator
+        if (graphQLConfig.asyncWriteTimeout != null) {
+            this.policy.asyncWriteTimeout = graphQLConfig.asyncWriteTimeout
+        }
+        if (graphQLConfig.idleTimeout != null) {
+            this.policy.idleTimeout = graphQLConfig.idleTimeout
+        }
+        if (graphQLConfig.maxBinaryMessageSize != null) {
+            this.policy.maxBinaryMessageSize = graphQLConfig.maxBinaryMessageSize
+        }
+        if (graphQLConfig.maxTextMessageSize != null) {
+            this.policy.maxTextMessageSize = graphQLConfig.maxTextMessageSize
+        }
         this.start()
     }
 

--- a/graphql/src/test/kotlin/com/trib3/graphql/GraphQLConfigTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/GraphQLConfigTest.kt
@@ -2,8 +2,8 @@ package com.trib3.graphql
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
 import com.trib3.config.ConfigLoader
-import com.trib3.config.KMSStringSelectReader
 import org.testng.annotations.Test
 
 class GraphQLConfigTest {
@@ -13,8 +13,16 @@ class GraphQLConfigTest {
 
     @Test
     fun testConfig() {
-        val config = GraphQLConfig(ConfigLoader(KMSStringSelectReader(null)))
+        val config = GraphQLConfig(ConfigLoader())
         assertThat(config.keepAliveIntervalSeconds).isEqualTo(DEFAULT_KEEPALIVE)
         assertThat(config.webSocketSubProtocol).isEqualTo("graphql-ws")
+        for (i in listOf(
+            config.asyncWriteTimeout,
+            config.idleTimeout,
+            config.maxBinaryMessageSize,
+            config.maxTextMessageSize
+        )) {
+            assertThat(i).isNull()
+        }
     }
 }

--- a/graphql/src/test/kotlin/com/trib3/graphql/resources/GraphQLResourceTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/resources/GraphQLResourceTest.kt
@@ -12,6 +12,8 @@ import com.expediagroup.graphql.SchemaGeneratorConfig
 import com.expediagroup.graphql.TopLevelObject
 import com.expediagroup.graphql.toSchema
 import com.fasterxml.jackson.module.kotlin.readValue
+import com.trib3.config.ConfigLoader
+import com.trib3.graphql.GraphQLConfig
 import com.trib3.graphql.execution.CustomDataFetcherExceptionHandler
 import com.trib3.graphql.execution.GraphQLRequest
 import com.trib3.graphql.execution.RequestIdInstrumentation
@@ -54,9 +56,18 @@ class GraphQLResourceTest {
                 .queryExecutionStrategy(AsyncExecutionStrategy(CustomDataFetcherExceptionHandler()))
                 .instrumentation(RequestIdInstrumentation())
                 .build(),
+            GraphQLConfig(ConfigLoader("GraphQLResourceTest")),
             WebSocketCreator { _, _ -> null }
         )
     val objectMapper = ObjectMapperProvider().get()
+
+    @Test
+    fun testPolicy() {
+        assertThat(resource.webSocketFactory.policy.asyncWriteTimeout).isEqualTo(100000)
+        assertThat(resource.webSocketFactory.policy.idleTimeout).isEqualTo(200000)
+        assertThat(resource.webSocketFactory.policy.maxBinaryMessageSize).isEqualTo(300000)
+        assertThat(resource.webSocketFactory.policy.maxTextMessageSize).isEqualTo(400000)
+    }
 
     @Test
     fun testSimpleQuery() {

--- a/graphql/src/test/kotlin/com/trib3/graphql/resources/GraphQLUpgradeResourceTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/resources/GraphQLUpgradeResourceTest.kt
@@ -5,6 +5,8 @@ import assertk.assertions.isEqualTo
 import com.expediagroup.graphql.SchemaGeneratorConfig
 import com.expediagroup.graphql.TopLevelObject
 import com.expediagroup.graphql.toSchema
+import com.trib3.config.ConfigLoader
+import com.trib3.graphql.GraphQLConfig
 import com.trib3.graphql.execution.CustomDataFetcherExceptionHandler
 import com.trib3.graphql.execution.RequestIdInstrumentation
 import com.trib3.testing.server.JettyWebTestContainerFactory
@@ -47,6 +49,7 @@ class GraphQLUpgradeResourceTest : ResourceTestBase<GraphQLResource>() {
     val rawResource =
         GraphQLResource(
             graphQL,
+            GraphQLConfig(ConfigLoader()),
             WebSocketCreator { request, _ ->
                 if (request.queryString != null && request.queryString.contains("fail")) {
                     null

--- a/graphql/src/test/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketCreatorTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketCreatorTest.kt
@@ -6,7 +6,6 @@ import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotNull
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.trib3.config.ConfigLoader
-import com.trib3.config.KMSStringSelectReader
 import com.trib3.graphql.GraphQLConfig
 import com.trib3.graphql.GraphQLConfigTest
 import com.trib3.testing.LeakyMock
@@ -21,7 +20,7 @@ class GraphQLWebSocketCreatorTest {
     fun testSocketCreation() {
         val graphQL = LeakyMock.mock<GraphQL>()
         val mapper = ObjectMapper()
-        val creator = GraphQLWebSocketCreator(graphQL, mapper, GraphQLConfig(ConfigLoader(KMSStringSelectReader(null))))
+        val creator = GraphQLWebSocketCreator(graphQL, mapper, GraphQLConfig(ConfigLoader()))
         assertThat(creator.graphQL).isEqualTo(graphQL)
         assertThat(creator.objectMapper).isEqualTo(mapper)
         assertThat(creator.graphQLConfig.keepAliveIntervalSeconds).isEqualTo(GraphQLConfigTest.DEFAULT_KEEPALIVE)

--- a/graphql/src/test/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketTest.kt
@@ -11,7 +11,6 @@ import com.expediagroup.graphql.SchemaGeneratorConfig
 import com.expediagroup.graphql.TopLevelObject
 import com.expediagroup.graphql.toSchema
 import com.trib3.config.ConfigLoader
-import com.trib3.config.KMSStringSelectReader
 import com.trib3.graphql.GraphQLConfig
 import com.trib3.json.ObjectMapperProvider
 import com.trib3.testing.LeakyMock
@@ -103,7 +102,7 @@ class GraphQLWebSocketTest {
         )
     ).build()
     val mapper = ObjectMapperProvider().get()
-    val config = GraphQLConfig(ConfigLoader(KMSStringSelectReader(null)))
+    val config = GraphQLConfig(ConfigLoader())
 
     /**
      * get a socket configured with the test graphQL and object mapper

--- a/graphql/src/test/resources/application.conf
+++ b/graphql/src/test/resources/application.conf
@@ -1,0 +1,8 @@
+GraphQLResourceTest {
+    graphQL {
+        asyncWriteTimeout: 100000
+        idleTimeout: 200000
+        maxBinaryMessageSize: 300000
+        maxTextMessageSize: 400000
+    }
+}

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.6-SNAPSHOT</version>
+        <version>1.7-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/lambda/pom.xml
+++ b/lambda/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.6-SNAPSHOT</version>
+        <version>1.7-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.trib3</groupId>
     <artifactId>parent-pom</artifactId>
-    <version>1.6-SNAPSHOT</version>
+    <version>1.7-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Trib3 parent pom</name>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>1.6-SNAPSHOT</version>
+        <version>1.7-SNAPSHOT</version>
         <relativePath>parent-pom/pom.xml</relativePath>
     </parent>
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.6-SNAPSHOT</version>
+        <version>1.7-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/server/src/main/kotlin/com/trib3/server/config/BootstrapConfig.kt
+++ b/server/src/main/kotlin/com/trib3/server/config/BootstrapConfig.kt
@@ -5,7 +5,6 @@ import com.google.inject.AbstractModule
 import com.google.inject.Guice
 import com.google.inject.Injector
 import com.trib3.config.ConfigLoader
-import com.trib3.config.KMSStringSelectReader
 import com.trib3.config.extract
 import io.dropwizard.logging.BootstrapLogging
 
@@ -18,7 +17,7 @@ class BootstrapConfig {
     val appModules: List<String>
 
     init {
-        val config = ConfigLoader(KMSStringSelectReader(null)).load()
+        val config = ConfigLoader().load()
         appModules = config.extract("application.modules")
     }
 

--- a/server/src/test/kotlin/com/trib3/server/config/TribeApplicationConfigTest.kt
+++ b/server/src/test/kotlin/com/trib3/server/config/TribeApplicationConfigTest.kt
@@ -3,13 +3,12 @@ package com.trib3.server.config
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import com.trib3.config.ConfigLoader
-import com.trib3.config.KMSStringSelectReader
 import org.testng.annotations.Test
 
 class TribeApplicationConfigTest {
     @Test
     fun testConfig() {
-        val config = TribeApplicationConfig(ConfigLoader(KMSStringSelectReader(null)))
+        val config = TribeApplicationConfig(ConfigLoader())
         assertThat(config.env).isEqualTo("dev")
         assertThat(config.appName).isEqualTo("Test")
         assertThat(config.adminAuthToken).isEqualTo("SECRET")

--- a/server/src/test/kotlin/com/trib3/server/config/dropwizard/HoconConfigurationTest.kt
+++ b/server/src/test/kotlin/com/trib3/server/config/dropwizard/HoconConfigurationTest.kt
@@ -3,7 +3,6 @@ package com.trib3.server.config.dropwizard
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import com.trib3.config.ConfigLoader
-import com.trib3.config.KMSStringSelectReader
 import com.trib3.json.ObjectMapperProvider
 import io.dropwizard.Configuration
 import io.dropwizard.configuration.FileConfigurationSourceProvider
@@ -15,7 +14,7 @@ import org.testng.annotations.Test
 class HoconConfigurationTest {
     @Test
     fun testHoconFactory() {
-        val factoryFactory = HoconConfigurationFactoryFactory<Configuration>(ConfigLoader(KMSStringSelectReader(null)))
+        val factoryFactory = HoconConfigurationFactoryFactory<Configuration>(ConfigLoader())
         val factory = factoryFactory.create(
             Configuration::class.java,
             Bootstrap<Configuration>(null).validatorFactory.validator,

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.6-SNAPSHOT</version>
+        <version>1.7-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Let websocket policy timeouts and max messages sizes be
specfied in application config.

Adds convenience methods to ConfigLoader to allow eg. tests
to inject a ConfigLoader that sets a "defaultPath" which
acts similar to an environmental override, without having
the specific Config code needing to load through a path.

https://trello.com/c/lOjLKQi8/