### PR TITLE
Support coroutine resource endpoints

### DIFF
--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -48,6 +48,7 @@
         <version.aws.java>2.13.76</version.aws.java>
         <version.aws.lambda>1.2.1</version.aws.lambda>
         <version.aws.serverless>1.5.1</version.aws.serverless>
+        <version.byte-buddy>1.10.14</version.byte-buddy>
         <version.checker-qual>3.5.0</version.checker-qual>
         <version.classgraph>4.8.87</version.classgraph>
         <version.commons-io>2.7</version.commons-io>
@@ -226,6 +227,11 @@
                         <artifactId>error_prone_annotations</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>${version.byte-buddy}</version>
             </dependency>
             <dependency>
                 <groupId>net.sourceforge.argparse4j</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -16,6 +16,18 @@
     <artifactId>server</artifactId>
 
     <dependencies>
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-slf4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+        </dependency>
         <!-- dropwizard -->
         <dependency>
             <groupId>io.dropwizard</groupId>
@@ -92,6 +104,10 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-common</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
@@ -194,6 +210,16 @@
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-testing</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.test-framework</groupId>
+            <artifactId>jersey-test-framework-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <!-- just so we have a Main dispatcher for tests -->
+            <artifactId>kotlinx-coroutines-swing</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/server/src/main/kotlin/com/trib3/server/coroutine/AsyncDispatcher.kt
+++ b/server/src/main/kotlin/com/trib3/server/coroutine/AsyncDispatcher.kt
@@ -1,0 +1,10 @@
+package com.trib3.server.coroutine
+
+/**
+ * Annotation that allows explicitly setting the dispatcher for coroutine async jersey resource methods.
+ * [dispatcher] can be any of: "Default", "IO", "Unconfined"
+ * ("Main" supported if a main dispatcher artifact is imported, but generally doesn't apply to a server)
+ */
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class AsyncDispatcher(val dispatcher: String)

--- a/server/src/main/kotlin/com/trib3/server/coroutine/CoroutineInvocationHandler.kt
+++ b/server/src/main/kotlin/com/trib3/server/coroutine/CoroutineInvocationHandler.kt
@@ -1,0 +1,66 @@
+package com.trib3.server.coroutine
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.slf4j.MDCContext
+import org.glassfish.jersey.server.AsyncContext
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Method
+import javax.inject.Provider
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.reflect.full.callSuspend
+import kotlin.reflect.jvm.kotlinFunction
+
+/**
+ * [InvocationHandler] that runs a jersey resource method implemented by a suspend
+ * function in a coroutine, and bridges the return/exception value into an [AsyncContext]
+ * for the request, allowing suspend functions to transparently implement jersey async requests.
+ *
+ * Resource classes/methods annotated with [AsyncDispatcher] can specify which standard coroutine dispatcher
+ * to launch the coroutine with, otherwise defaults to [Dispatchers.Unconfined].
+ * Additionally, if a resource class implements [CoroutineScope], that scope is used to launch the coroutine.
+ */
+class CoroutineInvocationHandler(
+    private val asyncContextProvider: Provider<AsyncContext>,
+    private val originalObject: Any,
+    private val originalMethod: Method
+) : InvocationHandler, CoroutineScope by CoroutineScope(Dispatchers.Unconfined) {
+    override fun invoke(proxy: Any, method: Method, args: Array<out Any>): Any? {
+        val asyncContext = asyncContextProvider.get()
+        if (!asyncContext.suspend()) {
+            throw IllegalStateException("Can't suspend!")
+        }
+        val methodAnnotation = originalMethod.getAnnotation(AsyncDispatcher::class.java)
+        val classAnnotation = originalMethod.declaringClass.getAnnotation(AsyncDispatcher::class.java)
+        val additionalContext = when ((methodAnnotation ?: classAnnotation)?.dispatcher) {
+            "Default" -> Dispatchers.Default
+            "IO" -> Dispatchers.IO
+            "Main" -> Dispatchers.Main
+            "Unconfined" -> Dispatchers.Unconfined
+            else -> EmptyCoroutineContext
+        }
+        val scope = (originalObject as? CoroutineScope) ?: this
+        scope.launch(additionalContext + MDCContext()) {
+            try {
+                val result = originalMethod.kotlinFunction!!.callSuspend(
+                    originalObject,
+                    *args
+                )
+                asyncContext.resume(result)
+            } catch (e: Throwable) {
+                var cause: Throwable? = e
+                while (cause !is CancellationException && cause != null) {
+                    cause = cause.cause
+                }
+                if (cause is CancellationException) {
+                    asyncContext.cancel()
+                } else {
+                    asyncContext.resume(e)
+                }
+            }
+        }
+        return null
+    }
+}

