### PR TITLE
Allow Elastic BeanStalk services to include Procfiles

### DIFF
--- a/build-resources/src/main/resources/assemblies/elasticbeanstalk.xml
+++ b/build-resources/src/main/resources/assemblies/elasticbeanstalk.xml
@@ -29,4 +29,13 @@
             <outputDirectory></outputDirectory>
         </file>
     </files>
+    <fileSets>
+        <fileSet>
+            <includes>
+                <include>Procfile</include>
+            </includes>
+            <outputDirectory></outputDirectory>
+            <filtered>true</filtered>
+        </fileSet>
+    </fileSets>
 </assembly>


### PR DESCRIPTION
In order to specify eg. jvm command line args, EBS
services need to provide a Procfile in the assembly zip.
This allows one to be added to source control in
`${projectDir}/server/Procfile`, filtered by maven for
eg. property value replacement, and included in the
final assembly.