### PR TITLE
Atomically start the cleanup monitor coroutine

### DIFF
--- a/db/src/test/kotlin/com/trib3/db/jooqext/ResultQueryFlowTest.kt
+++ b/db/src/test/kotlin/com/trib3/db/jooqext/ResultQueryFlowTest.kt
@@ -97,7 +97,6 @@ class ResultQueryFlowTest {
                 }.isFailure().isInstanceOf(RuntimeException::class.java).hasMessage("cancelled")
             }
             launch {
-                // delay(200)
                 iterateLatch.await() // wait for collection to start
                 collectJob.cancel()
             }


### PR DESCRIPTION
If the coroutine gets cancelled prior to the cleanup
monitor actually starting its work, the cleanup logic
will get skipped and the query cancellation won't happen.
This mostly affects the unit test which has been failing
sporadically because of this race condition