### PR TITLE
Bindings for GraphQL DataLoaderRegistry

### DIFF
--- a/graphql/pom.xml
+++ b/graphql/pom.xml
@@ -53,6 +53,10 @@
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+        </dependency>
 
         <!-- graphql -->
         <dependency>
@@ -62,6 +66,10 @@
         <dependency>
             <groupId>com.graphql-java</groupId>
             <artifactId>graphql-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.graphql-java</groupId>
+            <artifactId>java-dataloader</artifactId>
         </dependency>
         <dependency>
             <groupId>org.threeten</groupId>

--- a/graphql/src/main/kotlin/com/trib3/graphql/execution/GraphQLRequest.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/execution/GraphQLRequest.kt
@@ -1,6 +1,31 @@
 package com.trib3.graphql.execution
 
+import com.trib3.graphql.modules.DataLoaderRegistryFactory
+import graphql.ExecutionInput
+
 /**
  * A generic GraphQL Request object that includes query, variable, and operationName components
  */
 data class GraphQLRequest(val query: String, val variables: Map<String, Any>?, val operationName: String?)
+
+/**
+ * Extension function to convert a [GraphQLRequest] to an [ExecutionInput]
+ */
+fun GraphQLRequest.toExecutionInput(
+    context: Any? = null,
+    dataLoaderRegistryFactory: DataLoaderRegistryFactory? = null
+): ExecutionInput {
+    return ExecutionInput.newExecutionInput()
+        .query(this.query)
+        .variables(this.variables ?: emptyMap())
+        .operationName(operationName)
+        .let { builder ->
+            context?.let { ctx ->
+                builder.context(ctx)
+            } ?: builder
+        }.let { builder ->
+            dataLoaderRegistryFactory?.let { factory ->
+                builder.dataLoaderRegistry(factory(this, context))
+            } ?: builder
+        }.build()
+}

--- a/graphql/src/main/kotlin/com/trib3/graphql/modules/GraphQLApplicationModule.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/modules/GraphQLApplicationModule.kt
@@ -1,8 +1,24 @@
 package com.trib3.graphql.modules
 
 import com.google.inject.name.Names
+import com.trib3.graphql.execution.GraphQLRequest
 import com.trib3.server.modules.TribeApplicationModule
 import dev.misfitlabs.kotlinguice4.multibindings.KotlinMultibinder
+import dev.misfitlabs.kotlinguice4.multibindings.KotlinOptionalBinder
+import graphql.execution.instrumentation.Instrumentation
+import org.dataloader.DataLoaderRegistry
+
+/**
+ * Function that takes a [GraphQLRequest] and an optional context
+ * and returns a [DataLoaderRegistry] with registered [org.dataloader.DataLoader]s
+ *
+ * Invoked per GraphQL request to allow for batching of data fetchers
+ */
+typealias DataLoaderRegistryFactory = Function2<
+    @JvmSuppressWildcards GraphQLRequest,
+    @JvmSuppressWildcards Any?,
+    @JvmSuppressWildcards DataLoaderRegistry
+    >
 
 /**
  * Base class for GraphQL application guice modules.  Provides
@@ -67,5 +83,21 @@ abstract class GraphQLApplicationModule : TribeApplicationModule() {
             kotlinBinder,
             Names.named(GRAPHQL_SUBSCRIPTIONS_BIND_NAME)
         )
+    }
+
+    /**
+     * Optional binder for the dataLoaderRegistryFactory
+     */
+    fun dataLoaderRegistryFactoryBinder(): KotlinOptionalBinder<DataLoaderRegistryFactory> {
+        return KotlinOptionalBinder.newOptionalBinder(kotlinBinder)
+    }
+
+    /**
+     * Binder for graphql Instrumentations.  RequestIdInstrumentation
+     * will be registered by default, but additional ones can be registered
+     * via this binder.
+     */
+    fun graphQLInstrumentationsBinder(): KotlinMultibinder<Instrumentation> {
+        return KotlinMultibinder.newSetBinder(kotlinBinder)
     }
 }

