### PR TITLE
Bump config4k version back down to 0.4.1

### DIFF
--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -50,7 +50,7 @@
         <version.aws.serverless>1.4</version.aws.serverless>
         <version.classgraph>4.8.66</version.classgraph>
         <version.commons-io>2.6</version.commons-io>
-        <version.config4k>0.4.2</version.config4k>
+        <version.config4k>0.4.1</version.config4k>
         <version.detekt>1.7.2</version.detekt>
         <version.dokka>0.10.1</version.dokka>
         <version.dropwizard>2.0.5</version.dropwizard>


### PR DESCRIPTION
0.4.2 got removed from jcenter, which breaks all
builds without a cached copy of the artifact