--- a/server/src/main/kotlin/com/trib3/server/coroutine/CoroutineModelProcessor.kt
+++ b/server/src/main/kotlin/com/trib3/server/coroutine/CoroutineModelProcessor.kt
@@ -1,0 +1,110 @@
+package com.trib3.server.coroutine
+
+import net.bytebuddy.ByteBuddy
+import net.bytebuddy.description.modifier.Visibility
+import net.bytebuddy.implementation.InvocationHandlerAdapter
+import org.glassfish.jersey.internal.inject.InjectionManager
+import org.glassfish.jersey.server.AsyncContext
+import org.glassfish.jersey.server.model.ModelProcessor
+import org.glassfish.jersey.server.model.Resource
+import org.glassfish.jersey.server.model.ResourceModel
+import javax.inject.Inject
+import javax.ws.rs.core.Configuration
+import javax.ws.rs.ext.Provider
+import kotlin.coroutines.Continuation
+
+/**
+ * Jersey [ModelProcessor] that finds resource methods that are implemented
+ * with a suspend function, and redefines them with a dynamically created
+ * non-suspend function.  That dynamically created implementation will then
+ * use the [CoroutineInvocationHandler] to invoke the suspend function.
+ */
+@Provider
+class CoroutineModelProcessor @Inject constructor(
+    private val injectionManager: InjectionManager,
+    private val asyncContextProvider: javax.inject.Provider<AsyncContext>
+) : ModelProcessor {
+    /**
+     * Replace any suspend function (ie, function whose last param is a Continuation)
+     * with a dynamically created non-suspend implementation
+     */
+    private fun buildCoroutineReplacedResource(resource: Resource): Resource {
+        val resourceBuilder = Resource.builder(resource)
+        for (method in resource.resourceMethods) {
+            if (
+                method.invocable.parameters.isNotEmpty() &&
+                method.invocable.parameters.last().rawType == Continuation::class.java
+            ) {
+                val injectedInstance = method.invocable.handler.getInstance(injectionManager)
+                val fakeClass = ByteBuddy()
+                    .subclass(Object::class.java)
+                    .annotateType(method.invocable.handler.handlerClass.annotations.toList())
+                    .defineMethod(
+                        method.invocable.handlingMethod.name,
+                        method.invocable.rawResponseType,
+                        Visibility.PUBLIC
+                    )
+                    .withParameters(
+                        method.invocable.parameters
+                            .slice(0 until method.invocable.parameters.size - 1)
+                            .map { it.rawType }
+                    )
+                    .intercept(
+                        InvocationHandlerAdapter.of(
+                            CoroutineInvocationHandler(
+                                asyncContextProvider,
+                                injectedInstance,
+                                method.invocable.handlingMethod
+                            )
+                        )
+                    )
+                    .annotateMethod(method.invocable.handlingMethod.annotations.toList())
+                    // copy the annotations for each parameter in the invocable method
+                    // (except for the last/Continuation param)
+                    .let { fakeMethod ->
+                        method.invocable.handlingMethod.parameterAnnotations
+                            .slice(0 until method.invocable.handlingMethod.parameterAnnotations.size - 1)
+                            .foldIndexed(fakeMethod) { index, annotatedMethod, parameter ->
+                                annotatedMethod.annotateParameter(index, parameter.toList())
+                            }
+                    }
+                    .make()
+                    .load(this::class.java.classLoader)
+                    .loaded
+
+                val proxyInstance = fakeClass.getDeclaredConstructor().newInstance()
+                val handlingMethod =
+                    proxyInstance::class.java.methods.first { it.name == method.invocable.handlingMethod.name }
+                val replacedMethod = resourceBuilder.updateMethod(method)
+                replacedMethod.handledBy(
+                    proxyInstance,
+                    handlingMethod
+                )
+                replacedMethod.handlingMethod(handlingMethod)
+            }
+        }
+        return resourceBuilder.build()
+    }
+
+    /**
+     * Go though every child resource in the resourceModel and replace any coroutine resource methods found
+     */
+    override fun processResourceModel(resourceModel: ResourceModel, configuration: Configuration): ResourceModel {
+        val resourceModelBuilder = ResourceModel.Builder(false)
+        for (resource in resourceModel.resources) {
+            val resourceBuilder = Resource.builder(resource)
+            for (child in resource.childResources) {
+                resourceBuilder.replaceChildResource(child, buildCoroutineReplacedResource(child))
+            }
+            resourceModelBuilder.addResource(resourceBuilder.build())
+        }
+        return resourceModelBuilder.build()
+    }
+
+    /**
+     * Go though every child resource in the subResourceModel and replace any coroutine resource methods found
+     */
+    override fun processSubResource(subResourceModel: ResourceModel, configuration: Configuration): ResourceModel {
+        return processResourceModel(subResourceModel, configuration)
+    }
+}

