### PR TITLE
Serialize graphql json according to spec

### DIFF
--- a/graphql/src/main/kotlin/com/trib3/graphql/execution/JsonSafeExecutionResultMixin.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/execution/JsonSafeExecutionResultMixin.kt
@@ -1,0 +1,28 @@
+package com.trib3.graphql.execution
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonInclude
+import graphql.ExecutionResult
+import graphql.GraphQLError
+
+/**
+ * Jackson mixin for [ExecutionResult]s that ensures keys for data/errors/extensions
+ * only get written if there is corresponding data.  Similar to [ExecutionResult.toSpecification],
+ * but keeps the object typed as an [ExecutionResult] instead of converting to a [Map]
+ */
+interface JsonSafeExecutionResultMixin : ExecutionResult {
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    override fun getErrors(): List<GraphQLError>
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    override fun getExtensions(): Map<Any, Any>
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    override fun <T> getData(): T
+
+    @JsonIgnore
+    override fun isDataPresent(): Boolean
+
+    @JsonIgnore
+    override fun toSpecification(): Map<String, Any>
+}

--- a/graphql/src/main/kotlin/com/trib3/graphql/modules/DefaultGraphQLModule.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/modules/DefaultGraphQLModule.kt
@@ -7,17 +7,24 @@ import com.expediagroup.graphql.execution.SimpleKotlinDataFetcherFactoryProvider
 import com.expediagroup.graphql.toSchema
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.inject.Provides
+import com.google.inject.multibindings.MapBinder
+import com.google.inject.name.Names
 import com.trib3.graphql.execution.CustomDataFetcherExceptionHandler
+import com.trib3.graphql.execution.JsonSafeExecutionResultMixin
 import com.trib3.graphql.execution.LeakyCauldronHooks
 import com.trib3.graphql.execution.RequestIdInstrumentation
 import com.trib3.graphql.resources.GraphQLResource
 import com.trib3.graphql.websocket.GraphQLContextWebSocketCreatorFactory
 import com.trib3.graphql.websocket.GraphQLWebSocketCreatorFactory
+import com.trib3.json.ObjectMapperProvider
 import com.trib3.server.modules.ServletConfig
+import dev.misfitlabs.kotlinguice4.typeLiteral
+import graphql.ExecutionResult
 import graphql.GraphQL
 import graphql.execution.AsyncExecutionStrategy
 import io.dropwizard.servlets.assets.AssetServlet
 import javax.inject.Named
+import kotlin.reflect.KClass
 
 /**
  * Default Guice module for GraphQL applications.  Sets up
@@ -46,6 +53,13 @@ class DefaultGraphQLModule : GraphQLApplicationModule() {
                 listOf("/graphiql")
             )
         )
+        // use the JsonSafe jackson serialization mixin for ExecutionResults
+        MapBinder.newMapBinder(
+            kotlinBinder,
+            typeLiteral<KClass<*>>(),
+            typeLiteral<KClass<*>>(),
+            Names.named(ObjectMapperProvider.OBJECT_MAPPER_MIXINS)
+        ).addBinding(ExecutionResult::class).toInstance(JsonSafeExecutionResultMixin::class)
     }
 
     @Provides

--- a/graphql/src/test/kotlin/com/trib3/graphql/execution/JsonSafeExecutionResultMixinTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/execution/JsonSafeExecutionResultMixinTest.kt
@@ -1,0 +1,91 @@
+package com.trib3.graphql.execution
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.doesNotContain
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.trib3.json.ObjectMapperProvider
+import graphql.ExecutionResult
+import graphql.ExecutionResultImpl
+import graphql.GraphqlErrorException
+import org.testng.annotations.Test
+
+class JsonSafeExecutionResultMixinTest {
+    val mapper = ObjectMapperProvider().get().apply {
+        addMixIn(ExecutionResult::class.java, JsonSafeExecutionResultMixin::class.java)
+    }
+
+    @Test
+    fun testNoError() {
+        val result = ExecutionResultImpl.newExecutionResult()
+            .data("success")
+            .addExtension("ext", "value")
+            .build()
+        val json = mapper.writeValueAsString(result)
+        val mapped = mapper.readValue<Map<String, *>>(json)
+        assertThat(mapped.keys).all {
+            contains("data")
+            contains("extensions")
+            doesNotContain("errors")
+        }
+    }
+
+    @Test
+    fun testNoData() {
+        val result = ExecutionResultImpl.newExecutionResult()
+            .errors(
+                listOf(
+                    GraphqlErrorException.newErrorException().cause(IllegalStateException("bad state")).build()
+                )
+            )
+            .addExtension("ext", "value")
+            .build()
+        val json = mapper.writeValueAsString(result)
+        val mapped = mapper.readValue<Map<String, *>>(json)
+        assertThat(mapped.keys).all {
+            doesNotContain("data")
+            contains("extensions")
+            contains("errors")
+        }
+    }
+
+    @Test
+    fun testNoExt() {
+        val result = ExecutionResultImpl.newExecutionResult()
+            .data("success")
+            .errors(
+                listOf(
+                    GraphqlErrorException.newErrorException().cause(IllegalStateException("bad state")).build()
+                )
+            )
+            .build()
+        val json = mapper.writeValueAsString(result)
+        val mapped = mapper.readValue<Map<String, *>>(json)
+        assertThat(mapped.keys).all {
+            contains("data")
+            doesNotContain("extensions")
+            contains("errors")
+        }
+    }
+
+    @Test
+    fun testAll() {
+        val result = ExecutionResultImpl.newExecutionResult()
+            .data("success")
+            .errors(
+                listOf(
+                    GraphqlErrorException.newErrorException().cause(IllegalStateException("bad state")).build()
+                )
+            )
+            .addExtension("ext", "value")
+            .build()
+        val json = mapper.writeValueAsString(result)
+        val mapped = mapper.readValue<Map<String, *>>(json)
+        assertThat(mapped.keys).all {
+            contains("data")
+            contains("extensions")
+            contains("errors")
+        }
+    }
+}

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -50,6 +50,10 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>

--- a/json/src/main/kotlin/com/trib3/json/ObjectMapperProvider.kt
+++ b/json/src/main/kotlin/com/trib3/json/ObjectMapperProvider.kt
@@ -5,17 +5,34 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.trib3.json.ObjectMapperProvider.Companion.OBJECT_MAPPER_MIXINS
 import com.trib3.json.jackson.ThreeTenExtraModule
 import io.dropwizard.jackson.Jackson
 import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Named
 import javax.inject.Provider
+import kotlin.reflect.KClass
 
 /**
  * A provider that provides an ObjectMapper that has been configured
  * for tribe:  it's compatible with dropwizard, kotlin, java8 time
- * classes, and permissive on unknown properties
+ * classes, and permissive on unknown properties.
+ *
+ * Allows injecting mixins by providing a Map<KClass, KClass> bound
+ * by name [OBJECT_MAPPER_MIXINS]
  */
