### PR TITLE
Cancellable async GraphQL execution

### DIFF
--- a/build-resources/pom.xml
+++ b/build-resources/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.trib3</groupId>
     <artifactId>build-resources</artifactId>
-    <version>1.13-SNAPSHOT</version>
+    <version>1.14-SNAPSHOT</version>
 
     <name>Build Resources</name>
     <description>Resources for use during the build process</description>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.13-SNAPSHOT</version>
+        <version>1.14-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.13-SNAPSHOT</version>
+        <version>1.14-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/graphql/pom.xml
+++ b/graphql/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.13-SNAPSHOT</version>
+        <version>1.14-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -78,6 +78,10 @@
         <dependency>
             <groupId>org.jetbrains.kotlinx</groupId>
             <artifactId>kotlinx-coroutines-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-jdk8</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlinx</groupId>

--- a/graphql/src/main/kotlin/com/trib3/graphql/execution/ContextScopeFunctionDataFetcher.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/execution/ContextScopeFunctionDataFetcher.kt
@@ -1,0 +1,79 @@
+package com.trib3.graphql.execution
+
+import com.expediagroup.graphql.execution.FunctionDataFetcher
+import com.expediagroup.graphql.execution.SimpleKotlinDataFetcherFactoryProvider
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import graphql.schema.DataFetcherFactory
+import graphql.schema.DataFetchingEnvironment
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.future.future
+import java.lang.reflect.InvocationTargetException
+import java.util.concurrent.CompletableFuture
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.reflect.KFunction
+import kotlin.reflect.full.callSuspend
+
+/**
+ * [SimpleKotlinDataFetcherFactoryProvider] subclass that provides a
+ * [ContextScopeFunctionDataFetcher] to allow for structured concurrency
+ * based on the scope in the GraphQL context.
+ */
+open class ContextScopeKotlinDataFetcherFactoryProvider(
+    private val objectMapper: ObjectMapper = jacksonObjectMapper()
+) : SimpleKotlinDataFetcherFactoryProvider(objectMapper) {
+
+    override fun functionDataFetcherFactory(target: Any?, kFunction: KFunction<*>) = DataFetcherFactory {
+        ContextScopeFunctionDataFetcher(
+            target = target,
+            fn = kFunction,
+            objectMapper = objectMapper
+        )
+    }
+}
+
+/**
+ * [FunctionDataFetcher] that tries to run suspend functions
+ * in a [CoroutineScope] provided by the [DataFetchingEnvironment.getContext],
+ * if the context is a [CoroutineScope].  Otherwise runs in [GlobalScope] like
+ * [FunctionDataFetcher].
+ */
+open class ContextScopeFunctionDataFetcher(
+    private val target: Any?,
+    private val fn: KFunction<*>,
+    objectMapper: ObjectMapper = jacksonObjectMapper()
+) : FunctionDataFetcher(target, fn, objectMapper) {
+    override fun get(environment: DataFetchingEnvironment): Any? {
+        val instance: Any? = target ?: environment.getSource()
+
+        return instance?.let {
+            val parameterValues = getParameterValues(fn, environment)
+
+            if (fn.isSuspend) {
+                val scope = (environment.getContext<Any?>() as? CoroutineScope) ?: GlobalScope
+                runScopedSuspendingFunction(it, parameterValues, scope)
+            } else {
+                runBlockingFunction(it, parameterValues)
+            }
+        }
+    }
+
+    protected open fun runScopedSuspendingFunction(
+        instance: Any,
+        parameterValues: Array<Any?>,
+        scope: CoroutineScope,
+        coroutineContext: CoroutineContext = EmptyCoroutineContext,
+        coroutineStart: CoroutineStart = CoroutineStart.DEFAULT
+    ): CompletableFuture<Any?> {
+        return scope.future(coroutineContext, coroutineStart) {
+            try {
+                fn.callSuspend(instance, *parameterValues)
+            } catch (exception: InvocationTargetException) {
+                throw exception.cause ?: exception
+            }
+        }
+    }
+}

