### PR TITLE
Add activation jar to server runtime

### DIFF
--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -42,6 +42,7 @@
         <skip.source>false</skip.source>
         <skip.tests>false</skip.tests>
 
+        <version.activation>1.2.2</version.activation>
         <version.annotation>1.3.5</version.annotation>
         <version.argparse4j>0.8.1</version.argparse4j>
         <version.assertk>0.23</version.assertk>
@@ -419,6 +420,12 @@
                         <artifactId>joda-time</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.activation</groupId>
+                <artifactId>jakarta.activation</artifactId>
+                <version>${version.activation}</version>
+                <scope>runtime</scope>
             </dependency>
             <dependency>
                 <groupId>jakarta.xml.bind</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -70,6 +70,10 @@
             <artifactId>metrics-annotation</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.sun.activation</groupId>
+            <artifactId>jakarta.activation</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>


### PR DESCRIPTION
Silences a warning about javax.activation.DataSource
being missing from the classpath, and fixes downstream
projects that rely on activation (think this used to
be a transitive dependency that got removed)