--- a/server/src/main/kotlin/com/trib3/server/modules/DefaultApplicationModule.kt
+++ b/server/src/main/kotlin/com/trib3/server/modules/DefaultApplicationModule.kt
@@ -10,6 +10,7 @@ import com.trib3.config.modules.KMSModule
 import com.trib3.json.modules.ObjectMapperModule
 import com.trib3.server.config.TribeApplicationConfig
 import com.trib3.server.config.dropwizard.HoconConfigurationFactoryFactory
+import com.trib3.server.coroutine.CoroutineModelProcessor
 import com.trib3.server.filters.RequestIdFilter
 import com.trib3.server.healthchecks.PingHealthCheck
 import com.trib3.server.healthchecks.VersionHealthCheck
@@ -48,8 +49,11 @@ class DefaultApplicationModule : TribeApplicationModule() {
             ServletFilterConfig(RequestIdFilter::class.java.simpleName, RequestIdFilter::class.java)
         )
 
-        // Bind ping and graphql resources
+        // Bind ping resource
         resourceBinder().addBinding().to<PingResource>()
+
+        // Bind coroutine model processor
+        resourceBinder().addBinding().toInstance(CoroutineModelProcessor::class.java)
 
         // set up metrics for guice created instances
         val registry = MetricRegistry()

