### PR TITLE
Add jOOQ ResultQuery Flow adapter

### DIFF
--- a/db/pom.xml
+++ b/db/pom.xml
@@ -82,6 +82,11 @@
             <artifactId>postgresql</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-core</artifactId>
+        </dependency>
+
         <!-- flyway bundle -->
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/db/src/main/kotlin/com/trib3/db/jooqext/ResultQueryFlow.kt
+++ b/db/src/main/kotlin/com/trib3/db/jooqext/ResultQueryFlow.kt
@@ -1,0 +1,66 @@
+package com.trib3.db.jooqext
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
+import mu.KotlinLogging
+import org.jooq.Record
+import org.jooq.ResultQuery
+import kotlin.coroutines.CoroutineContext
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Convert a [ResultQuery] to a [Flow], ensuring that the underlying cursor gets closed on completion,
+ * and that the query is cancelled when the flow consuming coroutine is cancelled.
+ *
+ * Will run [ResultQuery.fetchLazy] in a new coroutine launched with the passed [coroutineContext].
+ * Will run an additional coroutine launched with the passed [coroutineContext] that monitors the
+ * fetch-ing coroutine for cancellation, and calls [ResultQuery.cancel] when that occurs.
+ */
+fun <T : Record> ResultQuery<T>.consumeAsFlow(coroutineContext: CoroutineContext = Dispatchers.IO): Flow<T> {
+    val query = this
+    return flow {
+        coroutineScope {
+            val fetchJob = async(coroutineContext) {
+                query.fetchLazy()
+            }
+            launch(coroutineContext) {
+                // wait until the fetch job is cancelled or complete before doing anything
+                log.trace("fetch monitor awaiting job cancellation or completion")
+                val cancelException = try {
+                    while (fetchJob.isActive) {
+                        delay(100)
+                    }
+                    null
+                } catch (e: CancellationException) {
+                    e
+                }
+                log.trace("fetch monitor awaiting job completion")
+                // wait until the fetch job is actually complete, cancelling the query to speed its completion
+                while (!fetchJob.isCompleted) {
+                    query.cancel()
+                    delay(100)
+                }
+                log.trace("fetch monitor job finished, throwing $cancelException")
+                if (cancelException != null) {
+                    throw cancelException
+                }
+            }
+            val cursor = fetchJob.await()
+            try {
+                for (i in cursor) {
+                    emit(i)
+                }
+            } finally {
+                log.debug("Closing cursor")
+                cursor.close()
+            }
+        }
+    }
+}

--- a/db/src/test/kotlin/com/trib3/db/jooqext/ResultQueryFlowTest.kt
+++ b/db/src/test/kotlin/com/trib3/db/jooqext/ResultQueryFlowTest.kt
@@ -1,0 +1,109 @@
+package com.trib3.db.jooqext
+
+import assertk.assertThat
+import assertk.assertions.hasMessage
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFailure
+import assertk.assertions.isInstanceOf
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.easymock.EasyMock
+import org.jooq.Cursor
+import org.jooq.Record
+import org.jooq.ResultQuery
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.testng.annotations.Test
+import java.util.concurrent.CountDownLatch
+
+class ResultQueryFlowTest {
+    val expectedData = (1..4).toList()
+
+    val mockData = expectedData.map {
+        DSL.using(SQLDialect.DEFAULT).newRecord(DSL.field("value")).values(it)
+    }.toMutableList()
+
+    @Test
+    fun testCollect() {
+        val query = EasyMock.mock<ResultQuery<out Record>>(ResultQuery::class.java)!!
+        val cursor = EasyMock.mock<Cursor<out Record>>(Cursor::class.java)!!
+        EasyMock.expect(query.fetchLazy()).andReturn(cursor).once()
+        EasyMock.expect(cursor.iterator()).andReturn(mockData.iterator()).once()
+        EasyMock.expect(cursor.close()).once()
+        EasyMock.replay(query, cursor)
+        runBlocking {
+            val list = query.consumeAsFlow().map { it["value"] as Int }.toList()
+            assertThat(list).isEqualTo(expectedData)
+        }
+        EasyMock.verify(query, cursor)
+    }
+
+    @Test
+    fun testCancelDuringIteration() {
+        val latch = CountDownLatch(1)
+        val query = EasyMock.mock<ResultQuery<out Record>>(ResultQuery::class.java)!!
+        val cursor = EasyMock.mock<Cursor<out Record>>(Cursor::class.java)!!
+        EasyMock.expect(query.fetchLazy()).andReturn(cursor).once()
+        EasyMock.expect(cursor.iterator()).andReturn(mockData.iterator()).once()
+        EasyMock.expect(cursor.close()).once()
+        EasyMock.replay(query, cursor)
+        val list = mutableListOf<Int>()
+        runBlocking {
+            val collectJob = launch {
+                query.consumeAsFlow().map { it["value"] as Int }.collect {
+                    // collect the first element and signal a value returned
+                    list.add(it)
+                    latch.countDown()
+                    delay(100000) // be "slow" so that only one element gets collected
+                }
+            }
+            launch(Dispatchers.IO) {
+                latch.await() // wait for a value returned
+                collectJob.cancel()
+            }
+        }
+        assertThat(list).isEqualTo(expectedData.subList(0, 1))
+        EasyMock.verify(query, cursor)
+    }
+
+    @Test
+    fun testCancelBeforeIteration() {
+        val cancelLatch = CountDownLatch(1)
+        val iterateLatch = CountDownLatch(1)
+        val query = EasyMock.mock<ResultQuery<out Record>>(ResultQuery::class.java)!!
+        // allow mockQuery to be invoked from multiple threads so that cancel()
+        // can be called when fetchLazy() is executing
+        EasyMock.makeThreadSafe(query, false)
+        EasyMock.expect(query.fetchLazy()).andAnswer {
+            iterateLatch.countDown() // signal collection has started
+            cancelLatch.await() // await cancellation
+            throw RuntimeException("cancelled")
+        }.once()
+        EasyMock.expect(query.cancel()).andAnswer {
+            cancelLatch.countDown() // signal cancellation
+        }
+        EasyMock.replay(query)
+        val list = mutableListOf<Int>()
+        runBlocking {
+            val collectJob = launch {
+                assertThat {
+                    query.consumeAsFlow().map { it["value"] as Int }.toList(list)
+                }.isFailure().isInstanceOf(RuntimeException::class.java).hasMessage("cancelled")
+            }
+            launch {
+                // delay(200)
+                iterateLatch.await() // wait for collection to start
+                collectJob.cancel()
+            }
+            collectJob.join()
+        }
+        assertThat(list).isEmpty()
+        EasyMock.verify(query)
+    }
+}


### PR DESCRIPTION
For a ResultQuery<T>, add a consumeAsFlow() extension
method that:
 - allows clients to consume a Flow<T>
 - ensures that the underlying query Cursor gets close()d
   on successful or unsuccessful completion
 - monitors the coroutine execution for cancellation,
   and calls query.cancel() to stop any synchronous JDBC
   operations that are blocking execution