--- a/graphql/src/main/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketCreatorFactory.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketCreatorFactory.kt
@@ -3,8 +3,10 @@ package com.trib3.graphql.websocket
 import com.expediagroup.graphql.execution.GraphQLContext
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.trib3.graphql.GraphQLConfig
+import com.trib3.graphql.modules.DataLoaderRegistryFactory
 import graphql.GraphQL
 import org.eclipse.jetty.websocket.servlet.WebSocketCreator
+import javax.annotation.Nullable
 import javax.inject.Inject
 
 interface GraphQLContextWebSocketCreatorFactory {
@@ -18,14 +20,17 @@ class GraphQLWebSocketCreatorFactory
 @Inject constructor(
     private val graphQL: GraphQL,
     private val objectMapper: ObjectMapper,
-    private val graphQLConfig: GraphQLConfig
+    private val graphQLConfig: GraphQLConfig,
+    @Nullable private val dataLoaderRegistryFactory: DataLoaderRegistryFactory? = null
 ) : GraphQLContextWebSocketCreatorFactory {
+
     override fun getCreator(context: GraphQLContext): WebSocketCreator {
         return GraphQLWebSocketCreator(
             graphQL,
             objectMapper,
             graphQLConfig,
-            context
+            context,
+            dataLoaderRegistryFactory
         )
     }
 }

--- a/graphql/src/test/kotlin/com/trib3/graphql/execution/GraphQLRequestTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/execution/GraphQLRequestTest.kt
@@ -1,0 +1,30 @@
+package com.trib3.graphql.execution
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import graphql.GraphQLContext
+import graphql.execution.instrumentation.dataloader.DataLoaderDispatcherInstrumentationState
+import org.dataloader.DataLoaderRegistry
+import org.testng.annotations.Test
+
+class GraphQLRequestTest {
+    @Test
+    fun testExtensionMethod() {
+        val request = GraphQLRequest("query test", mapOf(), "test")
+        val executionInput = request.toExecutionInput()
+        assertThat(executionInput.query).isEqualTo(request.query)
+        assertThat(executionInput.dataLoaderRegistry).isEqualTo(
+            DataLoaderDispatcherInstrumentationState.EMPTY_DATALOADER_REGISTRY
+        )
+        assertThat(executionInput.context).isInstanceOf(GraphQLContext::class)
+
+        val emptyRegistry = DataLoaderRegistry()
+        val executionInputWithArgs = request.toExecutionInput("context object") { _, _ ->
+            emptyRegistry
+        }
+        assertThat(executionInputWithArgs.query).isEqualTo(request.query)
+        assertThat(executionInputWithArgs.dataLoaderRegistry).isEqualTo(emptyRegistry)
+        assertThat(executionInputWithArgs.context).isInstanceOf(String::class).isEqualTo("context object")
+    }
+}

--- a/graphql/src/test/kotlin/com/trib3/graphql/modules/GraphQLApplicationModuleTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/modules/GraphQLApplicationModuleTest.kt
@@ -1,15 +1,26 @@
 package com.trib3.graphql.modules
 
 import assertk.assertThat
+import assertk.assertions.isEqualTo
 import assertk.assertions.isGreaterThan
 import assertk.assertions.isNotNull
+import assertk.assertions.isNull
 import assertk.assertions.size
 import com.trib3.config.modules.KMSModule
+import com.trib3.graphql.execution.GraphQLRequest
 import com.trib3.graphql.resources.GraphQLResource
 import com.trib3.json.ObjectMapperProvider
+import com.trib3.server.filters.RequestIdFilter
 import com.trib3.server.modules.TribeApplicationModule
+import graphql.GraphQL
+import graphql.execution.instrumentation.dataloader.DataLoaderDispatcherInstrumentation
+import graphql.execution.instrumentation.dataloader.DataLoaderDispatcherInstrumentationOptions
+import org.dataloader.BatchLoader
+import org.dataloader.DataLoader
+import org.dataloader.DataLoaderRegistry
 import org.testng.annotations.Guice
 import org.testng.annotations.Test
+import java.util.concurrent.CompletableFuture
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -22,6 +33,11 @@ class DummyQuery {
 class DummyModule : GraphQLApplicationModule() {
     override fun configureApplication() {
         graphQLQueriesBinder().addBinding().to<DummyQuery>()
+        graphQLInstrumentationsBinder().addBinding().toInstance(
+            DataLoaderDispatcherInstrumentation(
+                DataLoaderDispatcherInstrumentationOptions.newOptions().includeStatistics(true)
+            )
+        )
     }
 }
 
@@ -29,25 +45,81 @@ class DummyModule : GraphQLApplicationModule() {
 class GraphQLApplicationModuleTest
 @Inject constructor(
     @Named(TribeApplicationModule.APPLICATION_RESOURCES_BIND_NAME)
-    val resources: Set<@JvmSuppressWildcards Any>
+    val resources: Set<@JvmSuppressWildcards Any>,
+    val graphQL: GraphQL
 ) {
-
     @Test
     fun testBinding() {
-        assertThat(resources.filterIsInstance<GraphQLResource>()).size().isGreaterThan(0)
+        val graphQLResources = resources.filterIsInstance<GraphQLResource>()
+        assertThat(graphQLResources).size().isGreaterThan(0)
+        assertThat(graphQLResources.first().dataLoaderRegistryFactory).isNull()
+        RequestIdFilter.withRequestId("graphQLInstrumentationBindingTest") {
+            val result = graphQL.execute("query test")
+            assertThat(result.extensions["RequestId"]).isEqualTo("graphQLInstrumentationBindingTest")
+            assertThat(result.extensions["dataloader"]).isNotNull()
+            val x = result.extensions["dataloader"] as Map<*, *>
+            assertThat(x["overall-statistics"]).isNotNull()
+            assertThat(x["individual-statistics"]).isNotNull()
+        }
     }
+}
 
+@Test
+fun testGraphQLProvider() {
+    val module = DefaultGraphQLModule()
+    val graphQLInstance = module.provideGraphQLInstance(
+        setOf(),
+        setOf(DummyQuery()),
+        setOf(),
+        setOf(),
+        setOf(),
+        ObjectMapperProvider().get()
+    )
+    assertThat(graphQLInstance).isNotNull()
+}
+
+class OverrideDataLoaderModule : GraphQLApplicationModule() {
+    override fun configureApplication() {
+        dataLoaderRegistryFactoryBinder().setBinding().toInstance { _, _ ->
+            val registry = DataLoaderRegistry()
+            registry.register(
+                "loader",
+                DataLoader.newDataLoader(BatchLoader { keys: List<String> ->
+                    if (keys != listOf("a", "b")) {
+                        throw IllegalArgumentException("wrong keys!")
+                    }
+                    CompletableFuture.completedFuture(
+                        listOf(
+                            "1",
+                            "2"
+                        )
+                    )
+                })
+            )
+            registry
+        }
+    }
+}
+
+@Guice(modules = [DefaultGraphQLModule::class, KMSModule::class, DummyModule::class, OverrideDataLoaderModule::class])
+class GraphQLApplicationModuleDataLoaderOverrideTest
+@Inject constructor(
+    @Named(TribeApplicationModule.APPLICATION_RESOURCES_BIND_NAME)
+    val resources: Set<@JvmSuppressWildcards Any>
+) {
     @Test
-    fun testGraphQLProvider() {
-
-        val module = DefaultGraphQLModule()
-        val graphQLInstance = module.provideGraphQLInstance(
-            setOf(),
-            setOf(DummyQuery()),
-            setOf(),
-            setOf(),
-            ObjectMapperProvider().get()
-        )
-        assertThat(graphQLInstance).isNotNull()
+    fun testBinding() {
+        val graphQLResources = resources.filterIsInstance<GraphQLResource>()
+        assertThat(graphQLResources).size().isGreaterThan(0)
+        val factory = graphQLResources.first().dataLoaderRegistryFactory
+        assertThat(factory).isNotNull()
+        val loader = factory!!.invoke(GraphQLRequest("", mapOf(), ""), null).getDataLoader<String, String>("loader")
+        assertThat(loader).isNotNull()
+        val future = loader.loadMany(listOf("a", "b"))
+        // an actual GraphQL resolver would return CompletableFuture<T> instead of T, and graphql-java would
+        // deal with dispatching and awaiting as needed, but to make sure everything is hooked up right,
+        // dispatch and await the future explicitly to assert on its returned value
+        loader.dispatch()
+        assertThat(future.get()).isEqualTo(listOf("1", "2"))
     }
 }

--- a/lambda/src/main/kotlin/com/trib3/lambda/resources/AdminResource.kt
+++ b/lambda/src/main/kotlin/com/trib3/lambda/resources/AdminResource.kt
@@ -74,11 +74,11 @@ class AdminResource
     @Produces(MediaType.TEXT_PLAIN)
     fun getThreads(@QueryParam("key") key: String?): Response {
         checkAccess(key)
-        val responseBuilder = Response.ok()
-        threadDumper?.let {
-            val output = StreamingOutput { output -> it.dump(output) }
-            responseBuilder.entity(output)
-        }
-        return responseBuilder.build()
+        return Response.ok()
+            .let { builder ->
+                threadDumper?.let { tDumper ->
+                    builder.entity(StreamingOutput { output -> tDumper.dump(output) })
+                } ?: builder
+            }.build()
     }
 }

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -62,6 +62,7 @@
         <version.graphql-kotlin>2.1.0</version.graphql-kotlin>
         <version.graphql-java>14.0</version.graphql-java>
         <version.graphql-java.tools>5.2.4</version.graphql-java.tools>
+        <version.graphql-java.dataloader>2.2.3</version.graphql-java.dataloader>
         <version.graphql-java.servlet>6.1.3</version.graphql-java.servlet>
         <version.guava>29.0-jre</version.guava>
         <version.guice>4.2.3</version.guice>
@@ -1056,6 +1057,11 @@
                         <artifactId>jackson-datatype-jdk8</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.graphql-java</groupId>
+                <artifactId>java-dataloader</artifactId>
+                <version>${version.graphql-java.dataloader}</version>
             </dependency>
             <dependency>
                 <groupId>com.graphql-java</groupId>

--- a/server/src/main/kotlin/com/trib3/server/healthchecks/VersionHealthCheck.kt
+++ b/server/src/main/kotlin/com/trib3/server/healthchecks/VersionHealthCheck.kt
@@ -47,10 +47,13 @@ open class VersionHealthCheck : HealthCheck() {
     }
 
     public override fun check(): Result {
-        val resultBuilder = Result.builder().withMessage(info)
-        return when (healthy) {
-            true -> resultBuilder.healthy().build()
-            else -> resultBuilder.unhealthy().build()
-        }
+        return Result.builder().withMessage(info)
+            .let { builder ->
+                if (healthy) {
+                    builder.healthy()
+                } else {
+                    builder.unhealthy()
+                }
+            }.build()
     }
 }


### PR DESCRIPTION
When dealing with graphs of objects, DataLoaders allow applications
to avoid having to issue N+1 queries to fetch relations of N objects.
Allow applications to configure DataLoaders by binding an implementation
of a DataLoaderRegistryFactory that will create a per request registry
of DataLoaders.
(See https://www.graphql-java.com/documentation/v14/batching/ for more
details)

Add a centralized method to convert GraphQLRequest objects into
ExecutionInput objects to avoid duplicating that logic between the
WebSocket and Resource endpoints.

Use let scope function for more fluent conditional builder usage.