### PR TITLE
Change master references to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           command: |
             mkdir -p ~/.m2
             echo $MAVEN_SETTINGS_XML > ~/.m2/settings.xml
-            if [ "$CIRCLE_BRANCH" = "master" ]; then
+            if [ "$CIRCLE_BRANCH" = "main" ]; then
                 set +o pipefail # it's ok to keep going if grep doesn't match anything 
                 REPOIDS=`mvn org.sonatype.plugins:nexus-staging-maven-plugin:rc-list -DserverId=ossrh -DnexusUrl=https://oss.sonatype.org/   |grep comtrib3 |awk '{print $2}'`
                 set -o pipefail
@@ -41,7 +41,7 @@ jobs:
                 fi
             fi
             cd build-resources && BASE_VERSION=$(mvn -q  -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive exec:exec|sed 's/-SNAPSHOT.*//') && cd ..
-            if [ "$CIRCLE_BRANCH" = "master" ]; then
+            if [ "$CIRCLE_BRANCH" = "main" ]; then
               NEW_PROJECT_VERSION=${BASE_VERSION}.${CIRCLE_BUILD_NUM}
             else
               NEW_PROJECT_VERSION=${BASE_VERSION}-${CIRCLE_BRANCH}-SNAPSHOT
@@ -55,7 +55,7 @@ jobs:
       - run:
           name: Maven Build
           command: |
-            if [ "$CIRCLE_BRANCH" = "master" ]; then
+            if [ "$CIRCLE_BRANCH" = "main" ]; then
               mvn deploy -DaltDeploymentRepository=ossrh::${MAVEN_RELEASE_REPO} -U
             else
               mvn deploy -DaltDeploymentRepository=ossrh::${MAVEN_SNAPSHOT_REPO} -U
@@ -122,11 +122,11 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
       - deploy:
           requires:
             - hold
           filters:
             branches:
               only:
