### PR TITLE
Accept connectionParams on websocket for auth/context purposes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,5 +3,5 @@ indent_size=4
 continuation_indent_size=4
 insert_final_newline=true
 max_line_length=120
-# this is currently the default but make explicit:
 kotlin_imports_layout=idea
+ij_kotlin_imports_layout=*,java.**,javax.**,kotlin.**,^

--- a/build-resources/pom.xml
+++ b/build-resources/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.trib3</groupId>
     <artifactId>build-resources</artifactId>
-    <version>1.16-SNAPSHOT</version>
+    <version>1.17-SNAPSHOT</version>
 
     <name>Build Resources</name>
     <description>Resources for use during the build process</description>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.16-SNAPSHOT</version>
+        <version>1.17-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.16-SNAPSHOT</version>
+        <version>1.17-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/graphql/README.md
+++ b/graphql/README.md
@@ -1,32 +1,52 @@
 Graphql
 ======
-Provides the application infrastructure for adding [GraphQL](https://graphql.org) support 
-to a [server](https://github.com/trib3/leakycauldron/blob/HEAD/server) application.
+Provides the application infrastructure for adding [GraphQL](https://graphql.org) support to
+a [server](https://github.com/trib3/leakycauldron/blob/HEAD/server) application.
+
 * GraphQL endpoints:
-  * UUID, java8 time, and threeten-extra [Scalars](https://github.com/trib3/leakycauldron/blob/HEAD/graphql/src/main/kotlin/com/trib3/graphql/execution/LeakyCauldronHooks.kt)
-  * [Request Ids](https://github.com/trib3/leakycauldron/blob/HEAD/graphql/src/main/kotlin/com/trib3/graphql/execution/RequestIdInstrumentation.kt) 
+  * UUID, java8 time, and
+    threeten-extra [Scalars](https://github.com/trib3/leakycauldron/blob/HEAD/graphql/src/main/kotlin/com/trib3/graphql/execution/LeakyCauldronHooks.kt)
+  * [Request Ids](https://github.com/trib3/leakycauldron/blob/HEAD/graphql/src/main/kotlin/com/trib3/graphql/execution/RequestIdInstrumentation.kt)
     attached to the GraphQL response extensions
   * Any guice bound Query, Subscription or Mutation Resolvers
-  * Supports websockets using the [Apollo Protocol](https://github.com/apollographql/subscriptions-transport-ws/blob/HEAD/PROTOCOL.md)
-  * Supports subscriptions via [coroutine](https://github.com/kotlin/kotlinx.coroutines/) Flows 
-    for any Resolvers that return a `Publisher<T>`
-  * Supports [Dropwizard Authentication](https://www.dropwizard.io/en/latest/manual/auth.html) Principals
-    passed through to Resolvers via [GraphQLContext](https://github.com/ExpediaGroup/graphql-kotlin/blob/HEAD/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/execution/GraphQLContext.kt)
-  * Supports [coroutine](https://github.com/kotlin/kotlinx.coroutines/) structured concurrency and cancellation
-    of POSTed GraphQL queries for Resolvers implemented as `suspend` functions
+  * Supports websockets using
+    the [Apollo Protocol](https://github.com/apollographql/subscriptions-transport-ws/blob/HEAD/PROTOCOL.md)
+  * Supports subscriptions via [coroutine](https://github.com/kotlin/kotlinx.coroutines/) Flows for any Resolvers that
+    return a `Publisher<T>`
+  * Supports [Dropwizard Authentication](https://www.dropwizard.io/en/latest/manual/auth.html) Principals passed through
+    to Resolvers
+    via [GraphQLContext](https://github.com/ExpediaGroup/graphql-kotlin/blob/HEAD/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/execution/GraphQLContext.kt)
+  * Supports [coroutine](https://github.com/kotlin/kotlinx.coroutines/) structured concurrency and cancellation of
+    POSTed GraphQL queries for Resolvers implemented as `suspend` functions
 * Admin:
   * [GraphiQL](https://github.com/graphql/graphiql) available at `/admin/graphiql`
 
 #### Configuration
-Configuration is done primarily though Guice.  [`GraphQLApplicationModule`](https://github.com/trib3/leakycauldron/blob/HEAD/graphql/src/main/kotlin/com/trib3/graphql/modules/GraphQLApplicationModule.kt)
-exposes binders for commonly bound objects.  
+
+Configuration is done primarily though Guice.
+[`GraphQLApplicationModule`](https://github.com/trib3/leakycauldron/blob/HEAD/graphql/src/main/kotlin/com/trib3/graphql/modules/GraphQLApplicationModule.kt)
+exposes binders for commonly bound objects. Additionally, some parameters are set though the HOCON config:
+
+Default config:
+
+```hocon
+    graphql {
+        keepAliveIntervalSeconds: 15  # interval to send keepalive messages over apollo websocket protocol
+        webSocketSubProtocol: "graphql-ws"  # apollo websocket subprotocol to identify as
+        idleTimeout: null  # allows override of jetty websocket policy idleTimeout
+        maxBinaryMessageSize: null  # allows override of jetty websocket policy maxBinaryMessageSize
+        maxTextMessageSize: null  # allows override of jetty websocket policy maxTextMessageSize
+        checkAuthorization: false  # whether to kick unauthenticated clients off websocket sessions (allow by default)
+    }
+```
 
 ##### GraphQL Resolvers
+
 [`GraphQLApplicationModule`](https://github.com/trib3/leakycauldron/blob/HEAD/graphql/src/main/kotlin/com/trib3/graphql/modules/GraphQLApplicationModule.kt)
-provides methods that expose multi-binders for configuring GraphQL resolvers.  Any model
-classes must be added to the `graphQLPackagesBinder()` to allow [GraphQL Kotlin](https://github.com/ExpediaDotCom/graphql-kotlin/)
-to use them.  Query Resolver implementations can be added to the `graphQLQueriesBinder()`, 
-Subscriptions to the `graphQLSubscriptionsBinder()`, and Mutations to the `graphQLMutationsBinder()` 
+provides methods that expose multi-binders for configuring GraphQL resolvers. Any model classes must be added to
+the `graphQLPackagesBinder()` to allow [GraphQL Kotlin](https://github.com/ExpediaDotCom/graphql-kotlin/)
+to use them. Query Resolver implementations can be added to the `graphQLQueriesBinder()`, Subscriptions to
+the `graphQLSubscriptionsBinder()`, and Mutations to the `graphQLMutationsBinder()`
 
 ```kotlin
 class ExampleApplicationModule : GraphQLApplicationModule() {
@@ -35,30 +55,31 @@ class ExampleApplicationModule : GraphQLApplicationModule() {
         graphQLPackagesBinder().addBinding().toInstance("com.example.api")
         graphQLPackagesBinder().addBinding().toInstance("com.example.server.graphql")
 
-        graphQLQueriesBinder().addBinding().to<com.example.server.graphql.Query>()
-        graphQLMutationsBinder().addBinding().to<com.example.server.graphql.Mutation>()
-        graphQLSubscriptionsBinder().addBinding().to<com.example.server.graphql.Subscription>()
-        // ...
+      graphQLQueriesBinder().addBinding().to<com.example.server.graphql.Query>()
+      graphQLMutationsBinder().addBinding().to<com.example.server.graphql.Mutation>()
+      graphQLSubscriptionsBinder().addBinding().to<com.example.server.graphql.Subscription>()
+      // ...
     }
 }
 ```
 
 #### Auth
-If Dropwizard Authentication is setup per the [server README](https://github.com/trib3/leakycauldron/blob/HEAD/server/README.md#auth),
-GraphQL resolver methods can receive the principal inside the GraphQL context of type
-`GraphQLResourceContext`.  Resolver methods can write to the `cookie` field of the context 
-object they receive in order to set cookies on the client (useful when, for example, using
-a `CookieTokenAuthFilter` for auth).
+
+If Dropwizard Authentication is setup per
+the [server README](https://github.com/trib3/leakycauldron/blob/HEAD/server/README.md#auth), GraphQL resolver methods
+can receive the principal inside the GraphQL context of type
+`GraphQLResourceContext`. Resolver methods can write to the `cookie` field of the context object they receive in order
+to set cookies on the client (useful when, for example, using a `CookieTokenAuthFilter` for auth).
 
 ```kotlin
 class ExampleLoginMutations : GraphQLQueryResolver {
-    fun login(context: GraphQLResourceContext, email: String, pass: String): Boolean {
-        if (context.principal == null) {
-            // log in!
-            val userSession = authenticate(email, pass)
-            if (userSession == null) {
-                return false
-            }
+  fun login(context: GraphQLResourceContext, email: String, pass: String): Boolean {
+    if (context.principal == null) {
+      // log in!
+      val userSession = authenticate(email, pass)
+      if (userSession == null) {
+        return false
+      }
             // cookie will be set in response
             context.cookie = NewCookie("example-app-session-id", userSession.id)
         } else {
@@ -74,37 +95,41 @@ class ExampleLoginMutations : GraphQLQueryResolver {
                 NewCookie(
                     Cookie("example-app-session-id", ""),
                     null,
-                    -1,
-                    Date(0), // 1970
-                    false,
-                    false
+                  -1,
+                  Date(0), // 1970
+                  false,
+                  false
                 )
         }
-        return true
+      return true
     }
 }
 ```
 
+When using the WebSocket transport, credentials can be provided in HTTP headers/cookies of the upgrade request, or
+provided in the payload of the `connection_init` message.
+
 #### GraphQLResourceContext CoroutineScope
-`GraphQLResourceContext` implements `CoroutineScope`.  GraphQL resolver methods
-implemented as `suspend` functions will be run in this scope.  A `DELETE` call to 
-`/app/graphql?id=${requestId}` will cancel the scope of a running query. 
+
+`GraphQLResourceContext` implements `CoroutineScope`. GraphQL resolver methods implemented as `suspend` functions will
+be run in this scope. A `DELETE` call to
+`/app/graphql?id=${requestId}` will cancel the scope of a running query.
 
 ```kotlin
 class ExampleSuspendQuery : GraphQLQueryResolver {
-    suspend fun coroutineMethod(): String {
-        return coroutineScope {
-            // new scope whose parent scope is the GraphQLResourceContext object
-            val job1 = async {
-                // do stuff asynchronously
-                "value1"
-            }
-            val job2 = async {
-                 // do more stuff asynchronously, concurrently
-                 "value2"
-            }
-            "${job1.await()}:${job2.await()}"
-        }
+  suspend fun coroutineMethod(): String {
+    return coroutineScope {
+      // new scope whose parent scope is the GraphQLResourceContext object
+      val job1 = async {
+        // do stuff asynchronously
+        "value1"
+      }
+      val job2 = async {
+        // do more stuff asynchronously, concurrently
+        "value2"
+      }
+      "${job1.await()}:${job2.await()}"
     }
+  }
 }
 ```

--- a/graphql/pom.xml
+++ b/graphql/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.16-SNAPSHOT</version>
+        <version>1.17-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -161,6 +161,14 @@
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-common</artifactId>
         </dependency>
 
         <dependency>

--- a/graphql/src/main/kotlin/com/trib3/graphql/modules/DefaultGraphQLModule.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/modules/DefaultGraphQLModule.kt
@@ -16,6 +16,7 @@ import com.trib3.graphql.execution.RequestIdInstrumentation
 import com.trib3.graphql.resources.GraphQLResource
 import com.trib3.graphql.websocket.GraphQLContextWebSocketCreatorFactory
 import com.trib3.graphql.websocket.GraphQLWebSocketCreatorFactory
+import com.trib3.graphql.websocket.GraphQLWebSocketDropwizardAuthenticator
 import com.trib3.json.ObjectMapperProvider
 import com.trib3.server.modules.ServletConfig
 import dev.misfitlabs.kotlinguice4.typeLiteral
@@ -41,6 +42,13 @@ class DefaultGraphQLModule : GraphQLApplicationModule() {
         // override this by setting a binding
         dataLoaderRegistryFactoryBinder()
             .setDefault().toProvider(Provider { null })
+        // by default, any AuthFilter that is registered to guice will be used for
+        // authenticating websocket connections during the websocket upgrade or
+        // the [OperationType.GQL_CONNNECTION_INIT] message.  Applications can provide
+        // their own GraphQLAuthenticator by setting a binding
+        graphQLWebSocketAuthenticatorBinder()
+            .setDefault()
+            .to<GraphQLWebSocketDropwizardAuthenticator>()
 
         resourceBinder().addBinding().to<GraphQLResource>()
         // Ensure graphql binders are set up

--- a/graphql/src/main/kotlin/com/trib3/graphql/modules/GraphQLApplicationModule.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/modules/GraphQLApplicationModule.kt
@@ -2,11 +2,14 @@ package com.trib3.graphql.modules
 
 import com.google.inject.name.Names
 import com.trib3.graphql.execution.GraphQLRequest
+import com.trib3.server.modules.DefaultApplicationModule
 import com.trib3.server.modules.TribeApplicationModule
 import dev.misfitlabs.kotlinguice4.multibindings.KotlinMultibinder
 import dev.misfitlabs.kotlinguice4.multibindings.KotlinOptionalBinder
 import graphql.execution.instrumentation.Instrumentation
 import org.dataloader.DataLoaderRegistry
+import java.security.Principal
+import javax.ws.rs.container.ContainerRequestContext
 
 /**
  * Function that takes a [GraphQLRequest] and an optional context
@@ -19,6 +22,14 @@ typealias DataLoaderRegistryFactory = Function2<
     @JvmSuppressWildcards Any?,
     @JvmSuppressWildcards DataLoaderRegistry
     >
+
+/**
+ * Function that takes a [ContainerRequestContext] from the websocket upgrade request
+ * or `connection_init` payload and returns an authorized [Principal], if any.
+ */
+typealias GraphQLWebSocketAuthenticator = Function1<
+    @JvmSuppressWildcards ContainerRequestContext,
+    @JvmSuppressWildcards Principal?>
 
 /**
  * Base class for GraphQL application guice modules.  Provides
@@ -41,6 +52,7 @@ abstract class GraphQLApplicationModule : TribeApplicationModule() {
 
     final override fun configure() {
         super.configure()
+        install(DefaultApplicationModule())
         install(DefaultGraphQLModule())
         configureApplication()
     }
@@ -89,6 +101,13 @@ abstract class GraphQLApplicationModule : TribeApplicationModule() {
      * Optional binder for the dataLoaderRegistryFactory
      */
     fun dataLoaderRegistryFactoryBinder(): KotlinOptionalBinder<DataLoaderRegistryFactory> {
+        return KotlinOptionalBinder.newOptionalBinder(kotlinBinder)
+    }
+
+    /**
+     * Optional binder for the graphQLWebSocketAuthenticator
+     */
+    fun graphQLWebSocketAuthenticatorBinder(): KotlinOptionalBinder<GraphQLWebSocketAuthenticator> {
         return KotlinOptionalBinder.newOptionalBinder(kotlinBinder)
     }
 

--- a/graphql/src/main/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketCreator.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketCreator.kt
@@ -1,9 +1,9 @@
 package com.trib3.graphql.websocket
 
-import com.expediagroup.graphql.execution.GraphQLContext
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.trib3.graphql.GraphQLConfig
 import com.trib3.graphql.modules.DataLoaderRegistryFactory
+import com.trib3.graphql.modules.GraphQLWebSocketAuthenticator
 import graphql.GraphQL
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
@@ -11,6 +11,7 @@ import kotlinx.coroutines.launch
 import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest
 import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse
 import org.eclipse.jetty.websocket.servlet.WebSocketCreator
+import javax.ws.rs.container.ContainerRequestContext
 
 /**
  * [WebSocketCreator] that creates a [GraphQLWebSocketAdapter], a [Channel] that gets sent
@@ -20,8 +21,9 @@ class GraphQLWebSocketCreator(
     val graphQL: GraphQL,
     val objectMapper: ObjectMapper,
     val graphQLConfig: GraphQLConfig,
-    val context: GraphQLContext,
-    private val dataLoaderRegistryFactory: DataLoaderRegistryFactory? = null
+    val containerRequestContext: ContainerRequestContext,
+    private val dataLoaderRegistryFactory: DataLoaderRegistryFactory? = null,
+    private val graphQLWebSocketAuthenticator: GraphQLWebSocketAuthenticator? = null
 ) : WebSocketCreator {
     /**
      * Create the [GraphQLWebSocketAdapter]and its [Channel], and launch a [GraphQLWebSocketConsumer] coroutine
@@ -35,11 +37,12 @@ class GraphQLWebSocketCreator(
             GraphQLWebSocketConsumer(
                 graphQL,
                 graphQLConfig,
-                context,
+                containerRequestContext,
                 channel,
                 adapter,
                 Dispatchers.Default,
-                dataLoaderRegistryFactory
+                dataLoaderRegistryFactory,
+                graphQLWebSocketAuthenticator
             )
         adapter.launch {
             consumer.consume(this)

--- a/graphql/src/main/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketCreatorFactory.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketCreatorFactory.kt
@@ -1,16 +1,17 @@
 package com.trib3.graphql.websocket
 
-import com.expediagroup.graphql.execution.GraphQLContext
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.trib3.graphql.GraphQLConfig
 import com.trib3.graphql.modules.DataLoaderRegistryFactory
+import com.trib3.graphql.modules.GraphQLWebSocketAuthenticator
 import graphql.GraphQL
 import org.eclipse.jetty.websocket.servlet.WebSocketCreator
 import javax.annotation.Nullable
 import javax.inject.Inject
+import javax.ws.rs.container.ContainerRequestContext
 
 interface GraphQLContextWebSocketCreatorFactory {
-    fun getCreator(context: GraphQLContext): WebSocketCreator
+    fun getCreator(containerRequestContext: ContainerRequestContext): WebSocketCreator
 }
 
 /**
@@ -21,16 +22,18 @@ class GraphQLWebSocketCreatorFactory
     private val graphQL: GraphQL,
     private val objectMapper: ObjectMapper,
     private val graphQLConfig: GraphQLConfig,
-    @Nullable private val dataLoaderRegistryFactory: DataLoaderRegistryFactory? = null
+    @Nullable private val dataLoaderRegistryFactory: DataLoaderRegistryFactory? = null,
+    @Nullable private val graphQLWebSocketAuthenticator: GraphQLWebSocketAuthenticator? = null
 ) : GraphQLContextWebSocketCreatorFactory {
 
-    override fun getCreator(context: GraphQLContext): WebSocketCreator {
+    override fun getCreator(containerRequestContext: ContainerRequestContext): WebSocketCreator {
         return GraphQLWebSocketCreator(
             graphQL,
             objectMapper,
             graphQLConfig,
-            context,
-            dataLoaderRegistryFactory
+            containerRequestContext,
+            dataLoaderRegistryFactory,
+            graphQLWebSocketAuthenticator
         )
     }
 }

--- a/graphql/src/main/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketDropwizardAuthenticator.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketDropwizardAuthenticator.kt
@@ -1,0 +1,23 @@
+package com.trib3.graphql.websocket
+
+import com.trib3.graphql.modules.GraphQLWebSocketAuthenticator
+import io.dropwizard.auth.AuthFilter
+import java.security.Principal
+import javax.annotation.Nullable
+import javax.inject.Inject
+import javax.ws.rs.container.ContainerRequestContext
+
+/**
+ * A [GraphQLWebSocketAuthenticator] that delegates authentication
+ * to a Dropwizard [AuthFilter] from the Guice injector.
+ */
+class GraphQLWebSocketDropwizardAuthenticator @Inject constructor(
+    @Nullable val authFilter: AuthFilter<*, *>?
+) : GraphQLWebSocketAuthenticator {
+    override fun invoke(containerRequestContext: ContainerRequestContext): Principal? {
+        return runCatching {
+            authFilter?.filter(containerRequestContext)
+            containerRequestContext.securityContext?.userPrincipal
+        }.getOrNull()
+    }
+}

--- a/graphql/src/main/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketProtocol.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketProtocol.kt
@@ -30,7 +30,7 @@ data class OperationMessage<T : Any>(
         Type(name = "start", value = GraphQLRequest::class),
         Type(name = "data", value = ExecutionResult::class),
         Type(name = "error", value = String::class),
-        Type(name = "connection_init", value = Nothing::class),
+        Type(name = "connection_init", value = Map::class),
         Type(name = "connection_terminate", value = Nothing::class),
         Type(name = "connection_ack", value = Nothing::class),
         Type(name = "connection_error", value = String::class),
@@ -51,10 +51,11 @@ data class OperationType<T : Any>(
 ) {
     companion object {
         // client -> server
-        val GQL_CONNECTION_INIT = OperationType("connection_init", Nothing::class)
+        val GQL_CONNECTION_INIT = OperationType("connection_init", Map::class)
         val GQL_START = OperationType("start", GraphQLRequest::class)
         val GQL_STOP = OperationType("stop", Nothing::class)
         val GQL_CONNECTION_TERMINATE = OperationType("connection_terminate", Nothing::class)
+
         // server -> client
         val GQL_CONNECTION_ERROR = OperationType("connection_error", String::class)
         val GQL_CONNECTION_ACK = OperationType("connection_ack", Nothing::class)

--- a/graphql/src/main/resources/graphiql/index.html
+++ b/graphql/src/main/resources/graphiql/index.html
@@ -56,15 +56,19 @@
         .then(response => response.json())
         .catch(() => response.text());
     const wsproto = (window.location.protocol == 'https:') ? 'wss' : 'ws';
-    const subscriptionsClient = new window.SubscriptionsTransportWs.SubscriptionClient(
-      `${wsproto}://${window.location.host}/app/graphql`,
-      { reconnect: true, timeout: 60000 }
-    );
-    const subscriptionsFetcher = fetcherFactory(subscriptionsClient, graphQLFetcher);
-    ReactDOM.render(
-      React.createElement(GraphiQL, { fetcher: subscriptionsFetcher }),
-      document.getElementById('graphiql'),
-    );
+    fetch('/app/auth_cookie', {
+      method: 'get'
+    }).then(response => {
+        const subscriptionsClient = new window.SubscriptionsTransportWs.SubscriptionClient(
+          `${wsproto}://${window.location.host}/app/graphql`,
+          { reconnect: true, timeout: 60000 }
+        );
+        const subscriptionsFetcher = fetcherFactory(subscriptionsClient, graphQLFetcher);
+        ReactDOM.render(
+          React.createElement(GraphiQL, { fetcher: subscriptionsFetcher }),
+          document.getElementById('graphiql'),
+        );
+    });
 
 </script>
 </body>

--- a/graphql/src/main/resources/graphiql/index.html
+++ b/graphql/src/main/resources/graphiql/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
     <title>GraphiQL</title>
-    <link href="//unpkg.com/graphiql/graphiql.min.css" rel="stylesheet"/>
+    <link href="//unpkg.com/graphiql@1.0.6/graphiql.min.css" rel="stylesheet"/>
 </head>
 <body style="margin: 0;">
 <div id="graphiql" style="height: 100vh;"></div>

--- a/graphql/src/test/kotlin/com/trib3/graphql/modules/GraphQLApplicationModuleTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/modules/GraphQLApplicationModuleTest.kt
@@ -62,20 +62,20 @@ class GraphQLApplicationModuleTest
             assertThat(x["individual-statistics"]).isNotNull()
         }
     }
-}
 
-@Test
-fun testGraphQLProvider() {
-    val module = DefaultGraphQLModule()
-    val graphQLInstance = module.provideGraphQLInstance(
-        setOf(),
-        setOf(DummyQuery()),
-        setOf(),
-        setOf(),
-        setOf(),
-        ObjectMapperProvider().get()
-    )
-    assertThat(graphQLInstance).isNotNull()
+    @Test
+    fun testGraphQLProvider() {
+        val module = DefaultGraphQLModule()
+        val graphQLInstance = module.provideGraphQLInstance(
+            setOf(),
+            setOf(DummyQuery()),
+            setOf(),
+            setOf(),
+            setOf(),
+            ObjectMapperProvider().get()
+        )
+        assertThat(graphQLInstance).isNotNull()
+    }
 }
 
 class OverrideDataLoaderModule : GraphQLApplicationModule() {

--- a/graphql/src/test/kotlin/com/trib3/graphql/resources/GraphQLResourceIntegrationTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/resources/GraphQLResourceIntegrationTest.kt
@@ -14,6 +14,7 @@ import com.trib3.graphql.GraphQLConfig
 import com.trib3.graphql.execution.CustomDataFetcherExceptionHandler
 import com.trib3.graphql.execution.RequestIdInstrumentation
 import com.trib3.graphql.websocket.GraphQLContextWebSocketCreatorFactory
+import com.trib3.server.config.TribeApplicationConfig
 import com.trib3.server.filters.CookieTokenAuthFilter
 import com.trib3.testing.server.JettyWebTestContainerFactory
 import com.trib3.testing.server.ResourceTestBase
@@ -119,7 +120,8 @@ class GraphQLResourceIntegrationTest : ResourceTestBase<GraphQLResource>() {
                         }
                     }
                 }
-            }
+            },
+            appConfig = TribeApplicationConfig(ConfigLoader())
         )
 
     @Test

--- a/graphql/src/test/kotlin/com/trib3/graphql/resources/GraphQLResourceTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/resources/GraphQLResourceTest.kt
@@ -26,6 +26,7 @@ import com.trib3.graphql.execution.RequestIdInstrumentation
 import com.trib3.graphql.execution.SanitizedGraphQLError
 import com.trib3.graphql.websocket.GraphQLContextWebSocketCreatorFactory
 import com.trib3.json.ObjectMapperProvider
+import com.trib3.server.config.TribeApplicationConfig
 import com.trib3.server.filters.RequestIdFilter
 import com.trib3.testing.LeakyMock
 import graphql.ExecutionResult
@@ -97,13 +98,15 @@ class GraphQLResourceTest {
         GraphQLResource(
             graphQL,
             GraphQLConfig(ConfigLoader("GraphQLResourceTest")),
-            wsCreatorFactory
+            wsCreatorFactory,
+            appConfig = TribeApplicationConfig(ConfigLoader())
         )
     val lockedResource =
         GraphQLResource(
             graphQL,
             GraphQLConfig(ConfigLoader("GraphQLResourceIntegrationTest")),
-            wsCreatorFactory
+            wsCreatorFactory,
+            appConfig = TribeApplicationConfig(ConfigLoader())
         )
     val objectMapper = ObjectMapperProvider().get()
 
@@ -166,7 +169,7 @@ class GraphQLResourceTest {
         val result = resource.graphQL(Optional.empty(), GraphQLRequest("query {unauthorizedError}", mapOf(), null))
         assertThat(result.status).isEqualTo(HttpStatus.UNAUTHORIZED_401)
         assertThat(result.entity).isNull()
-        assertThat(result.getHeaderString("WWW-Authenticate")).isEqualTo("Basic realm=\"Realm\"")
+        assertThat(result.getHeaderString("WWW-Authenticate")).isEqualTo("Basic realm=\"realm\"")
     }
 
     @Test

--- a/graphql/src/test/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketDropwizardAuthenticatorTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketDropwizardAuthenticatorTest.kt
@@ -1,0 +1,83 @@
+package com.trib3.graphql.websocket
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import io.dropwizard.auth.AuthFilter
+import org.glassfish.jersey.internal.MapPropertiesDelegate
+import org.glassfish.jersey.server.ContainerRequest
+import org.testng.annotations.Test
+import java.security.Principal
+import javax.ws.rs.container.ContainerRequestContext
+import javax.ws.rs.core.SecurityContext
+
+data class TestPrincipal(val _name: String) : Principal {
+    override fun getName(): String {
+        return _name
+    }
+}
+
+class TestAuthenticator : AuthFilter<String, TestPrincipal>() {
+    override fun filter(requestContext: ContainerRequestContext) {
+        val principal = when (requestContext.getHeaderString("user")) {
+            "bill" -> TestPrincipal("billy")
+            "bob" -> TestPrincipal("bobby")
+            "evil" -> throw IllegalArgumentException("bad user")
+            else -> null
+        }
+        requestContext.securityContext = object : SecurityContext {
+            override fun getUserPrincipal(): Principal? {
+                return principal
+            }
+
+            override fun isUserInRole(role: String?): Boolean {
+                return false
+            }
+
+            override fun isSecure(): Boolean {
+                return false
+            }
+
+            override fun getAuthenticationScheme(): String {
+                return "test"
+            }
+        }
+    }
+}
+
+class GraphQLWebSocketDropwizardAuthenticatorTest {
+
+    private fun getContext(user: String?): ContainerRequestContext {
+        return ContainerRequest(
+            null,
+            null,
+            null,
+            null,
+            MapPropertiesDelegate(emptyMap()),
+            null
+        ).apply {
+            header("user", user)
+        }
+    }
+
+    @Test
+    fun testAuth() {
+        val authenticator = GraphQLWebSocketDropwizardAuthenticator(TestAuthenticator())
+        assertThat(authenticator.authFilter).isNotNull()
+        assertThat(authenticator.invoke(getContext("bob"))).isEqualTo(TestPrincipal("bobby"))
+        assertThat(authenticator.invoke(getContext("bill"))).isEqualTo(TestPrincipal("billy"))
+        assertThat(authenticator.invoke(getContext("sam"))).isNull()
+        assertThat(authenticator.invoke(getContext("evil"))).isNull()
+    }
+
+    @Test
+    fun testNoAuth() {
+        val authenticator = GraphQLWebSocketDropwizardAuthenticator(null)
+        assertThat(authenticator.authFilter).isNull()
+        assertThat(authenticator.invoke(getContext("bob"))).isNull()
+        assertThat(authenticator.invoke(getContext("bill"))).isNull()
+        assertThat(authenticator.invoke(getContext("sam"))).isNull()
+        assertThat(authenticator.invoke(getContext("evil"))).isNull()
+    }
+}

--- a/graphql/src/test/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketProtocolTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketProtocolTest.kt
@@ -15,6 +15,7 @@ import kotlin.reflect.full.memberProperties
 
 class GraphQLWebSocketProtocolTest {
     val mapper = ObjectMapperProvider().get()
+
     @Test
     fun testOperationTypeRawDeserialization() {
         val start = OperationType.getOperationType("start")
@@ -64,6 +65,7 @@ class GraphQLWebSocketProtocolTest {
             Nothing::class to null,
             String::class to "message",
             GraphQLRequest::class to GraphQLRequest("query {q}", mapOf(), null),
+            Map::class to mapOf("a" to "b", "c" to "d"),
             ExecutionResult::class to null // only need to support serialization right now, not round trip
         )
         for (

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.16-SNAPSHOT</version>
+        <version>1.17-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/lambda/pom.xml
+++ b/lambda/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.16-SNAPSHOT</version>
+        <version>1.17-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.trib3</groupId>
     <artifactId>parent-pom</artifactId>
-    <version>1.16-SNAPSHOT</version>
+    <version>1.17-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Trib3 parent pom</name>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>1.16-SNAPSHOT</version>
+        <version>1.17-SNAPSHOT</version>
         <relativePath>parent-pom/pom.xml</relativePath>
     </parent>
 

--- a/server/README.md
+++ b/server/README.md
@@ -1,40 +1,47 @@
 server
 ======
 Provides the application infrastructure for running a [Dropwizard](https://dropwizard.io)
-based application.  The application will be a [simple server](https://dropwizard.readthedocs.io/en/stable/manual/configuration.html#simple),
-and have:
-* [HOCON](https://github.com/trib3/leakycauldron/blob/HEAD/server/src/main/kotlin/com/trib3/server/config/dropwizard/HoconConfigurationFactory.kt) 
+based application. The application will be
+a [simple server](https://dropwizard.readthedocs.io/en/stable/manual/configuration.html#simple), and have:
+
+* [HOCON](https://github.com/trib3/leakycauldron/blob/HEAD/server/src/main/kotlin/com/trib3/server/config/dropwizard/HoconConfigurationFactory.kt)
   based configuration instead of the default .yaml based configuration
 * Health checks:
   * [Ping](https://github.com/trib3/leakycauldron/blob/HEAD/server/src/main/kotlin/com/trib3/server/healthchecks/PingHealthCheck.kt):
     A simple health check that will always return healthy
   * [Version](https://github.com/trib3/leakycauldron/blob/HEAD/server/src/main/kotlin/com/trib3/server/healthchecks/VersionHealthCheck.kt):
     A health check that will return the version of the running application
-  * Database: if a [DbModule](https://github.com/trib3/leakycauldron/blob/HEAD/db#dbmodule) is installed, 
+  * Database: if a [DbModule](https://github.com/trib3/leakycauldron/blob/HEAD/db#dbmodule) is installed,
     [HikariCP](https://github.com/brettwooldridge/HikariCP/wiki/Dropwizard-HealthChecks)
     will report on the db health
 * REST endpoints:
   * [Ping](https://github.com/trib3/leakycauldron/blob/HEAD/server/src/main/kotlin/com/trib3/server/resources/PingResource.kt):
     A simple REST GET endpoint that will always return `pong`
-  * [Request Ids](https://github.com/trib3/leakycauldron/blob/HEAD/server/src/main/kotlin/com/trib3/server/filters/RequestIdFilter.kt) 
+  * [Request Ids](https://github.com/trib3/leakycauldron/blob/HEAD/server/src/main/kotlin/com/trib3/server/filters/RequestIdFilter.kt)
     attached to HTTP headers
   * Any guice bound JAX-RS Resources
-  * JAX-RS Resource methods implementable via [suspend functions/coroutines](https://github.com/trib3/leakycauldron/blob/HEAD/server/src/main/kotlin/com/trib3/server/coroutine/CoroutineInvocationHandler.kt)
+  * JAX-RS Resource methods implementable
+    via [suspend functions/coroutines](https://github.com/trib3/leakycauldron/blob/HEAD/server/src/main/kotlin/com/trib3/server/coroutine/CoroutineInvocationHandler.kt)
 * Admin:
-  * The dropwizard `/admin` servlet will be [password protected](https://github.com/trib3/leakycauldron/blob/HEAD/server/src/main/kotlin/com/trib3/server/filters/AdminAuthFilter.kt)
-    with a password set from the `application.adminAuthToken` configuration variable 
+  * The dropwizard `/admin` servlet will
+    be [password protected](https://github.com/trib3/leakycauldron/blob/HEAD/server/src/main/kotlin/com/trib3/server/filters/AdminAuthFilter.kt)
+    with a password set from the `application.adminAuthToken` configuration variable
     (or `ADMIN_AUTH_TOKEN` environment variable)
   * [Swagger UI](https://github.com/swagger-api/swagger-ui) available at `/admin/swagger`
 
 #### Configuration
-Configuration is done primarily though Guice.  [`TribeApplicationModule`](https://github.com/trib3/leakycauldron/blob/HEAD/server/src/main/kotlin/com/trib3/server/modules/TribeApplicationModule.kt)
-exposes binders for commonly bound objects.  
-  
+
+Configuration is done primarily though
+Guice.  [`TribeApplicationModule`](https://github.com/trib3/leakycauldron/blob/HEAD/server/src/main/kotlin/com/trib3/server/modules/TribeApplicationModule.kt)
+exposes binders for commonly bound objects.
+
 ##### Application Guice Modules
-The modules to create the guice injector are specified in `application.conf` 
-under the `application.modules`configuration key.  
+
+The modules to create the guice injector are specified in `application.conf`
+under the `application.modules`configuration key.
 
 Example config:
+
 ```hocon
     application {
         modules: [
@@ -45,74 +52,75 @@ Example config:
 ```
 
 ##### JAX-RS Resources
+
 [`TribeApplicationModule`](https://github.com/trib3/leakycauldron/blob/HEAD/server/src/main/kotlin/com/trib3/server/modules/TribeApplicationModule.kt)
-provides a method that exposes a multi-binder for JAX-RS Resources.  Any Resource classes
-should be bound using this binder.
+provides a method that exposes a multi-binder for JAX-RS Resources. Any Resource classes should be bound using this
+binder.
 
 ```kotlin
 class ExampleApplicationModule : TribeApplicationModule() {
-    override fun configure() {
-        // ...
-        resourceBinder().addBinding().to<com.example.server.resources.ExampleResource>()
-        // ...
-    }
+  override fun configure() {
+    // ...
+    resourceBinder().addBinding().to<com.example.server.resources.ExampleResource>()
+    // ...
+  }
 }
 ```
 
 #### Auth
-Authentication and authorization can be implemented via [Dropwizard Authentication](https://www.dropwizard.io/en/latest/manual/auth.html)
-by binding an `AuthDynamicFeature` with an `Authenticator` (and optionally an `Authorizer`)
-as a jersey resource.  Binding and registration of the `RolesAllowedDynamicFeature` and
-`AuthValueFactoryProvider.Binder(Principal::class.java)` are done by default, so `@Auth`
-annotations on resource method parameterss are supported once the `AuthDynamicFeature` is
-registered.
 
-In addition, a `CookieTokenAuthFilter` implementation is provided for reading
-a session token out of a configured cookie value.
+Authentication and authorization can be implemented
+via [Dropwizard Authentication](https://www.dropwizard.io/en/latest/manual/auth.html)
+by binding an `AuthFilter` with an `Authenticator` (and optionally an `Authorizer`)
+in the Guice injector. Binding and registration of `AuthDynamicFeature`, `RolesAllowedDynamicFeature`
+and `AuthValueFactoryProvider.Binder(Principal::class.java)` are done by default, so `@Auth`
+annotations on resource method parameterss are supported once the `AuthFilter` is registered.
+
+In addition, a `CookieTokenAuthFilter` implementation is provided for reading a session token out of a configured cookie
+value.
 
 ```kotlin
 class ExampleCookieAuthedApplicationModule : TribeApplicationModule() {
-    override fun configure() {
-        // ...
-        bind<Authenticator<String?, Principal>>().to<com.example.server.auth.ExampleSessionAuthenticator>()
-        bind<Authorizer<Principal>>().to<com.example.server.auth.ExampleUserAuthorizer>()
-        // ...
-    }
+  override fun configure() {
+    // ...
+    bind<Authenticator<String?, Principal>>().to<com.example.server.auth.ExampleSessionAuthenticator>()
+    bind<Authorizer<Principal>>().to<com.example.server.auth.ExampleUserAuthorizer>()
 
-    @ProvidesIntoSet
-    @Named(APPLICATION_RESOURCES_BIND_NAME)
-    fun getAuthDynamicFeature(
-        authenticator: Authenticator<String?, Principal>,
-        authorizer: Authorizer<Principal>
-    ) : Any {
-        return AuthDynamicFeature(
-            // can also use a ChainedAuthFilter<Any, Principal> to add BasicAuthFilter/OAuthCredentialAuthFilter/etc
-            CookieTokenAuthFilter.Builder<Principal>("example-app-session-id")
-                .setAuthenticator(authenticator)
-                .setAuthorizer(authorizer)
-                .buildAuthFilter()
-        )
-    }
+    // can also use a ChainedAuthFilter<Any, Principal> to add BasicAuthFilter/OAuthCredentialAuthFilter/etc
+    authFilterBinder().setBinding().toInstance(
+      CookieTokenAuthFilter.Builder<Principal>("example-app-session-id")
+        .setAuthenticator(authenticator)
+        .setAuthorizer(authorizer)
+        .buildAuthFilter()
+    )
+    // ...
+  }
 }
 ```
 
 ##### GraphQL Resolvers
+
 To add [GraphQL](https://graphql.org) support, see [graphql](https://github.com/trib3/leakycauldron/blob/HEAD/graphql)
 
 #### Execution
+
 Running a downstream application is most easily done by using a shaded `.jar`:
+
 ```bash
 $ java -jar server/target/server-1.0-SNAPSHOT.jar
 ``` 
+
 or by using the maven exec plugin:
+
 ```bash
 $ mvn exec:java -Dexec.mainClass=com.trib3.server.TribeApplicationKt 
 ```
 
-When running in [AWS Elastic Beanstalk](https://aws.amazon.com/elasticbeanstalk/), the
-assembly configuration from [build-resources](https://github.com/trib3/leakycauldron/blob/HEAD/build-resources)
-can be used to create a `.zip` distribution that configures health checks and timeout
-values.  With the preconfigured `Java 8` Elastic Beanstalk platform, the `PORT` environment 
-property should be set to `5000` in the environment's software configuration.
+When running in [AWS Elastic Beanstalk](https://aws.amazon.com/elasticbeanstalk/), the assembly configuration
+from [build-resources](https://github.com/trib3/leakycauldron/blob/HEAD/build-resources)
+can be used to create a `.zip` distribution that configures health checks and timeout values. With the
+preconfigured `Java 8` Elastic Beanstalk platform, the `PORT` environment property should be set to `5000` in the
+environment's software configuration.
 
-For running in [AWS Lambda](https://aws.amazon.com/lambda/), see [lambda](https://github.com/trib3/leakycauldron/blob/HEAD/lambda)
+For running in [AWS Lambda](https://aws.amazon.com/lambda/),
+see [lambda](https://github.com/trib3/leakycauldron/blob/HEAD/lambda)

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.16-SNAPSHOT</version>
+        <version>1.17-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -164,6 +164,11 @@
             <groupId>dev.misfitlabs.kotlinguice4</groupId>
             <artifactId>kotlin-guice</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>

--- a/server/src/main/kotlin/com/trib3/server/config/BootstrapConfig.kt
+++ b/server/src/main/kotlin/com/trib3/server/config/BootstrapConfig.kt
@@ -12,12 +12,12 @@ import io.dropwizard.logging.BootstrapLogging
  * Startup configuration object that allows for configuration of the application guice modules
  * and provides a way to get a guice injector
  */
-class BootstrapConfig {
+class BootstrapConfig(configLoader: ConfigLoader = ConfigLoader()) {
 
     val appModules: List<String>
 
     init {
-        val config = ConfigLoader().load()
+        val config = configLoader.load()
         appModules = config.extract("application.modules")
     }
 

--- a/server/src/main/kotlin/com/trib3/server/filters/AdminAuthFilter.kt
+++ b/server/src/main/kotlin/com/trib3/server/filters/AdminAuthFilter.kt
@@ -15,7 +15,7 @@ import javax.servlet.http.HttpServletResponse
  */
 class AdminAuthFilter : Filter {
     private var token: String? = null
-    private var realm: String = "Realm"
+    private var realm: String = "realm"
     private val base64 = Base64.getDecoder()
 
     /**

--- a/server/src/main/kotlin/com/trib3/server/modules/DefaultApplicationModule.kt
+++ b/server/src/main/kotlin/com/trib3/server/modules/DefaultApplicationModule.kt
@@ -14,6 +14,7 @@ import com.trib3.server.coroutine.CoroutineModelProcessor
 import com.trib3.server.filters.RequestIdFilter
 import com.trib3.server.healthchecks.PingHealthCheck
 import com.trib3.server.healthchecks.VersionHealthCheck
+import com.trib3.server.resources.AuthCookieResource
 import com.trib3.server.resources.PingResource
 import dev.misfitlabs.kotlinguice4.multibindings.KotlinMultibinder
 import io.dropwizard.Configuration
@@ -50,8 +51,9 @@ class DefaultApplicationModule : TribeApplicationModule() {
             ServletFilterConfig(RequestIdFilter::class.java.simpleName, RequestIdFilter::class.java)
         )
 
-        // Bind ping resource
+        // Bind standard resources resources
         resourceBinder().addBinding().to<PingResource>()
+        resourceBinder().addBinding().to<AuthCookieResource>()
 
         // Bind coroutine model processor
         resourceBinder().addBinding().toInstance(CoroutineModelProcessor::class.java)

--- a/server/src/main/kotlin/com/trib3/server/modules/DefaultApplicationModule.kt
+++ b/server/src/main/kotlin/com/trib3/server/modules/DefaultApplicationModule.kt
@@ -22,6 +22,7 @@ import io.dropwizard.configuration.ConfigurationFactoryFactory
 import org.eclipse.jetty.servlets.CrossOriginFilter
 import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature
 import java.security.Principal
+import javax.inject.Provider
 import javax.servlet.Filter
 
 data class ServletFilterConfig(
@@ -61,9 +62,10 @@ class DefaultApplicationModule : TribeApplicationModule() {
         install(MetricsInstrumentationModule.builder().withMetricRegistry(registry).build())
         bind<HealthCheckRegistry>().`in`(Scopes.SINGLETON)
 
-        // Ensure @Auth annotations can be used as long as downstream binds an AuthDynamicFeature implementation
+        // Ensure @Auth annotations can be used as long as downstream binds an AuthFilter implementation
         resourceBinder().addBinding().toInstance(RolesAllowedDynamicFeature::class.java)
         resourceBinder().addBinding().toInstance(AuthValueFactoryProvider.Binder(Principal::class.java))
+        authFilterBinder().setDefault().toProvider(Provider { null })
     }
 
     /**

--- a/server/src/main/kotlin/com/trib3/server/modules/TribeApplicationModule.kt
+++ b/server/src/main/kotlin/com/trib3/server/modules/TribeApplicationModule.kt
@@ -3,6 +3,8 @@ package com.trib3.server.modules
 import com.google.inject.name.Names
 import dev.misfitlabs.kotlinguice4.KotlinModule
 import dev.misfitlabs.kotlinguice4.multibindings.KotlinMultibinder
+import dev.misfitlabs.kotlinguice4.multibindings.KotlinOptionalBinder
+import io.dropwizard.auth.AuthFilter
 import javax.servlet.Servlet
 
 data class ServletConfig(
@@ -52,5 +54,12 @@ abstract class TribeApplicationModule : KotlinModule() {
             kotlinBinder,
             Names.named(ADMIN_SERVLETS_BIND_NAME)
         )
+    }
+
+    /**
+     * Optional binder for dropwizard AuthFilter
+     */
+    fun authFilterBinder(): KotlinOptionalBinder<AuthFilter<*, *>> {
+        return KotlinOptionalBinder.newOptionalBinder(kotlinBinder)
     }
 }

--- a/server/src/main/kotlin/com/trib3/server/resources/AuthCookieResource.kt
+++ b/server/src/main/kotlin/com/trib3/server/resources/AuthCookieResource.kt
@@ -1,0 +1,68 @@
+package com.trib3.server.resources
+
+import com.codahale.metrics.annotation.Timed
+import com.trib3.server.config.TribeApplicationConfig
+import org.eclipse.jetty.http.HttpStatus
+import javax.annotation.security.PermitAll
+import javax.inject.Inject
+import javax.ws.rs.GET
+import javax.ws.rs.Path
+import javax.ws.rs.container.ContainerRequestContext
+import javax.ws.rs.core.Context
+import javax.ws.rs.core.NewCookie
+import javax.ws.rs.core.Response
+
+@Path("/")
+class AuthCookieResource @Inject constructor(
+    val appConfig: TribeApplicationConfig
+) {
+    /**
+     * Create the cookie name based on the configured application name
+     */
+    private fun getCookieName(): String {
+        val formattedAppName = appConfig.appName.toUpperCase().replace(' ', '_')
+        return "${formattedAppName}_AUTHORIZATION"
+    }
+
+    /**
+     * Set authorization credentials in the HTTP headers as a session-lifetime,
+     * HTTP-only cookie.
+     *
+     * This allows, eg, a JS websocket client to authenticate to the service
+     * via BasicAuthentication, make a request to this endpoint, and then
+     * initiate a cookie-authenticated websocket connection without js ever
+     * having access to a credential
+     */
+    @GET
+    @Path("/auth_cookie")
+    @Timed
+    @PermitAll
+    fun setAuthCookie(
+        @Context containerRequestContext: ContainerRequestContext
+    ): Response {
+        val authHeaderSplit = containerRequestContext
+            .getHeaderString("Authorization")
+            ?.split(' ', limit = 2)
+        val authToken = authHeaderSplit?.last()
+        return Response.status(HttpStatus.NO_CONTENT_204).let { builder ->
+            if (authToken != null) {
+                builder.cookie(
+                    NewCookie(
+                        getCookieName(),
+                        authToken,
+                        "/app",
+                        null,
+                        1,
+                        null,
+                        NewCookie.DEFAULT_MAX_AGE, // expire in 30 days
+                        null,
+                        containerRequestContext.securityContext.isSecure,
+                        true
+                    )
+                )
+            } else {
+                builder
+            }
+        }.build()
+    }
+}

--- a/server/src/main/resources/reference.conf
+++ b/server/src/main/resources/reference.conf
@@ -11,6 +11,7 @@ server {
   connector: {
     type: "http"
     port: 8080
+    useForwardedHeaders: true
   }
   requestLog {
     type: filtered-logback-access

--- a/server/src/test/kotlin/com/trib3/server/filters/AdminAuthFilterTest.kt
+++ b/server/src/test/kotlin/com/trib3/server/filters/AdminAuthFilterTest.kt
@@ -91,7 +91,7 @@ class AdminAuthFilterTest {
         EasyMock.expect(
             mockResponse.setHeader(
                 EasyMock.eq("WWW-Authenticate"),
-                EasyMock.eq("Basic realm=\"Realm\"")
+                EasyMock.eq("Basic realm=\"realm\"")
             )
         ).once()
         val mockFilterConfig = LeakyMock.niceMock<FilterConfig>()
@@ -119,7 +119,7 @@ class AdminAuthFilterTest {
         EasyMock.expect(
             mockResponse.setHeader(
                 EasyMock.eq("WWW-Authenticate"),
-                EasyMock.eq("Basic realm=\"Realm\"")
+                EasyMock.eq("Basic realm=\"realm\"")
             )
         ).once()
         val mockFilterConfig = LeakyMock.niceMock<FilterConfig>()

--- a/server/src/test/kotlin/com/trib3/server/resources/AuthCookieResourceTest.kt
+++ b/server/src/test/kotlin/com/trib3/server/resources/AuthCookieResourceTest.kt
@@ -1,0 +1,89 @@
+package com.trib3.server.resources
+
+import assertk.assertThat
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isTrue
+import com.trib3.config.ConfigLoader
+import com.trib3.server.config.TribeApplicationConfig
+import com.trib3.testing.LeakyMock
+import com.trib3.testing.server.ResourceTestBase
+import io.dropwizard.auth.AuthDynamicFeature
+import io.dropwizard.auth.basic.BasicCredentialAuthFilter
+import io.dropwizard.testing.common.Resource
+import org.easymock.EasyMock
+import org.eclipse.jetty.http.HttpStatus
+import org.testng.annotations.Test
+import java.security.Principal
+import java.util.Optional
+import javax.ws.rs.container.ContainerRequestContext
+import javax.ws.rs.core.SecurityContext
+
+data class UserPrincipal(private val _name: String) : Principal {
+    override fun getName(): String {
+        return _name
+    }
+}
+
+class AuthCookieResourceTest : ResourceTestBase<AuthCookieResource>() {
+    private val appConfig = TribeApplicationConfig(ConfigLoader())
+    override fun getResource(): AuthCookieResource {
+        return AuthCookieResource(appConfig)
+    }
+
+    override fun buildAdditionalResources(resourceBuilder: Resource.Builder<*>) {
+        resourceBuilder.addProvider(
+            AuthDynamicFeature(
+                BasicCredentialAuthFilter.Builder<UserPrincipal>()
+                    .setAuthenticator {
+                        if (it.username == "user") {
+                            Optional.of(UserPrincipal("bill"))
+                        } else {
+                            Optional.empty()
+                        }
+                    }
+                    .buildAuthFilter()
+            )
+        )
+    }
+
+    @Test
+    fun testUnauthorized() {
+        val response = resource.target("/auth_cookie").request().get()
+        assertThat(response.status).isEqualTo(HttpStatus.UNAUTHORIZED_401)
+        assertThat(response.cookies).isEmpty()
+    }
+
+    @Test
+    fun testBadAuthorization() {
+        val response = resource.target("/auth_cookie").request().header("Authorization", "Basic YmxhaDoxMjM0NQ==").get()
+        assertThat(response.status).isEqualTo(HttpStatus.UNAUTHORIZED_401)
+        assertThat(response.cookies).isEmpty()
+    }
+
+    @Test
+    fun testGoodAuthorization() {
+        val response = resource.target("/auth_cookie").request().header("Authorization", "Basic dXNlcjoxMjM0NQ==").get()
+        assertThat(response.status).isEqualTo(HttpStatus.NO_CONTENT_204)
+        assertThat(response.cookies["TEST_AUTHORIZATION"]?.name).isEqualTo("TEST_AUTHORIZATION")
+        assertThat(response.cookies["TEST_AUTHORIZATION"]?.value).isEqualTo("dXNlcjoxMjM0NQ==")
+        assertThat(response.cookies["TEST_AUTHORIZATION"]?.maxAge).isEqualTo(-1) // session cookie
+        assertThat(response.cookies["TEST_AUTHORIZATION"]?.isHttpOnly).isNotNull().isTrue()
+    }
+
+    @Test
+    fun testNullAuthHeaderCase() {
+        // test against the resource method directly
+        val rawResource = AuthCookieResource(appConfig)
+        val mockRequest = LeakyMock.mock<ContainerRequestContext>()
+        val mockSecContext = LeakyMock.mock<SecurityContext>()
+        EasyMock.expect(mockRequest.getHeaderString("Authorization")).andReturn(null)
+        EasyMock.expect(mockRequest.securityContext).andReturn(mockSecContext)
+        EasyMock.expect(mockSecContext.isSecure).andReturn(true)
+        EasyMock.replay(mockRequest, mockSecContext)
+        val response = rawResource.setAuthCookie(mockRequest)
+        assertThat(response.status).isEqualTo(HttpStatus.NO_CONTENT_204)
+        assertThat(response.cookies).isEmpty()
+    }
+}

--- a/server/src/test/resources/application.conf
+++ b/server/src/test/resources/application.conf
@@ -8,3 +8,9 @@ server {
     port: 9080
   }
 }
+
+withTestModule {
+  application {
+    modules: [com.trib3.config.modules.KMSModule, com.trib3.server.TestModule]
+  }
+}

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.16-SNAPSHOT</version>
+        <version>1.17-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Per https://www.apollographql.com/docs/graphql-subscriptions/authentication/,
should be able to specify auth parameters in the graphql websocket's
connection_init payload.  Add a Guice configurable callback to process
the connecitonParams, so that downstreams can hook into their auth system.

Also add an implementation that integrates with dropwizard-auth as long
as the AuthFilter is available to the Guice injector.

In addition, re-authenticate credentials on the start of any
websocket query, so that a socket opened with credentials that
become invalid by the time the query is requested gets rejected.

Finally, reject any requests with an Origin that is not allowed by the
CORS config.

Bump version as auth guice bindings and websocket auth behavior have
changed.