### PR TITLE
Bump version.jetty from 9.4.36.v20210114 to 9.4.37.v20210219

### DIFF
--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -87,7 +87,7 @@
         <version.jaxrs>2.1.6</version.jaxrs>
         <version.jersey>2.33</version.jersey>
         <version.jetbrains.annotations>13.0</version.jetbrains.annotations>
-        <version.jetty>9.4.36.v20210114</version.jetty>
+        <version.jetty>9.4.37.v20210219</version.jetty>
         <version.joda>2.10.10</version.joda>
         <version.jooq>3.14.7</version.jooq>
         <version.jsr305>3.0.2</version.jsr305>
@@ -133,6 +133,14 @@
 
     <repositories>
         <repository>
+            <id>central</id>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <layout>default</layout>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
             <id>jcenter</id>
             <url>https://jcenter.bintray.com/</url>
         </repository>
@@ -142,6 +150,17 @@
         </repository>
     </repositories>
     <pluginRepositories>
+        <pluginRepository>
+            <id>central</id>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <layout>default</layout>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <releases>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+        </pluginRepository>
         <pluginRepository>
             <id>jcenter</id>
             <url>https://jcenter.bintray.com/</url>


### PR DESCRIPTION
Bumps `version.jetty` from 9.4.36.v20210114 to 9.4.37.v20210219.

Updates `jetty-bom` from 9.4.36.v20210114 to 9.4.37.v20210219
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-9.4.36.v20210114...jetty-9.4.37.v20210219)

Updates `jetty-server` from 9.4.36.v20210114 to 9.4.37.v20210219
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-9.4.36.v20210114...jetty-9.4.37.v20210219)

Updates `websocket-servlet` from 9.4.36.v20210114 to 9.4.37.v20210219