### PR TITLE
Add endpoint moving header based auth to a cookie

### DIFF
--- a/graphql/src/main/resources/graphiql/index.html
+++ b/graphql/src/main/resources/graphiql/index.html
@@ -56,15 +56,19 @@
         .then(response => response.json())
         .catch(() => response.text());
     const wsproto = (window.location.protocol == 'https:') ? 'wss' : 'ws';
-    const subscriptionsClient = new window.SubscriptionsTransportWs.SubscriptionClient(
-      `${wsproto}://${window.location.host}/app/graphql`,
-      { reconnect: true, timeout: 60000 }
-    );
-    const subscriptionsFetcher = fetcherFactory(subscriptionsClient, graphQLFetcher);
-    ReactDOM.render(
-      React.createElement(GraphiQL, { fetcher: subscriptionsFetcher }),
-      document.getElementById('graphiql'),
-    );
+    fetch('/app/auth_cookie', {
+      method: 'get'
+    }).then(response => {
+        const subscriptionsClient = new window.SubscriptionsTransportWs.SubscriptionClient(
+          `${wsproto}://${window.location.host}/app/graphql`,
+          { reconnect: true, timeout: 60000 }
+        );
+        const subscriptionsFetcher = fetcherFactory(subscriptionsClient, graphQLFetcher);
+        ReactDOM.render(
+          React.createElement(GraphiQL, { fetcher: subscriptionsFetcher }),
+          document.getElementById('graphiql'),
+        );
+    });
 
 </script>
 </body>

--- a/graphql/src/test/kotlin/com/trib3/graphql/resources/GraphQLResourceIntegrationTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/resources/GraphQLResourceIntegrationTest.kt
@@ -14,6 +14,7 @@ import com.trib3.graphql.GraphQLConfig
 import com.trib3.graphql.execution.CustomDataFetcherExceptionHandler
 import com.trib3.graphql.execution.RequestIdInstrumentation
 import com.trib3.graphql.websocket.GraphQLContextWebSocketCreatorFactory
+import com.trib3.server.config.TribeApplicationConfig
 import com.trib3.server.filters.CookieTokenAuthFilter
 import com.trib3.testing.server.JettyWebTestContainerFactory
 import com.trib3.testing.server.ResourceTestBase
@@ -119,7 +120,8 @@ class GraphQLResourceIntegrationTest : ResourceTestBase<GraphQLResource>() {
                         }
                     }
                 }
-            }
+            },
+            appConfig = TribeApplicationConfig(ConfigLoader())
         )
 
     @Test

--- a/graphql/src/test/kotlin/com/trib3/graphql/resources/GraphQLResourceTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/resources/GraphQLResourceTest.kt
@@ -26,6 +26,7 @@ import com.trib3.graphql.execution.RequestIdInstrumentation
 import com.trib3.graphql.execution.SanitizedGraphQLError
 import com.trib3.graphql.websocket.GraphQLContextWebSocketCreatorFactory
 import com.trib3.json.ObjectMapperProvider
+import com.trib3.server.config.TribeApplicationConfig
 import com.trib3.server.filters.RequestIdFilter
 import com.trib3.testing.LeakyMock
 import graphql.ExecutionResult