--- a/server/src/test/kotlin/com/trib3/server/coroutine/CoroutineInvocationHandlerTest.kt
+++ b/server/src/test/kotlin/com/trib3/server/coroutine/CoroutineInvocationHandlerTest.kt
@@ -1,0 +1,307 @@
+package com.trib3.server.coroutine
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.isEqualTo
+import com.trib3.testing.server.JettyWebTestContainerFactory
+import com.trib3.testing.server.ResourceTestBase
+import io.dropwizard.testing.common.Resource
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.yield
+import org.glassfish.jersey.test.spi.TestContainerFactory
+import org.testng.annotations.Test
+import javax.ws.rs.GET
+import javax.ws.rs.POST
+import javax.ws.rs.Path
+import javax.ws.rs.QueryParam
+import javax.ws.rs.client.Entity
+import javax.ws.rs.core.Response
+import kotlin.coroutines.coroutineContext
+
+@OptIn(ExperimentalStdlibApi::class)
+@Path("/")
+class InvocationHandlerTestResource {
+
+    @Path("/regular")
+    @GET
+    fun regularMethod(): String {
+        return "regular"
+    }
+
+    @Path("/regularQ")
+    @GET
+    fun regularQueryParameter(@QueryParam("q") q: String?): String {
+        return "regular$q"
+    }
+
+    @Path("/regular")
+    @POST
+    fun regularPost(body: String): String {
+        return "regular$body"
+    }
+
+    @Path("/coroutine")
+    @GET
+    suspend fun coroutineMethod(): String {
+        if (coroutineContext[CoroutineDispatcher].toString() != "Dispatchers.Unconfined") {
+            throw IllegalStateException("wrong dispatcher ${coroutineContext[CoroutineDispatcher]}")
+        }
+        delay(1)
+        return "coroutine"
+    }
+
+    @Path("/coroutineQ")
+    @GET
+    suspend fun coroutineQueryParameter(@QueryParam("q") q: String?): String {
+        if (coroutineContext[CoroutineDispatcher].toString() != "Dispatchers.Unconfined") {
+            throw IllegalStateException("wrong dispatcher ${coroutineContext[CoroutineDispatcher]}")
+        }
+        delay(1)
+        return "coroutine$q"
+    }
+
+    @Path("/coroutine")
+    @POST
+    suspend fun coroutinePost(body: String): String {
+        if (coroutineContext[CoroutineDispatcher].toString() != "Dispatchers.Unconfined") {
+            throw IllegalStateException("wrong dispatcher ${coroutineContext[CoroutineDispatcher]}")
+        }
+        delay(1)
+        return "coroutine$body"
+    }
+
+    @Path("/coroutineDefault")
+    @GET
+    @AsyncDispatcher("Default")
+    suspend fun coroutineMethodDefaultDispatcher(): String {
+        if (coroutineContext[CoroutineDispatcher].toString() != "Dispatchers.Default") {
+            throw IllegalStateException("wrong dispatcher ${coroutineContext[CoroutineDispatcher]}")
+        }
+        delay(1)
+        return "coroutine"
+    }
+
+    @Path("/coroutineIO")
+    @GET
+    @AsyncDispatcher("IO")
+    suspend fun coroutineMethodDefaultIO(): String {
+        if (coroutineContext[CoroutineDispatcher].toString() != "Dispatchers.IO") {
+            throw IllegalStateException("wrong dispatcher ${coroutineContext[CoroutineDispatcher]}")
+        }
+        delay(1)
+        return "coroutine"
+    }
+
+    @Path("/coroutineMain")
+    @GET
+    @AsyncDispatcher("Main")
+    suspend fun coroutineMethodDefaultMain(): String {
+        if (coroutineContext[CoroutineDispatcher].toString() != "Dispatchers.Main") {
+            throw IllegalStateException("wrong dispatcher ${coroutineContext[CoroutineDispatcher]}")
+        }
+        delay(1)
+        return "coroutine"
+    }
+
+    @Path("/coroutineUnconfined")
+    @GET
+    @AsyncDispatcher("Unconfined")
+    suspend fun coroutineMethodDefaultUnconfined(): String {
+        if (coroutineContext[CoroutineDispatcher].toString() != "Dispatchers.Unconfined") {
+            throw IllegalStateException("wrong dispatcher ${coroutineContext[CoroutineDispatcher]}")
+        }
+        delay(1)
+        return "coroutine"
+    }
+
+    @Path("/coroutineException")
+    @GET
+    suspend fun coroutineMethodException(): String {
+        delay(1)
+        throw IllegalStateException("Bad implementation")
+    }
+
+    @Path("/coroutineCancelled")
+    @GET
+    suspend fun coroutineMethodCancelled(): String {
+        coroutineContext.cancel()
+        yield()
+        return "coroutine"
+    }
+}
+
+@OptIn(ExperimentalStdlibApi::class)
+@Path("/")
+@AsyncDispatcher("Default")
+class InvocationHandlerClassAnnotationTestResource {
+    @Path("/coroutineClassAnnotationDefault")
+    @GET
+    suspend fun coroutineMethodDefaultDispatcher(): String {
+        if (coroutineContext[CoroutineDispatcher].toString() != "Dispatchers.Default") {
+            throw IllegalStateException("wrong dispatcher ${coroutineContext[CoroutineDispatcher]}")
+        }
+        delay(1)
+        return "coroutineAnnotation"
+    }
+}
+
+@OptIn(ExperimentalStdlibApi::class)
+@Path("/")
+class InvocationHandlerClassScopeTestResource : CoroutineScope by CoroutineScope(Dispatchers.Default) {
+    @Path("/coroutineClassScopeDefault")
+    @GET
+    suspend fun coroutineMethodDefaultDispatcher(): String {
+        if (coroutineContext[CoroutineDispatcher].toString() != "Dispatchers.Default") {
+            throw IllegalStateException("wrong dispatcher ${coroutineContext[CoroutineDispatcher]}")
+        }
+        delay(1)
+        return "coroutineScope"
+    }
+}
+
+class CoroutineInvocationHandlerTest : ResourceTestBase<InvocationHandlerTestResource>() {
+    override fun getResource() = InvocationHandlerTestResource()
+
+    override fun getContainerFactory(): TestContainerFactory {
+        return JettyWebTestContainerFactory()
+    }
+
+    override fun buildAdditionalResources(resourceBuilder: Resource.Builder<*>) {
+        resourceBuilder.addResource(CoroutineModelProcessor::class.java)
+            .addResource(InvocationHandlerClassScopeTestResource())
+            .addResource(InvocationHandlerClassAnnotationTestResource())
+    }
+
+    @Test
+    fun testCoroutineMethod() {
+        val ping = resource.target("/coroutine").request().get()
+        assertThat(ping.status).isEqualTo(Response.Status.OK.statusCode)
+        assertThat(ping.readEntity(String::class.java)).isEqualTo("coroutine")
+    }
+
+    @Test
+    fun testRegularQueryParameter() {
+        val ping = resource.target("/regularQ").queryParam("q", "123").request().get()
+        assertThat(ping.status).isEqualTo(Response.Status.OK.statusCode)
+        assertThat(ping.readEntity(String::class.java)).isEqualTo("regular123")
+    }
+
+    @Test
+    fun testRegularQueryParameterNull() {
+        val ping = resource.target("/regularQ").request().get()
+        assertThat(ping.status).isEqualTo(Response.Status.OK.statusCode)
+        assertThat(ping.readEntity(String::class.java)).isEqualTo("regularnull")
+    }
+
+    @Test
+    fun testCoroutineQueryParameter() {
+        val ping = resource.target("/coroutineQ").queryParam("q", "123").request().get()
+        assertThat(ping.status).isEqualTo(Response.Status.OK.statusCode)
+        assertThat(ping.readEntity(String::class.java)).isEqualTo("coroutine123")
+    }
+
+    @Test
+    fun testCoroutineQueryParameterNull() {
+        val ping = resource.target("/coroutineQ").request().get()
+        assertThat(ping.status).isEqualTo(Response.Status.OK.statusCode)
+        assertThat(ping.readEntity(String::class.java)).isEqualTo("coroutinenull")
+    }
+
+    @Test
+    fun testRegularMethod() {
+        val ping = resource.target("/regular").request().get()
+        assertThat(ping.status).isEqualTo(Response.Status.OK.statusCode)
+        assertThat(ping.readEntity(String::class.java)).isEqualTo("regular")
+    }
+
+    @Test
+    fun testRegularPost() {
+        val ping = resource.target("/regular").request().post(Entity.entity("PostedBody", "text/plain"))
+        assertThat(ping.status).isEqualTo(Response.Status.OK.statusCode)
+        assertThat(ping.readEntity(String::class.java)).isEqualTo("regularPostedBody")
+    }
+
+    @Test
+    fun testCoroutinePost() {
+        val ping = resource.target("/coroutine").request().post(Entity.entity("PostedBody", "text/plain"))
+        assertThat(ping.status).isEqualTo(Response.Status.OK.statusCode)
+        assertThat(ping.readEntity(String::class.java)).isEqualTo("coroutinePostedBody")
+    }
+
+    @Test
+    fun testCoroutineMethodIODispatcher() {
+        val ping = resource.target("/coroutineIO").request().get()
+        assertThat(ping.status).isEqualTo(Response.Status.OK.statusCode)
+        assertThat(ping.readEntity(String::class.java)).isEqualTo("coroutine")
+    }
+
+    @Test
+    fun testCoroutineMethodMainDispatcher() {
+        val ping = resource.target("/coroutineMain").request().get()
+        assertThat(ping.status).isEqualTo(Response.Status.OK.statusCode)
+        assertThat(ping.readEntity(String::class.java)).isEqualTo("coroutine")
+    }
+
+    @Test
+    fun testCoroutineMethodUnconfinedDispatcher() {
+        val ping = resource.target("/coroutineUnconfined").request().get()
+        assertThat(ping.status).isEqualTo(Response.Status.OK.statusCode)
+        assertThat(ping.readEntity(String::class.java)).isEqualTo("coroutine")
+    }
+
+    @Test
+    fun testCoroutineMethodDefaultDispatcher() {
+        val ping = resource.target("/coroutineDefault").request().get()
+        assertThat(ping.status).isEqualTo(Response.Status.OK.statusCode)
+        assertThat(ping.readEntity(String::class.java)).isEqualTo("coroutine")
+    }
+
+    @Test
+    fun testCoroutineMethodClassAnnotationDefaultDispatcher() {
+        val ping = resource.target("/coroutineClassAnnotationDefault").request().get()
+        assertThat(ping.status).isEqualTo(Response.Status.OK.statusCode)
+        assertThat(ping.readEntity(String::class.java)).isEqualTo("coroutineAnnotation")
+    }
+
+    @Test
+    fun testCoroutineMethodClassScopeDefaultDispatcher() {
+        val ping = resource.target("/coroutineClassScopeDefault").request().get()
+        assertThat(ping.status).isEqualTo(Response.Status.OK.statusCode)
+        assertThat(ping.readEntity(String::class.java)).isEqualTo("coroutineScope")
+    }
+
+    @Test
+    fun testCoroutineMethodException() {
+        val ping = resource.target("/coroutineException").request().get()
+        assertThat(ping.status).isEqualTo(Response.Status.INTERNAL_SERVER_ERROR.statusCode)
+        assertThat(ping.readEntity(String::class.java)).contains("There was an error processing your request")
+    }
+
+    @Test
+    fun testCoroutineMethodCancel() {
+        val ping = resource.target("/coroutineCancelled").request().get()
+        assertThat(ping.status).isEqualTo(Response.Status.SERVICE_UNAVAILABLE.statusCode)
+    }
+}
+
+/**
+ * Separate test with in memory container which doesn't support async resources methods
+ * in order to test failure case
+ */
+class CoroutineInvocationHandlerCantSuspendTest : ResourceTestBase<InvocationHandlerTestResource>() {
+    override fun getResource() = InvocationHandlerTestResource()
+
+    override fun buildAdditionalResources(resourceBuilder: Resource.Builder<*>) {
+        resourceBuilder.addResource(CoroutineModelProcessor::class.java)
+    }
+
+    @Test
+    fun testCantSuspend() {
+        val ping = resource.target("/coroutine").request().get()
+        assertThat(ping.status).isEqualTo(Response.Status.INTERNAL_SERVER_ERROR.statusCode)
+    }
+}

