### PR TITLE
Flyway config and UUID scalars

### DIFF
--- a/db/README.md
+++ b/db/README.md
@@ -49,6 +49,7 @@ section to `application.conf` explicitly:
 * `DB_CONNECTION_TEST_QUERY`: connection timeout, defaults to `null`
 * `DB_MINIMUM_IDLE`: min number of idle connections, defaults to `10`
 * `DB_MAXIMUM_POOL_SIZE`: max number of total connections, defaults to `10`
+* `DB_URL`: raw jdbc URL to use instead of `subprotocol`/`host`/`port`/`schema`, defaults to `null`
 
 NamedDbModule
 -------------
@@ -89,5 +90,23 @@ class PostgresDAO
 class MysqlDAO
 @Inject constructor(@Named("mysql") val ctx: DSLContext) {
    // ...
+}
+```
+
+FlywayModule
+------------
+To run [Flyway](https://flywaydb.org) migrations at server startup, install the `FlywayModule`.
+It will run a Flyway instance with default configurations against the `DbModule`'s `DataSource`.
+
+To further configure Flyway, bind a `FluentConfiguration` in one of your application module, for example:
+```kotlin
+class MyApplicationPersistenceModule : KotlinModule() {
+    override fun configure() {
+        install(FlywayModule())
+        bind<FluentConfiguration>().toInstance(
+            Flyway.configure().sqlMigrationSuffixes(".sql", ".postgresql")
+                .locations("db/schema") // ... etc
+        )
+    }
 }
 ```

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -82,20 +82,20 @@
             <artifactId>postgresql</artifactId>
         </dependency>
 
-        <!-- test logging -->
+        <!-- flyway bundle -->
         <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.opentable.components</groupId>
-            <artifactId>otj-pg-embedded</artifactId>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
-            <scope>test</scope>
+        </dependency>
+
+        <!-- test -->
+        <dependency>
+            <groupId>com.opentable.components</groupId>
+            <artifactId>otj-pg-embedded</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/db/src/main/kotlin/com/trib3/db/config/DbConfig.kt
+++ b/db/src/main/kotlin/com/trib3/db/config/DbConfig.kt
@@ -41,13 +41,14 @@ class DbConfig
         val connectionTestQuery = config.extract<String?>("connectionTestQuery")
         val minimumIdle = config.extract<Int?>("minimumIdle")
         val maximumPoolSize = config.extract<Int?>("maximumPoolSize")
+        val url = config.extract<String?>("url")
 
         val hds = HikariDataSource()
         hds.poolName = configPath
         hds.username = username
         hds.password = password
         hds.driverClassName = driverClassName
-        hds.jdbcUrl = "jdbc:$subprotocol://$host:$port/$schema"
+        hds.jdbcUrl = url ?: "jdbc:$subprotocol://$host:$port/$schema"
         hds.healthCheckRegistry = healthCheckRegistry
         hds.metricRegistry = metricRegistry
         hds.isAutoCommit = autoCommit

--- a/db/src/main/kotlin/com/trib3/db/flyway/FlywayBundle.kt
+++ b/db/src/main/kotlin/com/trib3/db/flyway/FlywayBundle.kt
@@ -1,0 +1,23 @@
+package com.trib3.db.flyway
+
+import io.dropwizard.Configuration
+import io.dropwizard.ConfiguredBundle
+import io.dropwizard.setup.Environment
+import org.flywaydb.core.api.configuration.FluentConfiguration
+import javax.inject.Inject
+import javax.sql.DataSource
+
+/**
+ * Dropwizard bundle for running flyway migrations at initialization time,
+ * with configuration supplied by guice.
+ */
+class FlywayBundle
+@Inject constructor(
+    internal val dataSource: DataSource,
+    internal val baseConfig: FluentConfiguration
+) : ConfiguredBundle<Configuration> {
+
+    override fun run(configuration: Configuration?, env: Environment?) {
+        baseConfig.dataSource(dataSource).load().migrate()
+    }
+}

--- a/db/src/main/kotlin/com/trib3/db/modules/FlywayModule.kt
+++ b/db/src/main/kotlin/com/trib3/db/modules/FlywayModule.kt
@@ -1,0 +1,27 @@
+package com.trib3.db.modules
+
+import com.trib3.db.flyway.FlywayBundle
+import dev.misfitlabs.kotlinguice4.KotlinModule
+import dev.misfitlabs.kotlinguice4.multibindings.KotlinMultibinder
+import io.dropwizard.Configuration
+import io.dropwizard.ConfiguredBundle
+
+/**
+ * Module that binds in a Flyway Dropwizard Bundle to run db migrations at
+ * application startup time
+ */
+class FlywayModule : KotlinModule() {
+    override fun configure() {
+        install(DbModule())
+        KotlinMultibinder.newSetBinder<ConfiguredBundle<Configuration>>(kotlinBinder).addBinding().to<FlywayBundle>()
+    }
+
+    // allow multiple installations so that multiple other modules can install this one
+    override fun equals(other: Any?): Boolean {
+        return other is FlywayModule
+    }
+
+    override fun hashCode(): Int {
+        return this::class.hashCode()
+    }
+}

--- a/db/src/main/resources/reference.conf
+++ b/db/src/main/resources/reference.conf
@@ -15,5 +15,6 @@ overrides {
     connectionTestQuery: ${?DB_CONNECTION_TEST_QUERY}
     minimumIdle: ${?DB_MINIMUM_IDLE}
     maximumPoolSize: ${?DB_MAXIMUM_POOL_SIZE}
+    url: ${?DB_URL}
   }
 }

--- a/db/src/test/kotlin/com/trib3/db/flyway/FlywayBundleTest.kt
+++ b/db/src/test/kotlin/com/trib3/db/flyway/FlywayBundleTest.kt
@@ -1,0 +1,23 @@
+package com.trib3.db.flyway
+
+import org.easymock.EasyMock
+import org.flywaydb.core.Flyway
+import org.flywaydb.core.api.configuration.FluentConfiguration
+import org.testng.annotations.Test
+import javax.sql.DataSource
+
+class FlywayBundleTest {
+    @Test
+    fun testFlywayMigrate() {
+        val mockConfig = EasyMock.mock<FluentConfiguration>(FluentConfiguration::class.java)
+        val mockDatasource = EasyMock.mock<DataSource>(DataSource::class.java)
+        val mockFlyway = EasyMock.mock<Flyway>(Flyway::class.java)
+        EasyMock.expect(mockConfig.dataSource(mockDatasource)).andReturn(mockConfig).once()
+        EasyMock.expect(mockConfig.load()).andReturn(mockFlyway).once()
+        EasyMock.expect(mockFlyway.migrate()).andReturn(1).once()
+        EasyMock.replay(mockConfig, mockDatasource, mockFlyway)
+        val bundle = FlywayBundle(mockDatasource, mockConfig)
+        bundle.run(null, null)
+        EasyMock.verify(mockConfig, mockDatasource, mockFlyway)
+    }
+}

--- a/db/src/test/kotlin/com/trib3/db/modules/FlywayModuleTest.kt
+++ b/db/src/test/kotlin/com/trib3/db/modules/FlywayModuleTest.kt
@@ -1,0 +1,53 @@
+package com.trib3.db.modules
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import com.trib3.db.flyway.FlywayBundle
+import dev.misfitlabs.kotlinguice4.KotlinModule
+import io.dropwizard.Configuration
+import io.dropwizard.ConfiguredBundle
+import org.flywaydb.core.Flyway
+import org.flywaydb.core.api.configuration.FluentConfiguration
+import org.testng.annotations.Guice
+import org.testng.annotations.Test
+import javax.inject.Inject
+
+@Guice(modules = [FlywayModule::class])
+class DefaultFlywayModuleTest
+@Inject constructor(
+    val dropwizardBundles: Set<@JvmSuppressWildcards ConfiguredBundle<Configuration>>
+) {
+    @Test
+    fun testFlyway() {
+        val flywayBundle = dropwizardBundles.filterIsInstance<FlywayBundle>().first()
+        assertThat(flywayBundle.dataSource).isNotNull()
+        assertThat(flywayBundle.baseConfig).isNotNull()
+        assertThat(flywayBundle.baseConfig.sqlMigrationSuffixes.toList()).isEqualTo(listOf(".sql"))
+    }
+
+    @Test
+    fun testEquals() {
+        assertThat(FlywayModule()).isEqualTo(FlywayModule())
+    }
+}
+
+private class ConfiguredFlywayModule : KotlinModule() {
+    override fun configure() {
+        bind<FluentConfiguration>().toInstance(Flyway.configure().sqlMigrationSuffixes(".sql", ".test"))
+    }
+}
+
+@Guice(modules = [FlywayModule::class, ConfiguredFlywayModule::class])
+class ConfiguredFlywayModuleTest
+@Inject constructor(
+    val dropwizardBundles: Set<@JvmSuppressWildcards ConfiguredBundle<Configuration>>
+) {
+    @Test
+    fun testFlyway() {
+        val flywayBundle = dropwizardBundles.filterIsInstance<FlywayBundle>().first()
+        assertThat(flywayBundle.dataSource).isNotNull()
+        assertThat(flywayBundle.baseConfig).isNotNull()
+        assertThat(flywayBundle.baseConfig.sqlMigrationSuffixes.toList()).isEqualTo(listOf(".sql", ".test"))
+    }
+}

--- a/db/src/test/kotlin/com/trib3/db/modules/NamedDbModuleTest.kt
+++ b/db/src/test/kotlin/com/trib3/db/modules/NamedDbModuleTest.kt
@@ -27,6 +27,7 @@ class ModuleFactory : IModuleFactory {
                 install(DbModule())
                 install(NamedDbModule("test"))
                 install(NamedDbModule("test2"))
+                install(NamedDbModule("test3"))
             }
         }
     }
@@ -50,7 +51,11 @@ class NamedDbModuleTest
 
     @Named("test2") val test2DbConfig: DbConfig,
     @Named("test2") val test2DataSource: DataSource,
-    @Named("test2") val test2DSLContext: DSLContext
+    @Named("test2") val test2DSLContext: DSLContext,
+
+    @Named("test3") val test3DbConfig: DbConfig,
+    @Named("test3") val test3DataSource: DataSource,
+    @Named("test3") val test3DSLContext: DSLContext
 ) {
     @Test
     fun testConfigs() {
@@ -60,6 +65,8 @@ class NamedDbModuleTest
             doesNotContain("test2")
         }
         assertThat((test2DbConfig.dataSource as HikariDataSource).jdbcUrl).contains("test2")
+        assertThat((test3DbConfig.dataSource as HikariDataSource).jdbcUrl)
+            .isEqualTo("jdbc:postgres://test3:12345/test3")
     }
 
     @Test
@@ -70,6 +77,7 @@ class NamedDbModuleTest
             doesNotContain("test2")
         }
         assertThat((test2DataSource as HikariDataSource).jdbcUrl).contains("test2")
+        assertThat((test3DataSource as HikariDataSource).jdbcUrl).isEqualTo("jdbc:postgres://test3:12345/test3")
     }
 
     @Test
@@ -80,12 +88,15 @@ class NamedDbModuleTest
             (testDSLContext.configuration().connectionProvider() as DataSourceConnectionProvider).dataSource()
         val test2DS =
             (test2DSLContext.configuration().connectionProvider() as DataSourceConnectionProvider).dataSource()
+        val test3DS =
+            (test3DSLContext.configuration().connectionProvider() as DataSourceConnectionProvider).dataSource()
         assertThat((defaultDS as HikariDataSource).jdbcUrl).contains("localhost")
         assertThat((testDS as HikariDataSource).jdbcUrl).all {
             contains("test")
             doesNotContain("test2")
         }
         assertThat((test2DS as HikariDataSource).jdbcUrl).contains("test2")
+        assertThat((test3DS as HikariDataSource).jdbcUrl).isEqualTo("jdbc:postgres://test3:12345/test3")
     }
 
     @Test

--- a/db/src/test/resources/application.conf
+++ b/db/src/test/resources/application.conf
@@ -6,6 +6,10 @@ test2 {
   host: test2
 }
 
+test3 {
+  url: "jdbc:postgres://test3:12345/test3"
+}
+
 db {
   // configure these slightly different than hikariCP defaults
   connectionTimeout: 30001

--- a/graphql/README.md
+++ b/graphql/README.md
@@ -3,7 +3,7 @@ Graphql
 Provides the application infrastructure for adding [GraphQL](https://graphql.org) support 
 to a [server](https://github.com/trib3/leakycauldron/blob/master/server) application.
 * GraphQL endpoints:
-  * java8 time and threeten-extra [Scalars](https://github.com/trib3/leakycauldron/blob/master/graphql/src/main/kotlin/com/trib3/graphql/execution/DateTimeHooks.kt)
+  * UUID, java8 time, and threeten-extra [Scalars](https://github.com/trib3/leakycauldron/blob/master/graphql/src/main/kotlin/com/trib3/graphql/execution/LeakyCauldronHooks.kt)
   * [Request Ids](https://github.com/trib3/leakycauldron/blob/master/graphql/src/main/kotlin/com/trib3/graphql/execution/RequestIdInstrumentation.kt) 
     attached to the GraphQL response extensions
   * Any guice bound Query, Subscription or Mutation Resolvers

--- a/graphql/src/main/kotlin/com/trib3/graphql/modules/DefaultGraphQLModule.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/modules/DefaultGraphQLModule.kt
@@ -8,7 +8,7 @@ import com.expediagroup.graphql.toSchema
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.inject.Provides
 import com.trib3.graphql.execution.CustomDataFetcherExceptionHandler
-import com.trib3.graphql.execution.DateTimeHooks
+import com.trib3.graphql.execution.LeakyCauldronHooks
 import com.trib3.graphql.execution.RequestIdInstrumentation
 import com.trib3.graphql.resources.GraphQLResource
 import com.trib3.graphql.websocket.GraphQLWebSocketCreator
@@ -60,7 +60,7 @@ class DefaultGraphQLModule : GraphQLApplicationModule() {
         subscriptions: Set<@JvmSuppressWildcards Any>,
         mapper: ObjectMapper
     ): GraphQL {
-        val hooks = DateTimeHooks()
+        val hooks = LeakyCauldronHooks()
         val config = SchemaGeneratorConfig(
             graphQLPackages.toList(),
             hooks = hooks,

--- a/testing/src/main/kotlin/com/trib3/testing/db/DAOTestBase.kt
+++ b/testing/src/main/kotlin/com/trib3/testing/db/DAOTestBase.kt
@@ -2,6 +2,7 @@ package com.trib3.testing.db
 
 import com.opentable.db.postgres.embedded.EmbeddedPostgres
 import org.flywaydb.core.Flyway
+import org.flywaydb.core.api.configuration.FluentConfiguration
 import org.jooq.DSLContext
 import org.jooq.SQLDialect
 import org.jooq.impl.DSL
@@ -19,6 +20,15 @@ open class DAOTestBase {
     private lateinit var postgres: EmbeddedPostgres
     private var inited: Boolean = false
 
+    /**
+     * By default use a flyway with default configuration
+     * pointing at the postgres [DataSource].  Subclasses
+     * can override for additional configuration.
+     */
+    open fun getFlywayConfiguration(): FluentConfiguration {
+        return Flyway.configure().dataSource(dataSource)
+    }
+
     @BeforeClass
     open fun setUp() {
         if (!inited) {
@@ -28,8 +38,7 @@ open class DAOTestBase {
                 .start()
             dataSource = postgres.postgresDatabase
             ctx = DSL.using(dataSource, SQLDialect.POSTGRES)
-            val flyway = Flyway.configure().dataSource(dataSource).load()
-            flyway.migrate()
+            getFlywayConfiguration().load().migrate()
         }
     }
 


### PR DESCRIPTION
```
Add configuration for flyway and full jdbc url

Allow non-default Flyway configuration in tests via override and
at runtime via a new guice module.
Allow configuration via full jdbc url when running in, eg heroku.
```
```
Add UUID graphql scalar type

Support UUIDs in graphql queries as String representations.
Rename DateTimeHooks -> LeakyCauldronHooks since it's not all
DateTime related anymore.  Include a typealias for backward
compatiblity.
```