### PR TITLE
GraphQL Authentication Tweaks

### DIFF
--- a/build-resources/pom.xml
+++ b/build-resources/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.trib3</groupId>
     <artifactId>build-resources</artifactId>
-    <version>1.15-SNAPSHOT</version>
+    <version>1.16-SNAPSHOT</version>
 
     <name>Build Resources</name>
     <description>Resources for use during the build process</description>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.15-SNAPSHOT</version>
+        <version>1.16-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.15-SNAPSHOT</version>
+        <version>1.16-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/graphql/pom.xml
+++ b/graphql/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.15-SNAPSHOT</version>
+        <version>1.16-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/graphql/src/main/kotlin/com/trib3/graphql/GraphQLConfig.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/GraphQLConfig.kt
@@ -11,6 +11,7 @@ class GraphQLConfig
     val idleTimeout: Long?
     val maxBinaryMessageSize: Int?
     val maxTextMessageSize: Int?
+    val authorizedWebSocketOnly: Boolean
 
     init {
         val config = loader.load("graphQL")
@@ -19,5 +20,6 @@ class GraphQLConfig
         idleTimeout = config.extract("idleTimeout")
         maxBinaryMessageSize = config.extract("maxBinaryMessageSize")
         maxTextMessageSize = config.extract("maxTextMessageSize")
+        authorizedWebSocketOnly = config.extract("authorizedWebSocketOnly") ?: false
     }
 }

--- a/graphql/src/main/resources/graphiql/index.html
+++ b/graphql/src/main/resources/graphiql/index.html
@@ -1,148 +1,70 @@
-<!--
- *  Copyright (c) Facebook, Inc.
- *  All rights reserved.
- *
- *  This source code is licensed under the license found in the
- *  LICENSE file in the root directory of this source tree.
--->
-<!DOCTYPE html>
 <html>
 <head>
-    <style>
-      body {
-        height: 100%;
-        margin: 0;
-        width: 100%;
-        overflow: hidden;
-      }
-      #graphiql {
-        height: 100vh;
-      }
-
-
-
-
-    </style>
-
-    <!--
-      This GraphiQL example depends on Promise and fetch, which are available in
-      modern browsers, but can be "polyfilled" for older browsers.
-      GraphiQL itself depends on React DOM.
-      If you do not want to rely on a CDN, you can host these files locally or
-      include them directly in your favored resource bunder.
-    -->
-    <script src="//cdn.jsdelivr.net/es6-promise/4.0.5/es6-promise.auto.min.js"></script>
-    <script src="//cdn.jsdelivr.net/fetch/0.9.0/fetch.min.js"></script>
-    <script src="//cdn.jsdelivr.net/react/15.4.2/react.min.js"></script>
-    <script src="//cdn.jsdelivr.net/react/15.4.2/react-dom.min.js"></script>
-
-    <!--
-      These two files can be found in the npm module, however you may wish to
-      copy them directly into your environment, or perhaps include them in your
-      favored resource bundler.
-     -->
-    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphiql@0.11.2/graphiql.css"/>
-    <script src="//cdn.jsdelivr.net/npm/graphiql@0.11.2/graphiql.js"></script>
-
+    <title>GraphiQL</title>
+    <link href="//unpkg.com/graphiql/graphiql.min.css" rel="stylesheet"/>
 </head>
-<body>
-<div id="graphiql">Loading...</div>
+<body style="margin: 0;">
+<div id="graphiql" style="height: 100vh;"></div>
+
+<script crossorigin src="//unpkg.com/react@17.0.1/umd/react.production.min.js"></script>
+<script crossorigin src="//unpkg.com/react-dom@17.0.1/umd/react-dom.production.min.js"></script>
+<script crossorigin src="//unpkg.com/graphiql@1.0.6/graphiql.min.js"></script>
+<script crossorigin src="//unpkg.com/subscriptions-transport-ws@0.9.18/browser/client.js"></script>
+
 <script>