-                - master
+                - main

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![CircleCI](https://circleci.com/gh/trib3/leakycauldron.svg?style=svg&circle-token=75d8c0fddf399e7d6393730422d42be35ef4f3b2)](https://circleci.com/gh/trib3/leakycauldron)
-[![codecov](https://codecov.io/gh/trib3/leakycauldron/branch/master/graph/badge.svg?token=MmCucLTttM)](https://codecov.io/gh/trib3/leakycauldron)
+[![codecov](https://codecov.io/gh/trib3/leakycauldron/branch/main/graph/badge.svg?token=MmCucLTttM)](https://codecov.io/gh/trib3/leakycauldron)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.trib3/leakycauldron/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.trib3/leakycauldron/)
 
 Tribe Dynamics' Leaky Cauldron
@@ -42,44 +42,44 @@ Project Layout
 Note that most modules make use of [Guice](https://github.com/google/guice) for 
 dependency injection of configured instances.
 
-* [`/build-resources`](https://github.com/trib3/leakycauldron/tree/master/build-resources)
+* [`/build-resources`](https://github.com/trib3/leakycauldron/tree/HEAD/build-resources)
 
 This contains resources for use during a maven build.  If depended upon, it should only be
 brought into test scope.
 
-* [`/parent-pom`](https://github.com/trib3/leakycauldron/tree/master/parent-pom)
+* [`/parent-pom`](https://github.com/trib3/leakycauldron/tree/HEAD/parent-pom)
 
 This contains the parent pom to be used for all maven projects at Tribe.
 
-* [`/json`](https://github.com/trib3/leakycauldron/tree/master/json)
+* [`/json`](https://github.com/trib3/leakycauldron/tree/HEAD/json)
 
 This contains classes and [Guice](https://github.com/google/guice) modules for configuring 
 [Jackson](https://github.com/FasterXML/jackson) objects to work with Tribe codebases.
 
-* [`/testing`](https://github.com/trib3/leakycauldron/tree/master/testing)
+* [`/testing`](https://github.com/trib3/leakycauldron/tree/HEAD/testing)
 
 This contains classes that enhance writing unit tests.
 
-* [`/config`](https://github.com/trib3/leakycauldron/tree/master/config)
+* [`/config`](https://github.com/trib3/leakycauldron/tree/HEAD/config)
 
 This contains classes for parsing [HOCON](https://github.com/lightbend/config) application.conf
 files with support for environmental overrides and AWS KMS-based encrypted values.
 
-* [`/db`](https://github.com/trib3/leakycauldron/tree/master/db)
+* [`/db`](https://github.com/trib3/leakycauldron/tree/HEAD/db)
 
 This contains classes for injecting configured [jOOQ](https://www.jooq.org) `DSLContext`s and 
 JDBC `DataSource`s into application data access code.
 
-* [`/server`](https://github.com/trib3/leakycauldron/tree/master/server)
+* [`/server`](https://github.com/trib3/leakycauldron/tree/HEAD/server)
 
 This contains classes for setting up a configurable [Dropwizard](https://dropwizard.io) based 
 application.
 
-* [`/graphql`](https://github.com/trib3/leakycauldron/tree/master/graphql)
+* [`/graphql`](https://github.com/trib3/leakycauldron/tree/HEAD/graphql)
 
 This contains classes for adding [GraphQL](https://graphql.org) support to an application.
 
-* [`/lambda`](https://github.com/trib3/leakycauldron/tree/master/lambda)
+* [`/lambda`](https://github.com/trib3/leakycauldron/tree/HEAD/lambda)
 
 This contains classes that allow an application to be deployed to 
 [AWS Lambda](https://aws.amazon.com/lambda/).

--- a/build-resources/pom.xml
+++ b/build-resources/pom.xml
@@ -11,7 +11,7 @@
 
     <name>Build Resources</name>
     <description>Resources for use during the build process</description>
-    <url>https://github.com/trib3/leakycauldron/tree/master/build-resources</url>
+    <url>https://github.com/trib3/leakycauldron/tree/HEAD/build-resources</url>
 
     <licenses>
         <license>

--- a/config/README.md
+++ b/config/README.md
@@ -7,12 +7,12 @@ and the ability to read [AWS KMS](https://aws.amazon.com/kms/) encrypted values.
 Generally, a maven module will provide a Config object that encapsulates usage of the 
 config module and exposes the raw configuration values needed.  For example, see the 
 `db` module's
-[DbConfig](https://github.com/trib3/leakycauldron/blob/master/db/src/main/kotlin/com/trib3/db/config/DbConfig.kt).
+[DbConfig](https://github.com/trib3/leakycauldron/blob/HEAD/db/src/main/kotlin/com/trib3/db/config/DbConfig.kt).
 
 Environmental Overrides
 -----------------------
 Configuration files loaded by 
-[`ConfigLoader`](https://github.com/trib3/leakycauldron/blob/master/config/src/main/kotlin/com/trib3/config/ConfigLoader.kt)
+[`ConfigLoader`](https://github.com/trib3/leakycauldron/blob/HEAD/config/src/main/kotlin/com/trib3/config/ConfigLoader.kt)
 support environmental overrides.  Files will first be loaded through standard means 
 (`application.conf` will be loaded with fallback to `reference.conf`), and then the value 
 of the `ENV` environment variable (or `env` config value) will be read to specify a comma
@@ -40,7 +40,7 @@ Example config:
 AWS KMS Encrypted Values
 ------------------------
 Configuration string values read by 
-[`Config.extract(path: String)`](https://github.com/trib3/leakycauldron/blob/master/config/src/main/kotlin/com/trib3/config/Extension.kt) 
+[`Config.extract(path: String)`](https://github.com/trib3/leakycauldron/blob/HEAD/config/src/main/kotlin/com/trib3/config/Extension.kt) 
 support reading AWS KMS-encrypted strings.  Any string encoded as `KMS(ciphertext)` will be
 decoded through KMS before being returned.  Note that in order to successfully decrypt a 
 KMS-encrypted value, the String itself must be `extract()`ed directly, and not nested within

--- a/graphql/README.md
+++ b/graphql/README.md
@@ -1,26 +1,26 @@
 Graphql
 ======
 Provides the application infrastructure for adding [GraphQL](https://graphql.org) support 
-to a [server](https://github.com/trib3/leakycauldron/blob/master/server) application.
+to a [server](https://github.com/trib3/leakycauldron/blob/HEAD/server) application.
 * GraphQL endpoints:
-  * UUID, java8 time, and threeten-extra [Scalars](https://github.com/trib3/leakycauldron/blob/master/graphql/src/main/kotlin/com/trib3/graphql/execution/LeakyCauldronHooks.kt)
-  * [Request Ids](https://github.com/trib3/leakycauldron/blob/master/graphql/src/main/kotlin/com/trib3/graphql/execution/RequestIdInstrumentation.kt) 
+  * UUID, java8 time, and threeten-extra [Scalars](https://github.com/trib3/leakycauldron/blob/HEAD/graphql/src/main/kotlin/com/trib3/graphql/execution/LeakyCauldronHooks.kt)
+  * [Request Ids](https://github.com/trib3/leakycauldron/blob/HEAD/graphql/src/main/kotlin/com/trib3/graphql/execution/RequestIdInstrumentation.kt) 
     attached to the GraphQL response extensions
   * Any guice bound Query, Subscription or Mutation Resolvers
-  * Supports websockets using the [Apollo Protocol](https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md)
+  * Supports websockets using the [Apollo Protocol](https://github.com/apollographql/subscriptions-transport-ws/blob/HEAD/PROTOCOL.md)
   * Supports subscriptions via [coroutine](https://github.com/kotlin/kotlinx.coroutines/) Flows 
     for any Resolvers that return a `Publisher<T>`
   * Supports [Dropwizard Authentication](https://www.dropwizard.io/en/latest/manual/auth.html) Principals
-    passed through to Resolvers via [GraphQLContext](https://github.com/ExpediaGroup/graphql-kotlin/blob/master/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/execution/GraphQLContext.kt)
+    passed through to Resolvers via [GraphQLContext](https://github.com/ExpediaGroup/graphql-kotlin/blob/HEAD/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/execution/GraphQLContext.kt)
 * Admin:
   * [GraphiQL](https://github.com/graphql/graphiql) available at `/admin/graphiql`
 
 #### Configuration
-Configuration is done primarily though Guice.  [`GraphQLApplicationModule`](https://github.com/trib3/leakycauldron/blob/master/graphql/src/main/kotlin/com/trib3/graphql/modules/GraphQLApplicationModule.kt)
+Configuration is done primarily though Guice.  [`GraphQLApplicationModule`](https://github.com/trib3/leakycauldron/blob/HEAD/graphql/src/main/kotlin/com/trib3/graphql/modules/GraphQLApplicationModule.kt)
 exposes binders for commonly bound objects.  
 
 ##### GraphQL Resolvers
-[`GraphQLApplicationModule`](https://github.com/trib3/leakycauldron/blob/master/graphql/src/main/kotlin/com/trib3/graphql/modules/GraphQLApplicationModule.kt)
+[`GraphQLApplicationModule`](https://github.com/trib3/leakycauldron/blob/HEAD/graphql/src/main/kotlin/com/trib3/graphql/modules/GraphQLApplicationModule.kt)
 provides methods that expose multi-binders for configuring GraphQL resolvers.  Any model
 classes must be added to the `graphQLPackagesBinder()` to allow [GraphQL Kotlin](https://github.com/ExpediaDotCom/graphql-kotlin/)
 to use them.  Query Resolver implementations can be added to the `graphQLQueriesBinder()`, 
@@ -42,7 +42,7 @@ class ExampleApplicationModule : GraphQLApplicationModule() {
 ```
 
 #### Auth
-If Dropwizard Authentication is setup per the [server README](https://github.com/trib3/leakycauldron/blob/master/server/README.md#auth),
+If Dropwizard Authentication is setup per the [server README](https://github.com/trib3/leakycauldron/blob/HEAD/server/README.md#auth),
 GraphQL resolver methods can receive the principal inside the GraphQL context of type
 `GraphQLResourceContext`.  Resolver methods can write to the `cookie` field of the context 
 object they receive in order to set cookies on the client (useful when, for example, using

--- a/graphql/src/main/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketConsumer.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketConsumer.kt
@@ -147,7 +147,7 @@ class QueryCoroutine(
 /**
  * Coroutine based consumer that listens for events on coming from the WebSocket managed
  * by a [GraphQLWebSocketAdapter], and implements the apollo graphql-ws protocol
- * from https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md
+ * from https://github.com/apollographql/subscriptions-transport-ws/blob/HEAD/PROTOCOL.md
  *
  * Handling some WebSocket events launches a child coroutine (eg, starting a query or
  * a keepalive timer).  The handlers for those subscriptions must inject back into the

--- a/graphql/src/main/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketProtocol.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketProtocol.kt
@@ -15,7 +15,7 @@ import kotlin.reflect.full.memberProperties
 /**
  * Model for a message in the graphql websocket protocol
  *
- * https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md
+ * https://github.com/apollographql/subscriptions-transport-ws/blob/HEAD/PROTOCOL.md
  */
 data class OperationMessage<T : Any>(
     val type: OperationType<T>?,

--- a/json/README.md
+++ b/json/README.md
@@ -1,7 +1,7 @@
 Json
 ====
 Provides an injectable `ObjectMapper` that is configured to support:
-* Dropwizard object mapper [defaults](https://github.com/dropwizard/dropwizard/blob/master/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java)
+* Dropwizard object mapper [defaults](https://github.com/dropwizard/dropwizard/blob/HEAD/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java)
 * kotlin data classes via the [jackson kotlin module](https://github.com/FasterXML/jackson-module-kotlin)
 * java8 time classes (and [threeten-extra](https://github.com/ThreeTen/threeten-extra) `YearQuarter`s)
 * permissiveness on unknown properties (`FAIL_ON_UNKNOWN_PROPERTIES` set to false)

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -11,7 +11,7 @@
 
     <name>Trib3 parent pom</name>
     <description>Parent pom for downstream projects</description>
-    <url>https://github.com/trib3/leakycauldron/tree/master/parent-pom</url>
+    <url>https://github.com/trib3/leakycauldron/tree/HEAD/parent-pom</url>
 
     <licenses>
         <license>

--- a/server/README.md
+++ b/server/README.md
@@ -3,30 +3,30 @@ server
 Provides the application infrastructure for running a [Dropwizard](https://dropwizard.io)
 based application.  The application will be a [simple server](https://dropwizard.readthedocs.io/en/stable/manual/configuration.html#simple),
 and have:
-* [HOCON](https://github.com/trib3/leakycauldron/blob/master/server/src/main/kotlin/com/trib3/server/config/dropwizard/HoconConfigurationFactory.kt) 
+* [HOCON](https://github.com/trib3/leakycauldron/blob/HEAD/server/src/main/kotlin/com/trib3/server/config/dropwizard/HoconConfigurationFactory.kt) 
   based configuration instead of the default .yaml based configuration
 * Health checks:
-  * [Ping](https://github.com/trib3/leakycauldron/blob/master/server/src/main/kotlin/com/trib3/server/healthchecks/PingHealthCheck.kt):
+  * [Ping](https://github.com/trib3/leakycauldron/blob/HEAD/server/src/main/kotlin/com/trib3/server/healthchecks/PingHealthCheck.kt):
     A simple health check that will always return healthy
-  * [Version](https://github.com/trib3/leakycauldron/blob/master/server/src/main/kotlin/com/trib3/server/healthchecks/VersionHealthCheck.kt):
+  * [Version](https://github.com/trib3/leakycauldron/blob/HEAD/server/src/main/kotlin/com/trib3/server/healthchecks/VersionHealthCheck.kt):
     A health check that will return the version of the running application
-  * Database: if a [DbModule](https://github.com/trib3/leakycauldron/blob/master/db#dbmodule) is installed, 
+  * Database: if a [DbModule](https://github.com/trib3/leakycauldron/blob/HEAD/db#dbmodule) is installed, 
     [HikariCP](https://github.com/brettwooldridge/HikariCP/wiki/Dropwizard-HealthChecks)
     will report on the db health
 * REST endpoints:
-  * [Ping](https://github.com/trib3/leakycauldron/blob/master/server/src/main/kotlin/com/trib3/server/resources/PingResource.kt):
+  * [Ping](https://github.com/trib3/leakycauldron/blob/HEAD/server/src/main/kotlin/com/trib3/server/resources/PingResource.kt):
     A simple REST GET endpoint that will always return `pong`
-  * [Request Ids](https://github.com/trib3/leakycauldron/blob/master/server/src/main/kotlin/com/trib3/server/filters/RequestIdFilter.kt) 
+  * [Request Ids](https://github.com/trib3/leakycauldron/blob/HEAD/server/src/main/kotlin/com/trib3/server/filters/RequestIdFilter.kt) 
     attached to HTTP headers
   * Any guice bound JAX-RS Resources
 * Admin:
-  * The dropwizard `/admin` servlet will be [password protected](https://github.com/trib3/leakycauldron/blob/master/server/src/main/kotlin/com/trib3/server/filters/AdminAuthFilter.kt)
+  * The dropwizard `/admin` servlet will be [password protected](https://github.com/trib3/leakycauldron/blob/HEAD/server/src/main/kotlin/com/trib3/server/filters/AdminAuthFilter.kt)
     with a password set from the `application.adminAuthToken` configuration variable 
     (or `ADMIN_AUTH_TOKEN` environment variable)
   * [Swagger UI](https://github.com/swagger-api/swagger-ui) available at `/admin/swagger`
 
 #### Configuration
-Configuration is done primarily though Guice.  [`TribeApplicationModule`](https://github.com/trib3/leakycauldron/blob/master/server/src/main/kotlin/com/trib3/server/modules/TribeApplicationModule.kt)
+Configuration is done primarily though Guice.  [`TribeApplicationModule`](https://github.com/trib3/leakycauldron/blob/HEAD/server/src/main/kotlin/com/trib3/server/modules/TribeApplicationModule.kt)
 exposes binders for commonly bound objects.  
   
 ##### Application Guice Modules
@@ -44,7 +44,7 @@ Example config:
 ```
 
 ##### JAX-RS Resources
-[`TribeApplicationModule`](https://github.com/trib3/leakycauldron/blob/master/server/src/main/kotlin/com/trib3/server/modules/TribeApplicationModule.kt)
+[`TribeApplicationModule`](https://github.com/trib3/leakycauldron/blob/HEAD/server/src/main/kotlin/com/trib3/server/modules/TribeApplicationModule.kt)
 provides a method that exposes a multi-binder for JAX-RS Resources.  Any Resource classes
 should be bound using this binder.
 
@@ -96,7 +96,7 @@ class ExampleCookieAuthedApplicationModule : TribeApplicationModule() {
 ```
 
 ##### GraphQL Resolvers
-To add [GraphQL](https://graphql.org) support, see [graphql](https://github.com/trib3/leakycauldron/blob/master/graphql)
+To add [GraphQL](https://graphql.org) support, see [graphql](https://github.com/trib3/leakycauldron/blob/HEAD/graphql)
 
 #### Execution
 Running a downstream application is most easily done by using a shaded `.jar`:
@@ -109,9 +109,9 @@ $ mvn exec:java -Dexec.mainClass=com.trib3.server.TribeApplicationKt
 ```
 
 When running in [AWS Elastic Beanstalk](https://aws.amazon.com/elasticbeanstalk/), the
-assembly configuration from [build-resources](https://github.com/trib3/leakycauldron/blob/master/build-resources)
+assembly configuration from [build-resources](https://github.com/trib3/leakycauldron/blob/HEAD/build-resources)
 can be used to create a `.zip` distribution that configures health checks and timeout
 values.  With the preconfigured `Java 8` Elastic Beanstalk platform, the `PORT` environment 
 property should be set to `5000` in the environment's software configuration.
 
-For running in [AWS Lambda](https://aws.amazon.com/lambda/), see [lambda](https://github.com/trib3/leakycauldron/blob/master/lambda)
+For running in [AWS Lambda](https://aws.amazon.com/lambda/), see [lambda](https://github.com/trib3/leakycauldron/blob/HEAD/lambda)


### PR DESCRIPTION
Update github links in README files to point
to `HEAD` (ie, whatever the default branch is),
and update circle to treat `main` as the main
branch to deploy to production.