### PR TITLE
Fix swagger in graphQL resource

### DIFF
--- a/graphql/pom.xml
+++ b/graphql/pom.xml
@@ -158,6 +158,10 @@
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-servlet</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-annotations</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.trib3</groupId>

--- a/graphql/src/main/kotlin/com/trib3/graphql/GraphQLConfig.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/GraphQLConfig.kt
@@ -11,7 +11,7 @@ class GraphQLConfig
     val idleTimeout: Long?
     val maxBinaryMessageSize: Int?
     val maxTextMessageSize: Int?
-    val authorizedWebSocketOnly: Boolean
+    val checkAuthorization: Boolean
 
     init {
         val config = loader.load("graphQL")
@@ -20,6 +20,6 @@ class GraphQLConfig
         idleTimeout = config.extract("idleTimeout")
         maxBinaryMessageSize = config.extract("maxBinaryMessageSize")
         maxTextMessageSize = config.extract("maxTextMessageSize")
-        authorizedWebSocketOnly = config.extract("authorizedWebSocketOnly") ?: false
+        checkAuthorization = config.extract("checkAuthorization") ?: config.extract("authorizedWebSocketOnly") ?: false
     }
 }

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -697,6 +697,11 @@
             </dependency>
             <dependency>
                 <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-annotations</artifactId>
+                <version>${version.swagger}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.swagger.core.v3</groupId>
                 <artifactId>swagger-integration</artifactId>
                 <version>${version.swagger}</version>
                 <exclusions>


### PR DESCRIPTION
Hide the optional @Auth principals from swagger
documentation, as they break the construction of
the OpenAPI response