-      /**
-       * This GraphiQL example illustrates how to use some of GraphiQL's props
-       * in order to enable reading and updating the URL parameters, making
-       * link sharing of queries a little bit easier.
-       *
-       * This is only one example of this kind of feature, GraphiQL exposes
-       * various React params to enable interesting integrations.
-       */
-      // Parse the search string to get url parameters.
-      var search = window.location.search;
-      var parameters = {};
-      search.substr(1).split('&').forEach(function (entry) {
-        var eq = entry.indexOf('=');
-        if (eq >= 0) {
-          parameters[decodeURIComponent(entry.slice(0, eq))] =
-            decodeURIComponent(entry.slice(eq + 1));
+    const fetcherFactory = function (subscriptionsClient, fallbackFetcher) {
+      var activeSubscription = null;
+      var results = [];
+      return function (graphQLParams) {
+        if (subscriptionsClient && activeSubscription !== null) {
+          activeSubscription.unsubscribe();
+          results = [];
         }
-      });
-      // if variables was provided, try to format it.
-      if (parameters.variables) {
-        try {
-          parameters.variables =
-            JSON.stringify(JSON.parse(parameters.variables), null, 2);
-        } catch (e) {
-          // Do nothing, we want to display the invalid JSON as a string, rather
-          // than present an error.
+        if (subscriptionsClient && graphQLParams.query.trim().startsWith("subscription")) {
+          return {
+            subscribe: function (observer) {
+              observer.next('Your subscription data will appear here after server publication!');
+              activeSubscription = subscriptionsClient.request({
+                query: graphQLParams.query,
+                variables: graphQLParams.variables,
+              }).subscribe(function (result) {
+                results.push(result);
+                if (results.length % 10 == 0) { // debounce
+                  observer.next(results);
+                }
+              }, function(error) {
+                observer.error(error);
+              },
+              function() {
+                observer.next(results); // on completion show all results
+              });
+            },
+          };
+        } else {
+          return fallbackFetcher(graphQLParams);
         }
-      }
-      // When the query and variables string is edited, update the URL bar so
-      // that it can be easily shared
-      function onEditQuery(newQuery) {
-        parameters.query = newQuery;
-        updateURL();
-      }
-      function onEditVariables(newVariables) {
-        parameters.variables = newVariables;
-        updateURL();
-      }
-      function onEditOperationName(newOperationName) {
-        parameters.operationName = newOperationName;
-        updateURL();
-      }
-      function updateURL() {
-        var newSearch = '?' + Object.keys(parameters).filter(function (key) {
-          return Boolean(parameters[key]);
-        }).map(function (key) {
-          return encodeURIComponent(key) + '=' +
-            encodeURIComponent(parameters[key]);
-        }).join('&');
-        history.replaceState(null, null, newSearch);
-      }
-      // Defines a GraphQL fetcher using the fetch API. You're not required to
-      // use fetch, and could instead implement graphQLFetcher however you like,
-      // as long as it returns a Promise or Observable.
-      function graphQLFetcher(graphQLParams) {
-        // This example expects a GraphQL server at the path /graphql.
-        // Change this to point wherever you host your GraphQL server.
-        return fetch('/app/graphql', {
-          method: 'post',
-          headers: {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify(graphQLParams),
-          credentials: 'include',
-        }).then(function (response) {
-          return response.text();
-        }).then(function (responseBody) {
-          try {
-            return JSON.parse(responseBody);
-          } catch (error) {
-            return responseBody;
-          }
-        });
-      }
-      // Render <GraphiQL /> into the body.
-      // See the README in the top level of this module to learn more about
-      // how you can customize GraphiQL by providing different values or
-      // additional child elements.
-      ReactDOM.render(
-        React.createElement(GraphiQL, {
-          fetcher: graphQLFetcher,
-          query: parameters.query,
-          variables: parameters.variables,
-          operationName: parameters.operationName,
-          onEditQuery: onEditQuery,
-          onEditVariables: onEditVariables,
-          onEditOperationName: onEditOperationName
-        }),
-        document.getElementById('graphiql')
-      );
+      };
+    };
 
 
-
-
+    const graphQLFetcher = graphQLParams =>
+      fetch('/app/graphql', {
+        method: 'post',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(graphQLParams),
+      })
+        .then(response => response.json())
+        .catch(() => response.text());
+    const wsproto = (window.location.protocol == 'https:') ? 'wss' : 'ws';
+    const subscriptionsClient = new window.SubscriptionsTransportWs.SubscriptionClient(
+      `${wsproto}://${window.location.host}/app/graphql`,
+      { reconnect: true, timeout: 60000 }
+    );
+    const subscriptionsFetcher = fetcherFactory(subscriptionsClient, graphQLFetcher);
+    ReactDOM.render(
+      React.createElement(GraphiQL, { fetcher: subscriptionsFetcher }),
+      document.getElementById('graphiql'),
+    );
 
 </script>
 </body>

--- a/graphql/src/test/resources/application.conf
+++ b/graphql/src/test/resources/application.conf
@@ -5,3 +5,8 @@ GraphQLResourceTest {
         maxTextMessageSize: 400000
     }
 }
+GraphQLResourceIntegrationTest {
+    graphQL {
+        authorizedWebSocketOnly: true
+    }
+}

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.15-SNAPSHOT</version>
+        <version>1.16-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/lambda/pom.xml
+++ b/lambda/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.15-SNAPSHOT</version>
+        <version>1.16-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.trib3</groupId>
     <artifactId>parent-pom</artifactId>
-    <version>1.15-SNAPSHOT</version>
+    <version>1.16-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Trib3 parent pom</name>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>1.15-SNAPSHOT</version>
+        <version>1.16-SNAPSHOT</version>
         <relativePath>parent-pom/pom.xml</relativePath>
     </parent>
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.15-SNAPSHOT</version>
+        <version>1.16-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.15-SNAPSHOT</version>
+        <version>1.16-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Allow services to enforce that all websocket clients
must be authenticated to connect.

Return a 401 Unauthorized when all GraphQL responses
are 401 Unauthorized.  Bump version to 1.16.x due to
behavior change.

Also update graphiql to latest version and support
subscriptions via subscriptions-transport-ws.