### PR TITLE
Bump ktlint from implicit 0.37.0 to explicit 0.37.1

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,5 +3,5 @@ indent_size=4
 continuation_indent_size=4
 insert_final_newline=true
 max_line_length=120
-# https://github.com/pinterest/ktlint/issues/527
-disabled_rules=import-ordering
+# this is currently the default but make explicit:
+kotlin_imports_layout=idea

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -88,6 +88,7 @@
         <version.kotlin.coroutines>1.3.7</version.kotlin.coroutines>
         <version.kotlin.guice>1.4.1</version.kotlin.guice>
         <version.kotlin.logging>1.7.9</version.kotlin.logging>
+        <version.ktlint>0.37.1</version.ktlint>
         <version.leakycauldron>${project.version}</version.leakycauldron>
         <version.logback>1.2.3</version.logback>
         <version.maven.antrun>3.0.0</version.maven.antrun>
@@ -1356,6 +1357,38 @@
                             </goals>
                         </execution>
                     </executions>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.pinterest.ktlint</groupId>
+                            <artifactId>ktlint-core</artifactId>
+                            <version>${version.ktlint}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>com.pinterest.ktlint</groupId>
+                            <artifactId>ktlint-reporter-checkstyle</artifactId>
+                            <version>${version.ktlint}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>com.pinterest.ktlint</groupId>
+                            <artifactId>ktlint-reporter-json</artifactId>
+                            <version>${version.ktlint}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>com.pinterest.ktlint</groupId>
+                            <artifactId>ktlint-reporter-plain</artifactId>
+                            <version>${version.ktlint}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>com.pinterest.ktlint</groupId>
+                            <artifactId>ktlint-ruleset-experimental</artifactId>
+                            <version>${version.ktlint}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>com.pinterest.ktlint</groupId>
+                            <artifactId>ktlint-ruleset-standard</artifactId>
+                            <version>${version.ktlint}</version>
+                        </dependency>
+                    </dependencies>
                     <configuration>
                         <skip>${skip.checks}</skip>
                     </configuration>


### PR DESCRIPTION
Explicitly manage the ktlint version instead of relying
on the transitive version of the ktlint-maven-plugin and
having to wait for another release.  With latest ktlint,
we can turn on the import ordering rule without conflicting
with IntelliJ's defaults, so do that.