-class ObjectMapperProvider : Provider<ObjectMapper> {
+
+class ObjectMapperProvider @Inject constructor(
+    @Named(OBJECT_MAPPER_MIXINS)
+    private val mixins: Map<@JvmSuppressWildcards KClass<*>, @JvmSuppressWildcards KClass<*>>
+) : Provider<ObjectMapper> {
+    constructor() : this(emptyMap())
+
+    companion object {
+        const val OBJECT_MAPPER_MIXINS = "ObjectMapperMixins"
+    }
+
     override fun get(): ObjectMapper {
         val mapper = Jackson.newObjectMapper()
         mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
@@ -24,6 +41,9 @@ class ObjectMapperProvider : Provider<ObjectMapper> {
         mapper.registerModule(KotlinModule())
         mapper.registerModule(MetricsModule(TimeUnit.SECONDS, TimeUnit.SECONDS, false))
         mapper.registerModule(ThreeTenExtraModule())
+        mixins.forEach {
+            mapper.addMixIn(it.key.java, it.value.java)
+        }
         return mapper
     }
 }

--- a/json/src/main/kotlin/com/trib3/json/modules/ObjectMapperModule.kt
+++ b/json/src/main/kotlin/com/trib3/json/modules/ObjectMapperModule.kt
@@ -1,8 +1,12 @@
 package com.trib3.json.modules
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.inject.multibindings.MapBinder
+import com.google.inject.name.Names
 import com.trib3.json.ObjectMapperProvider
 import dev.misfitlabs.kotlinguice4.KotlinModule
+import dev.misfitlabs.kotlinguice4.typeLiteral
+import kotlin.reflect.KClass
 
 /**
  * Module for getting correctly configured [ObjectMapper]s
@@ -10,6 +14,13 @@ import dev.misfitlabs.kotlinguice4.KotlinModule
 class ObjectMapperModule : KotlinModule() {
     override fun configure() {
         bind<ObjectMapper>().toProvider<ObjectMapperProvider>()
+        // create an empty map by default
+        MapBinder.newMapBinder(
+            binder(),
+            typeLiteral<KClass<*>>(),
+            typeLiteral<KClass<*>>(),
+            Names.named(ObjectMapperProvider.OBJECT_MAPPER_MIXINS)
+        )
     }
 
     // allow multiple installations so that multiple other modules can install this one


### PR DESCRIPTION
According to the graphql spec, the data/errors/extensions
keys should exist in the json unless they have corresponding
data attached.  Some 3rd party tools like the js-graphql
plugin for jetbrains products fail to read the graphql
schema because of this deviation.  Use a jackson mixin in
order to serialize to json properly, and add the ability for
custom mixins to be injected into the ObjectMapper provider.