### PR TITLE
Fix coroutine jersey bugs with generics and AOP

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -66,6 +66,10 @@
             <artifactId>metrics-healthchecks</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-annotation</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>

--- a/server/src/test/kotlin/com/trib3/server/coroutine/CoroutineModelProcessorTest.kt
+++ b/server/src/test/kotlin/com/trib3/server/coroutine/CoroutineModelProcessorTest.kt
@@ -3,6 +3,7 @@ package com.trib3.server.coroutine
 import assertk.assertThat
 import assertk.assertions.hasSize
 import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
 import com.trib3.testing.LeakyMock
 import kotlinx.coroutines.delay
 import org.easymock.EasyMock
@@ -12,9 +13,11 @@ import org.glassfish.jersey.server.ResourceConfig
 import org.glassfish.jersey.server.model.Resource
 import org.glassfish.jersey.server.model.ResourceModel
 import org.testng.annotations.Test
+import java.util.Optional
 import javax.inject.Provider
 import javax.ws.rs.GET
 import javax.ws.rs.Path
+import javax.ws.rs.QueryParam
 
 @Path("/")
 class ProcessorTestResource {
@@ -26,9 +29,9 @@ class ProcessorTestResource {
 
     @GET
     @Path("/coroutine")
-    suspend fun coroutineMethod(): String {
+    suspend fun coroutineMethod(@QueryParam("a") a: Optional<String>): String {
         delay(1)
-        return "coroutine"
+        return "coroutine${a.orElse("null")}"
     }
 }
 
@@ -53,7 +56,15 @@ class CoroutineModelProcessorTest {
         assertThat(builtResource.resources).hasSize(1)
         for (childResource in builtResource.resources[0].childResources) {
             for (method in childResource.resourceMethods) {
-                assertThat(method.invocable.parameters).isEmpty()
+                if (method.invocable.handlingMethod.name == "coroutineMethod") {
+                    assertThat(method.invocable.parameters).hasSize(1)
+                    assertThat(method.invocable.parameters[0].getAnnotation(QueryParam::class.java).value)
+                        .isEqualTo("a")
+                    assertThat(method.invocable.parameters[0].type.typeName)
+                        .isEqualTo("java.util.Optional<java.lang.String>")
+                } else {
+                    assertThat(method.invocable.parameters).isEmpty()
+                }
             }
         }
     }
@@ -78,7 +89,15 @@ class CoroutineModelProcessorTest {
         assertThat(builtResource.resources).hasSize(1)
         for (childResource in builtResource.resources[0].childResources) {
             for (method in childResource.resourceMethods) {
-                assertThat(method.invocable.parameters).isEmpty()
+                if (method.invocable.handlingMethod.name == "coroutineMethod") {
+                    assertThat(method.invocable.parameters).hasSize(1)
+                    assertThat(method.invocable.parameters[0].getAnnotation(QueryParam::class.java).value)
+                        .isEqualTo("a")
+                    assertThat(method.invocable.parameters[0].type.typeName)
+                        .isEqualTo("java.util.Optional<java.lang.String>")
+                } else {
+                    assertThat(method.invocable.parameters).isEmpty()
+                }
             }
         }
     }

--- a/testing/src/main/kotlin/com/trib3/testing/server/ResourceTestBase.kt
+++ b/testing/src/main/kotlin/com/trib3/testing/server/ResourceTestBase.kt
@@ -30,6 +30,11 @@ abstract class ResourceTestBase<T> {
     val resource: Resource by lazy {
         val resourceBuilder = Builder()
         resourceBuilder.setTestContainerFactory(getContainerFactory())
+        // try to add the CoroutineModelProcessor without directly depending on the server jar
+        runCatching {
+            val modelProcessor = Class.forName("com.trib3.server.coroutine.CoroutineModelProcessor")
+            resourceBuilder.addResource(modelProcessor)
+        }
         resourceBuilder.addResource(getResource())
         buildAdditionalResources(resourceBuilder)
         System.setProperty("jersey.config.test.container.port", "0")


### PR DESCRIPTION
When a resource is wrapped in an AOP dynamic subclass,
grab annotations from the definitionMethod instead of
the handlingMethod, and work around a reflection issue
by using `call(*args, continuation)` instead of
`callSuspending(*args)`.

Also use `type` instead of `rawType` to define method
parameters so that we don't lose generic type parameter
information.