@@ -97,13 +98,15 @@ class GraphQLResourceTest {
         GraphQLResource(
             graphQL,
             GraphQLConfig(ConfigLoader("GraphQLResourceTest")),
-            wsCreatorFactory
+            wsCreatorFactory,
+            appConfig = TribeApplicationConfig(ConfigLoader())
         )
     val lockedResource =
         GraphQLResource(
             graphQL,
             GraphQLConfig(ConfigLoader("GraphQLResourceIntegrationTest")),
-            wsCreatorFactory
+            wsCreatorFactory,
+            appConfig = TribeApplicationConfig(ConfigLoader())
         )
     val objectMapper = ObjectMapperProvider().get()
 
@@ -166,7 +169,7 @@ class GraphQLResourceTest {
         val result = resource.graphQL(Optional.empty(), GraphQLRequest("query {unauthorizedError}", mapOf(), null))
         assertThat(result.status).isEqualTo(HttpStatus.UNAUTHORIZED_401)
         assertThat(result.entity).isNull()
-        assertThat(result.getHeaderString("WWW-Authenticate")).isEqualTo("Basic realm=\"Realm\"")
+        assertThat(result.getHeaderString("WWW-Authenticate")).isEqualTo("Basic realm=\"realm\"")
     }
 
     @Test

--- a/server/src/main/kotlin/com/trib3/server/filters/AdminAuthFilter.kt
+++ b/server/src/main/kotlin/com/trib3/server/filters/AdminAuthFilter.kt
@@ -15,7 +15,7 @@ import javax.servlet.http.HttpServletResponse
  */
 class AdminAuthFilter : Filter {
     private var token: String? = null
-    private var realm: String = "Realm"
+    private var realm: String = "realm"
     private val base64 = Base64.getDecoder()
 
     /**

--- a/server/src/main/kotlin/com/trib3/server/modules/DefaultApplicationModule.kt
+++ b/server/src/main/kotlin/com/trib3/server/modules/DefaultApplicationModule.kt
@@ -14,6 +14,7 @@ import com.trib3.server.coroutine.CoroutineModelProcessor
 import com.trib3.server.filters.RequestIdFilter
 import com.trib3.server.healthchecks.PingHealthCheck
 import com.trib3.server.healthchecks.VersionHealthCheck
+import com.trib3.server.resources.AuthCookieResource
 import com.trib3.server.resources.PingResource
 import dev.misfitlabs.kotlinguice4.multibindings.KotlinMultibinder
 import io.dropwizard.Configuration
@@ -50,8 +51,9 @@ class DefaultApplicationModule : TribeApplicationModule() {
             ServletFilterConfig(RequestIdFilter::class.java.simpleName, RequestIdFilter::class.java)
         )
 
-        // Bind ping resource
+        // Bind standard resources resources
         resourceBinder().addBinding().to<PingResource>()
+        resourceBinder().addBinding().to<AuthCookieResource>()
 
         // Bind coroutine model processor
         resourceBinder().addBinding().toInstance(CoroutineModelProcessor::class.java)

--- a/server/src/main/kotlin/com/trib3/server/resources/AuthCookieResource.kt
+++ b/server/src/main/kotlin/com/trib3/server/resources/AuthCookieResource.kt
@@ -1,0 +1,68 @@
+package com.trib3.server.resources
+
+import com.codahale.metrics.annotation.Timed
+import com.trib3.server.config.TribeApplicationConfig
+import org.eclipse.jetty.http.HttpStatus
+import javax.annotation.security.PermitAll
+import javax.inject.Inject
+import javax.ws.rs.GET
+import javax.ws.rs.Path
+import javax.ws.rs.container.ContainerRequestContext
+import javax.ws.rs.core.Context
+import javax.ws.rs.core.NewCookie
+import javax.ws.rs.core.Response
+
+@Path("/")
+class AuthCookieResource @Inject constructor(
+    val appConfig: TribeApplicationConfig
+) {
+    /**
+     * Create the cookie name based on the configured application name
+     */
+    private fun getCookieName(): String {
+        val formattedAppName = appConfig.appName.toUpperCase().replace(' ', '_')
+        return "${formattedAppName}_AUTHORIZATION"
+    }
+
+    /**
+     * Set authorization credentials in the HTTP headers as a session-lifetime,
+     * HTTP-only cookie.
+     *
+     * This allows, eg, a JS websocket client to authenticate to the service
+     * via BasicAuthentication, make a request to this endpoint, and then
+     * initiate a cookie-authenticated websocket connection without js ever
+     * having access to a credential
+     */
+    @GET
+    @Path("/auth_cookie")
+    @Timed
+    @PermitAll
+    fun setAuthCookie(
+        @Context containerRequestContext: ContainerRequestContext
+    ): Response {
+        val authHeaderSplit = containerRequestContext
+            .getHeaderString("Authorization")
+            ?.split(' ', limit = 2)
+        val authToken = authHeaderSplit?.last()
+        return Response.status(HttpStatus.NO_CONTENT_204).let { builder ->
+            if (authToken != null) {
+                builder.cookie(
+                    NewCookie(
+                        getCookieName(),
+                        authToken,
+                        "/app",
+                        null,
+                        1,
+                        null,
+                        NewCookie.DEFAULT_MAX_AGE, // expire in 30 days
+                        null,
+                        containerRequestContext.securityContext.isSecure,
+                        true
+                    )
+                )
+            } else {
+                builder
+            }
+        }.build()
+    }
+}

--- a/server/src/main/resources/reference.conf
+++ b/server/src/main/resources/reference.conf
@@ -11,6 +11,7 @@ server {
   connector: {
     type: "http"
     port: 8080
+    useForwardedHeaders: true
   }
   requestLog {
     type: filtered-logback-access

--- a/server/src/test/kotlin/com/trib3/server/filters/AdminAuthFilterTest.kt
+++ b/server/src/test/kotlin/com/trib3/server/filters/AdminAuthFilterTest.kt
@@ -91,7 +91,7 @@ class AdminAuthFilterTest {
         EasyMock.expect(
             mockResponse.setHeader(
                 EasyMock.eq("WWW-Authenticate"),
-                EasyMock.eq("Basic realm=\"Realm\"")
+                EasyMock.eq("Basic realm=\"realm\"")
             )
         ).once()
         val mockFilterConfig = LeakyMock.niceMock<FilterConfig>()
@@ -119,7 +119,7 @@ class AdminAuthFilterTest {
         EasyMock.expect(
             mockResponse.setHeader(
                 EasyMock.eq("WWW-Authenticate"),
-                EasyMock.eq("Basic realm=\"Realm\"")
+                EasyMock.eq("Basic realm=\"realm\"")
             )
         ).once()
         val mockFilterConfig = LeakyMock.niceMock<FilterConfig>()

--- a/server/src/test/kotlin/com/trib3/server/resources/AuthCookieResourceTest.kt
+++ b/server/src/test/kotlin/com/trib3/server/resources/AuthCookieResourceTest.kt
@@ -1,0 +1,89 @@
+package com.trib3.server.resources
+
+import assertk.assertThat
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isTrue
+import com.trib3.config.ConfigLoader
+import com.trib3.server.config.TribeApplicationConfig
+import com.trib3.testing.LeakyMock
+import com.trib3.testing.server.ResourceTestBase
+import io.dropwizard.auth.AuthDynamicFeature
+import io.dropwizard.auth.basic.BasicCredentialAuthFilter
+import io.dropwizard.testing.common.Resource
+import org.easymock.EasyMock
+import org.eclipse.jetty.http.HttpStatus
+import org.testng.annotations.Test
+import java.security.Principal
+import java.util.Optional
+import javax.ws.rs.container.ContainerRequestContext
+import javax.ws.rs.core.SecurityContext
+
+data class UserPrincipal(private val _name: String) : Principal {
+    override fun getName(): String {
+        return _name
+    }
+}
+
+class AuthCookieResourceTest : ResourceTestBase<AuthCookieResource>() {
+    private val appConfig = TribeApplicationConfig(ConfigLoader())
+    override fun getResource(): AuthCookieResource {
+        return AuthCookieResource(appConfig)
+    }
+
+    override fun buildAdditionalResources(resourceBuilder: Resource.Builder<*>) {
+        resourceBuilder.addProvider(
+            AuthDynamicFeature(
+                BasicCredentialAuthFilter.Builder<UserPrincipal>()
+                    .setAuthenticator {
+                        if (it.username == "user") {
+                            Optional.of(UserPrincipal("bill"))
+                        } else {
+                            Optional.empty()
+                        }
+                    }
+                    .buildAuthFilter()
+            )
+        )
+    }
+
+    @Test
+    fun testUnauthorized() {
+        val response = resource.target("/auth_cookie").request().get()
+        assertThat(response.status).isEqualTo(HttpStatus.UNAUTHORIZED_401)
+        assertThat(response.cookies).isEmpty()
+    }
+
+    @Test
+    fun testBadAuthorization() {
+        val response = resource.target("/auth_cookie").request().header("Authorization", "Basic YmxhaDoxMjM0NQ==").get()
+        assertThat(response.status).isEqualTo(HttpStatus.UNAUTHORIZED_401)
+        assertThat(response.cookies).isEmpty()
+    }
+
+    @Test
+    fun testGoodAuthorization() {
+        val response = resource.target("/auth_cookie").request().header("Authorization", "Basic dXNlcjoxMjM0NQ==").get()
+        assertThat(response.status).isEqualTo(HttpStatus.NO_CONTENT_204)
+        assertThat(response.cookies["TEST_AUTHORIZATION"]?.name).isEqualTo("TEST_AUTHORIZATION")
+        assertThat(response.cookies["TEST_AUTHORIZATION"]?.value).isEqualTo("dXNlcjoxMjM0NQ==")
+        assertThat(response.cookies["TEST_AUTHORIZATION"]?.maxAge).isEqualTo(-1) // session cookie
+        assertThat(response.cookies["TEST_AUTHORIZATION"]?.isHttpOnly).isNotNull().isTrue()
+    }
+
+    @Test
+    fun testNullAuthHeaderCase() {
+        // test against the resource method directly
+        val rawResource = AuthCookieResource(appConfig)
+        val mockRequest = LeakyMock.mock<ContainerRequestContext>()
+        val mockSecContext = LeakyMock.mock<SecurityContext>()
+        EasyMock.expect(mockRequest.getHeaderString("Authorization")).andReturn(null)
+        EasyMock.expect(mockRequest.securityContext).andReturn(mockSecContext)
+        EasyMock.expect(mockSecContext.isSecure).andReturn(true)
+        EasyMock.replay(mockRequest, mockSecContext)
+        val response = rawResource.setAuthCookie(mockRequest)
+        assertThat(response.status).isEqualTo(HttpStatus.NO_CONTENT_204)
+        assertThat(response.cookies).isEmpty()
+    }
+}


### PR DESCRIPTION
Add an endpoint to convert header based auth to cookie based auth,
and use in graphiql to authenticate the graphql websocket without
exposing the credentials directly to javascript code
