### PR TITLE
Explicitly use maven versions plugin 2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
             fi
             for i in build-resources parent-pom; do
                cd $i
-               mvn versions:set -DgenerateBackupPoms=false -DnewVersion=${NEW_PROJECT_VERSION}
+               mvn org.codehaus.mojo:versions-maven-plugin:2.7:set -DgenerateBackupPoms=false -DnewVersion=${NEW_PROJECT_VERSION}
                cd ..
             done
             echo ${NEW_PROJECT_VERSION} > ~/repo/current_version.txt


### PR DESCRIPTION
Latest version doesn't support setting version with
parent pom in a subdirectory, so use the last version
that worked.  Also better to specify version explicitly
than to automatically get latest version.

See https://github.com/mojohaus/versions-maven-plugin/issues/426