--- a/graphql/src/main/kotlin/com/trib3/graphql/modules/DefaultGraphQLModule.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/modules/DefaultGraphQLModule.kt
@@ -3,12 +3,12 @@ package com.trib3.graphql.modules
 import com.expediagroup.graphql.SchemaGeneratorConfig
 import com.expediagroup.graphql.TopLevelObject
 import com.expediagroup.graphql.execution.FlowSubscriptionExecutionStrategy
-import com.expediagroup.graphql.execution.SimpleKotlinDataFetcherFactoryProvider
 import com.expediagroup.graphql.toSchema
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.inject.Provides
 import com.google.inject.multibindings.MapBinder
 import com.google.inject.name.Names
+import com.trib3.graphql.execution.ContextScopeKotlinDataFetcherFactoryProvider
 import com.trib3.graphql.execution.CustomDataFetcherExceptionHandler
 import com.trib3.graphql.execution.JsonSafeExecutionResultMixin
 import com.trib3.graphql.execution.LeakyCauldronHooks
@@ -88,7 +88,7 @@ class DefaultGraphQLModule : GraphQLApplicationModule() {
         val config = SchemaGeneratorConfig(
             graphQLPackages.toList(),
             hooks = hooks,
-            dataFetcherFactoryProvider = SimpleKotlinDataFetcherFactoryProvider(mapper)
+            dataFetcherFactoryProvider = ContextScopeKotlinDataFetcherFactoryProvider(mapper)
         )
         return GraphQL.newGraphQL(
             toSchema(

--- a/graphql/src/test/kotlin/com/trib3/graphql/execution/ContextScopeFunctionDataFetcherTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/execution/ContextScopeFunctionDataFetcherTest.kt
@@ -1,0 +1,141 @@
+package com.trib3.graphql.execution
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.fail
+import com.trib3.graphql.resources.GraphQLResourceContext
+import com.trib3.testing.LeakyMock
+import graphql.schema.DataFetchingEnvironment
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.supervisorScope
+import org.easymock.EasyMock
+import org.testng.annotations.Test
+import java.lang.reflect.InvocationTargetException
+import java.util.concurrent.CompletableFuture
+
+class ContextScopeQuery {
+    suspend fun coroutine(): String {
+        delay(100)
+        return "coroutine"
+    }
+
+    suspend fun coroutineException(): String {
+        delay(1)
+        throw InvocationTargetException(IllegalStateException("boom"))
+    }
+
+    suspend fun coroutineExceptionNoCause(): String {
+        delay(1)
+        throw InvocationTargetException(null, "boom")
+    }
+}
+
+class ContextScopeFunctionDataFetcherTest {
+
+    @Test
+    fun testNoTarget() {
+        val fetcher = ContextScopeFunctionDataFetcher(null, ContextScopeQuery::coroutine)
+        val mockEnv = LeakyMock.mock<DataFetchingEnvironment>()
+        EasyMock.expect(mockEnv.getContext<GraphQLResourceContext>()).andReturn(null)
+        EasyMock.expect(mockEnv.getSource<Any?>()).andReturn(null)
+        EasyMock.replay(mockEnv)
+        assertThat(fetcher.get(mockEnv)).isNull()
+    }
+
+    @Test
+    fun testNoScopeSuccess() = runBlocking {
+        val fetcher = ContextScopeFunctionDataFetcher(ContextScopeQuery(), ContextScopeQuery::coroutine)
+        val mockEnv = LeakyMock.mock<DataFetchingEnvironment>()
+        EasyMock.expect(mockEnv.getContext<GraphQLResourceContext>()).andReturn(null)
+        EasyMock.replay(mockEnv)
+        val future = fetcher.get(mockEnv) as CompletableFuture<*>
+        assertThat(future.await()).isEqualTo("coroutine")
+    }
+
+    @Test
+    fun testNoScopeError() = runBlocking {
+        val fetcher = ContextScopeFunctionDataFetcher(ContextScopeQuery(), ContextScopeQuery::coroutineExceptionNoCause)
+        val mockEnv = LeakyMock.mock<DataFetchingEnvironment>()
+        EasyMock.expect(mockEnv.getContext<GraphQLResourceContext>()).andReturn(null)
+        EasyMock.replay(mockEnv)
+        val future = fetcher.get(mockEnv) as CompletableFuture<*>
+        try {
+            future.await()
+            fail("Should not get here")
+        } catch (e: Exception) {
+            assertThat(e.message).isEqualTo("boom")
+        }
+    }
+
+    @Test
+    fun testNoScopeCancel() = runBlocking {
+        val fetcher = ContextScopeFunctionDataFetcher(ContextScopeQuery(), ContextScopeQuery::coroutine)
+        val mockEnv = LeakyMock.mock<DataFetchingEnvironment>()
+        EasyMock.expect(mockEnv.getContext<GraphQLResourceContext>()).andReturn(null)
+        EasyMock.replay(mockEnv)
+        val scope = this
+        val future = fetcher.get(mockEnv) as CompletableFuture<*>
+        launch {
+            scope.coroutineContext[Job]?.cancelChildren()
+        }
+        assertThat(future.await()).isEqualTo("coroutine")
+    }
+
+    @Test
+    fun testScopeSuccess() = runBlocking {
+        val scope = this
+        val fetcher = ContextScopeFunctionDataFetcher(ContextScopeQuery(), ContextScopeQuery::coroutine)
+        val mockEnv = LeakyMock.mock<DataFetchingEnvironment>()
+        EasyMock.expect(mockEnv.getContext<GraphQLResourceContext>()).andReturn(GraphQLResourceContext(null, scope))
+        EasyMock.replay(mockEnv)
+        val future = fetcher.get(mockEnv) as CompletableFuture<*>
+        assertThat(future.await()).isEqualTo("coroutine")
+    }
+
+    @Test
+    fun testScopeError() = runBlocking {
+        supervisorScope {
+            val scope = this
+            val fetcher = ContextScopeFunctionDataFetcher(ContextScopeQuery(), ContextScopeQuery::coroutineException)
+            val mockEnv = LeakyMock.mock<DataFetchingEnvironment>()
+            EasyMock.expect(mockEnv.getContext<GraphQLResourceContext>()).andReturn(GraphQLResourceContext(null, scope))
+            EasyMock.replay(mockEnv)
+            val future = fetcher.get(mockEnv) as CompletableFuture<*>
+            try {
+                future.await()
+                fail("Should not get here")
+            } catch (e: Exception) {
+                assertThat(e.message).isEqualTo("boom")
+            }
+        }
+    }
+
+    @Test
+    fun testScopeCancel() = runBlocking<Unit> {
+        supervisorScope {
+            val scope = this
+            val fetcher = ContextScopeFunctionDataFetcher(ContextScopeQuery(), ContextScopeQuery::coroutine)
+            val mockEnv = LeakyMock.mock<DataFetchingEnvironment>()
+            EasyMock.expect(mockEnv.getContext<GraphQLResourceContext>()).andReturn(GraphQLResourceContext(null, scope))
+            EasyMock.replay(mockEnv)
+            val future = fetcher.get(mockEnv) as CompletableFuture<*>
+            launch {
+                scope.coroutineContext[Job]?.cancelChildren()
+            }
+            try {
+                future.await()
+                fail("Should not get here")
+            } catch (e: Exception) {
+                assertThat(e.message).isNotNull().contains("was cancelled")
+            }
+        }
+    }
+}

--- a/graphql/src/test/kotlin/com/trib3/graphql/resources/GraphQLResourceTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/resources/GraphQLResourceTest.kt
@@ -4,8 +4,13 @@ import assertk.assertThat
 import assertk.assertions.contains
 import assertk.assertions.doesNotContain
 import assertk.assertions.hasRootCause
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
+import assertk.assertions.isNull
+import assertk.assertions.isSuccess
+import assertk.assertions.isTrue
 import assertk.assertions.prop
 import com.coxautodev.graphql.tools.GraphQLQueryResolver
 import com.expediagroup.graphql.SchemaGeneratorConfig
@@ -15,19 +20,30 @@ import com.expediagroup.graphql.toSchema
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.trib3.config.ConfigLoader
 import com.trib3.graphql.GraphQLConfig
+import com.trib3.graphql.execution.ContextScopeKotlinDataFetcherFactoryProvider
 import com.trib3.graphql.execution.CustomDataFetcherExceptionHandler
 import com.trib3.graphql.execution.GraphQLRequest
 import com.trib3.graphql.execution.RequestIdInstrumentation
 import com.trib3.graphql.execution.SanitizedGraphQLError
 import com.trib3.graphql.websocket.GraphQLContextWebSocketCreatorFactory
 import com.trib3.json.ObjectMapperProvider
+import com.trib3.server.filters.RequestIdFilter
+import com.trib3.testing.LeakyMock
 import graphql.ExecutionResult
 import graphql.GraphQL
 import graphql.GraphQLError
 import graphql.execution.AsyncExecutionStrategy
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.easymock.EasyMock
 import org.eclipse.jetty.websocket.servlet.WebSocketCreator
 import org.testng.annotations.Test
 import java.util.Optional
+import java.util.UUID
+import kotlin.coroutines.CoroutineContext
 
 class TestQuery : GraphQLQueryResolver {
     fun test(value: String): String {
@@ -41,6 +57,11 @@ class TestQuery : GraphQLQueryResolver {
     fun unknownError(): String {
         throw IllegalArgumentException()
     }
+
+    suspend fun cancellable(): String {
+        delay(100)
+        return "result"
+    }
 }
 
 class GraphQLResourceTest {
@@ -49,7 +70,8 @@ class GraphQLResourceTest {
             GraphQL.newGraphQL(
                 toSchema(
                     SchemaGeneratorConfig(
-                        listOf(this::class.java.packageName)
+                        listOf(this::class.java.packageName),
+                        dataFetcherFactoryProvider = ContextScopeKotlinDataFetcherFactoryProvider()
                     ),
                     listOf(TopLevelObject(TestQuery())),
                     listOf(),
@@ -76,14 +98,14 @@ class GraphQLResourceTest {
     }
 
     @Test
-    fun testSimpleQuery() {
+    fun testSimpleQuery() = runBlocking {
         val result = resource.graphQL(Optional.empty(), GraphQLRequest("query {test(value:\"123\")}", null, null))
         val graphQLResult = result.entity as ExecutionResult
         assertThat(graphQLResult.getData<Map<String, String>>()["test"]).isEqualTo("123")
     }
 
     @Test
-    fun testVariablesQuery() {
+    fun testVariablesQuery() = runBlocking {
         val result = resource.graphQL(
             Optional.empty(),
             GraphQLRequest(
@@ -97,7 +119,7 @@ class GraphQLResourceTest {
     }
 
     @Test
-    fun testErrorQuery() {
+    fun testErrorQuery() = runBlocking {
         val result = resource.graphQL(Optional.empty(), GraphQLRequest("query {error}", mapOf(), null))
         val graphQLResult = result.entity as ExecutionResult
         assertThat(graphQLResult.errors.first()).prop("message", GraphQLError::getMessage)
@@ -110,12 +132,70 @@ class GraphQLResourceTest {
     }
 
     @Test
-    fun testUnknownErrorQuery() {
+    fun testUnknownErrorQuery() = runBlocking {
         val result = resource.graphQL(Optional.empty(), GraphQLRequest("query {unknownError}", mapOf(), null))
         val graphQLResult = result.entity as ExecutionResult
         assertThat(graphQLResult.errors.first()).prop("message", GraphQLError::getMessage)
             .contains("Exception while fetching data")
         val serializedError = objectMapper.writeValueAsString(graphQLResult.errors.first())
         assertThat(objectMapper.readValue<Map<String, *>>(serializedError).keys).doesNotContain("exception")
+    }
+
+    @Test
+    fun testCancellableQuery() = runBlocking {
+        var reached = false
+        val requestId = UUID.randomUUID().toString()
+        val job = launch {
+            RequestIdFilter.withRequestId(requestId) {
+                val result = resource.graphQL(Optional.empty(), GraphQLRequest("query {cancellable}", mapOf(), null))
+                val entity = result.entity as ExecutionResult
+                assertThat(entity.getData<Any>()).isNull()
+                assertThat(entity.errors).hasSize(1)
+                assertThat(entity.errors[0].message).contains("was cancelled")
+                assertThat(entity.extensions["RequestId"]).isEqualTo(requestId)
+                reached = true
+            }
+        }
+        while (resource.runningFutures[requestId] == null) {
+            delay(1)
+        }
+        resource.cancel(requestId)
+        job.join()
+        assertThat(reached).isTrue()
+    }
+
+    @Test
+    fun testCancellableQueryCompletes() = runBlocking {
+        var reached = false
+        val requestId = UUID.randomUUID().toString()
+        val job = launch {
+            RequestIdFilter.withRequestId(requestId) {
+                val result = resource.graphQL(Optional.empty(), GraphQLRequest("query {cancellable}", mapOf(), null))
+                val entity = result.entity as ExecutionResult
+                assertThat(entity.getData<Map<String, String>>()["cancellable"]).isEqualTo("result")
+                assertThat(entity.errors).isEmpty()
+                assertThat(entity.extensions["RequestId"]).isEqualTo(requestId)
+                reached = true
+            }
+        }
+        while (resource.runningFutures[requestId] == null) {
+            delay(1)
+        }
+        resource.cancel("123")
+        job.join()
+        assertThat(reached).isTrue()
+    }
+
+    @Test
+    fun testCancellableJoblessContext() {
+        val mockScope = LeakyMock.mock<CoroutineScope>()
+        val mockContext = LeakyMock.mock<CoroutineContext>()
+        EasyMock.expect(mockScope.coroutineContext).andReturn(mockContext).anyTimes()
+        EasyMock.expect(mockContext[Job]).andReturn(null).anyTimes()
+        EasyMock.replay(mockScope, mockContext)
+        resource.runningFutures["987"] = mockScope
+        assertThat {
+            resource.cancel("987")
+        }.isSuccess()
     }
 }

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.13-SNAPSHOT</version>
+        <version>1.14-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/lambda/pom.xml
+++ b/lambda/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.13-SNAPSHOT</version>
+        <version>1.14-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.trib3</groupId>
     <artifactId>parent-pom</artifactId>
-    <version>1.13-SNAPSHOT</version>
+    <version>1.14-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Trib3 parent pom</name>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>1.13-SNAPSHOT</version>
+        <version>1.14-SNAPSHOT</version>
         <relativePath>parent-pom/pom.xml</relativePath>
     </parent>
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.13-SNAPSHOT</version>
+        <version>1.14-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -218,6 +218,11 @@
         <dependency>
             <groupId>org.glassfish.jersey.test-framework</groupId>
             <artifactId>jersey-test-framework-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.test-framework.providers</groupId>
+            <artifactId>jersey-test-framework-provider-inmemory</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlinx</groupId>

--- a/server/src/test/kotlin/com/trib3/server/coroutine/CoroutineInvocationHandlerTest.kt
+++ b/server/src/test/kotlin/com/trib3/server/coroutine/CoroutineInvocationHandlerTest.kt
@@ -7,7 +7,6 @@ import com.codahale.metrics.MetricRegistry
 import com.codahale.metrics.annotation.Timed
 import com.google.inject.Guice
 import com.palominolabs.metrics.guice.MetricsInstrumentationModule
-import com.trib3.testing.server.JettyWebTestContainerFactory
 import com.trib3.testing.server.ResourceTestBase
 import dev.misfitlabs.kotlinguice4.KotlinModule
 import dev.misfitlabs.kotlinguice4.getInstance
@@ -18,6 +17,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.yield
+import org.glassfish.jersey.test.inmemory.InMemoryTestContainerFactory
 import org.glassfish.jersey.test.spi.TestContainerFactory
 import org.testng.annotations.Test
 import java.util.Optional
@@ -208,10 +208,6 @@ class CoroutineInvocationHandlerTest : ResourceTestBase<InvocationHandlerTestRes
         return injector.getInstance()
     }
 
-    override fun getContainerFactory(): TestContainerFactory {
-        return JettyWebTestContainerFactory()
-    }
-
     override fun buildAdditionalResources(resourceBuilder: Resource.Builder<*>) {
         resourceBuilder.addResource(CoroutineModelProcessor::class.java)
             .addResource(InvocationHandlerClassScopeTestResource::class.java)
@@ -353,6 +349,10 @@ class CoroutineInvocationHandlerCantSuspendTest : ResourceTestBase<InvocationHan
 
     override fun buildAdditionalResources(resourceBuilder: Resource.Builder<*>) {
         resourceBuilder.addResource(CoroutineModelProcessor::class.java)
+    }
+
+    override fun getContainerFactory(): TestContainerFactory {
+        return InMemoryTestContainerFactory()
     }
 
     @Test

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.13-SNAPSHOT</version>
+        <version>1.14-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/testing/src/main/kotlin/com/trib3/testing/server/ResourceTestBase.kt
+++ b/testing/src/main/kotlin/com/trib3/testing/server/ResourceTestBase.kt
@@ -3,7 +3,6 @@ package com.trib3.testing.server
 import com.trib3.json.ObjectMapperProvider
 import io.dropwizard.auth.AuthValueFactoryProvider
 import io.dropwizard.testing.common.Resource
-import org.glassfish.jersey.test.inmemory.InMemoryTestContainerFactory
 import org.glassfish.jersey.test.spi.TestContainerFactory
 import org.testng.annotations.AfterClass
 import org.testng.annotations.BeforeClass
@@ -44,7 +43,7 @@ abstract class ResourceTestBase<T> {
     abstract fun getResource(): T
 
     open fun getContainerFactory(): TestContainerFactory {
-        return InMemoryTestContainerFactory()
+        return JettyWebTestContainerFactory()
     }
 
     open fun buildAdditionalResources(resourceBuilder: Resource.Builder<*>) {

--- a/testing/src/test/kotlin/com/trib3/testing/server/ResourceTestBaseTest.kt
+++ b/testing/src/test/kotlin/com/trib3/testing/server/ResourceTestBaseTest.kt
@@ -2,6 +2,7 @@ package com.trib3.testing.server
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import org.glassfish.jersey.test.inmemory.InMemoryTestContainerFactory
 import org.glassfish.jersey.test.spi.TestContainerFactory
 import org.testng.annotations.Test
 import javax.servlet.http.HttpServletRequest
@@ -22,10 +23,6 @@ class ResourceTestBaseJettyWebContainerTest : ResourceTestBase<SimpleResource>()
         return SimpleResource()
     }
 
-    override fun getContainerFactory(): TestContainerFactory {
-        return JettyWebTestContainerFactory()
-    }
-
     @Test
     fun testSimpleResource() {
         val response = resource.target("/").request().header("Test-Header", "Test-Value").get()
@@ -37,6 +34,10 @@ class ResourceTestBaseJettyWebContainerTest : ResourceTestBase<SimpleResource>()
 class ResourceTestBaseInMemoryContainerTest : ResourceTestBase<SimpleResource>() {
     override fun getResource(): SimpleResource {
         return SimpleResource()
+    }
+
+    override fun getContainerFactory(): TestContainerFactory {
+        return InMemoryTestContainerFactory()
     }
 
     @Test


### PR DESCRIPTION
Run REST-based GraphQL queries as asynchronous coroutines, and
support an endpoint to cancel them by requestId.

Includes an implementation of FunctionDataFetcher that reads
coroutine scope from the GraphQL context to fix a structured
concurrency issue, see:
  https://github.com/ExpediaGroup/graphql-kotlin/pull/879

Also default to use JettyWebTestContainerFactory in resource
tests since enough new functionality isn't supported by the
in-memory container.
  (Breaking change, update version to 1.14.x)