--- a/server/src/test/kotlin/com/trib3/server/coroutine/CoroutineModelProcessorTest.kt
+++ b/server/src/test/kotlin/com/trib3/server/coroutine/CoroutineModelProcessorTest.kt
@@ -1,0 +1,85 @@
+package com.trib3.server.coroutine
+
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
+import com.trib3.testing.LeakyMock
+import kotlinx.coroutines.delay
+import org.easymock.EasyMock
+import org.glassfish.jersey.internal.inject.InjectionManager
+import org.glassfish.jersey.server.AsyncContext
+import org.glassfish.jersey.server.ResourceConfig
+import org.glassfish.jersey.server.model.Resource
+import org.glassfish.jersey.server.model.ResourceModel
+import org.testng.annotations.Test
+import javax.inject.Provider
+import javax.ws.rs.GET
+import javax.ws.rs.Path
+
+@Path("/")
+class ProcessorTestResource {
+    @GET
+    @Path("/simple")
+    fun simpleMethod(): String {
+        return "simple"
+    }
+
+    @GET
+    @Path("/coroutine")
+    suspend fun coroutineMethod(): String {
+        delay(1)
+        return "coroutine"
+    }
+}
+
+class CoroutineModelProcessorTest {
+    @Test
+    fun testBuildResource() {
+        val mockInjector = LeakyMock.mock<InjectionManager>()
+        val mockAsyncProvider = LeakyMock.mock<Provider<AsyncContext>>()
+        EasyMock.expect(mockInjector.getInstance(ProcessorTestResource::class.java)).andReturn(ProcessorTestResource())
+        EasyMock.replay(mockInjector, mockAsyncProvider)
+        val resourceModel = ResourceModel.Builder(
+            listOf(
+                Resource.builder(ProcessorTestResource::class.java).build()
+            ),
+            false
+        ).build()
+        val builtResource =
+            CoroutineModelProcessor(mockInjector, mockAsyncProvider).processResourceModel(
+                resourceModel,
+                ResourceConfig()
+            )
+        assertThat(builtResource.resources).hasSize(1)
+        for (childResource in builtResource.resources[0].childResources) {
+            for (method in childResource.resourceMethods) {
+                assertThat(method.invocable.parameters).isEmpty()
+            }
+        }
+    }
+
+    @Test
+    fun testBuildSubResource() {
+        val mockInjector = LeakyMock.mock<InjectionManager>()
+        val mockAsyncProvider = LeakyMock.mock<Provider<AsyncContext>>()
+        EasyMock.expect(mockInjector.getInstance(ProcessorTestResource::class.java)).andReturn(ProcessorTestResource())
+        EasyMock.replay(mockInjector, mockAsyncProvider)
+        val resourceModel = ResourceModel.Builder(
+            listOf(
+                Resource.builder(ProcessorTestResource::class.java).build()
+            ),
+            true
+        ).build()
+        val builtResource =
+            CoroutineModelProcessor(mockInjector, mockAsyncProvider).processSubResource(
+                resourceModel,
+                ResourceConfig()
+            )
+        assertThat(builtResource.resources).hasSize(1)
+        for (childResource in builtResource.resources[0].childResources) {
+            for (method in childResource.resourceMethods) {
+                assertThat(method.invocable.parameters).isEmpty()
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add a jersey ModelProcessor that transforms resource
methods implemented by suspend functions into a
non-suspend dynamically created function, which calls
the original suspend function and resumes an AsyncContext
with the result/exception of the coroutine.  Results in
suspend functions being supported transparently, with
an optional @AsyncDispatcher annotation to allow users
to specify which dispatcher to run the suspend function on.

h/t https://github.com/alex-shpak/rx-jersey for inspiration