### PR TITLE
Allow jooq custom settings via DbConfig

### DIFF
--- a/db/README.md
+++ b/db/README.md
@@ -1,15 +1,18 @@
 Db
 ==
 Allows injection of configured [jOOQ](https://www.jooq.org) `DSLContext` or jdbc `DataSource`
-instances into application code.  Also provides [jOOQ](https://www.jooq.org) `Converter` 
+instances into application code. Also provides [jOOQ](https://www.jooq.org) `Converter`
 implementations for `java.time.YearMonth` and `org.threeten.extra.YearQuarter`.
 
 DbModule
 --------
 Configures a `DataSource` and a `DSLContext` from the `db` section of config, using
-[HikariCP](https://github.com/brettwooldridge/HikariCP) as a connection pool implementation.
+[HikariCP](https://github.com/brettwooldridge/HikariCP) as a connection pool implementation. In addition, allows setting
+any [jOOQ Custom Settings](https://www.jooq.org/doc/latest/manual/sql-building/dsl-context/custom-settings/)
+in a nested `jooq` section.
 
 Example config:
+
 ```hocon
     db {
         dialect: POSTGRES
@@ -21,19 +24,25 @@ Example config:
         password: dbpass
         driverClassName: org.postgresql.Driver
         autoCommit: false
+        jooq {
+            fetchSize: 1000
+            statementType: STATIC_STATEMENT
+        }
     }
 ```
 
 Example application code injection:
+
 ```kotlin
 class DAO
 @Inject constructor(val ctx: DSLContext) {
-   // ...
+    // ...
 }
 ```
 
 The following environment variables can be used to specify config without adding a `db`
 section to `application.conf` explicitly:
+
 * `DB_DIALECT`:  jOOQ dialect to use, defaults to `POSTGRES`
 * `DB_SUBPROTOCOL`:  jdbc subprotocol to use, defaults to `postgresql`
 * `DB_HOST`:  database hostname, defaults to `localhost`
@@ -43,7 +52,7 @@ section to `application.conf` explicitly:
 * `DB_PASSWORD`:  database password, defaults to no password
 * `DB_DRIVER_CLASS_NAME`:  jdbc driver, defaults to `org.postgresql.Driver`
 * `DB_AUTOCOMMTI`: connection autocommit status, defaults to `false`
-* `DB_CONNECT_TIMEOUT`: connection timeout, defaults to `30000` 
+* `DB_CONNECT_TIMEOUT`: connection timeout, defaults to `30000`
 * `DB_IDLE_TIMEOUT`: connection idle timeout, defaults to `600000`
 * `DB_MAX_LIFETIME`: connection max lifetime, defaults to `1800000`
 * `DB_CONNECTION_TEST_QUERY`: connection timeout, defaults to `null`
@@ -53,10 +62,11 @@ section to `application.conf` explicitly:
 
 NamedDbModule
 -------------
-If an application needs to connect to multiple databases, `NamedDbModule` can be used
-instead of `DbModule` to specify different configuration for each database.
+If an application needs to connect to multiple databases, `NamedDbModule` can be used instead of `DbModule` to specify
+different configuration for each database.
 
 Example config:
+
 ```hocon
     postgres {
         dialect: POSTGRES
@@ -81,31 +91,33 @@ Example config:
 ```
 
 Example application code injection:
+
 ```kotlin
 class PostgresDAO
 @Inject constructor(@Named("postgres") val ctx: DSLContext) {
-   // ...
+    // ...
 }
 
 class MysqlDAO
 @Inject constructor(@Named("mysql") val ctx: DSLContext) {
-   // ...
+    // ...
 }
 ```
 
 FlywayModule
 ------------
-To run [Flyway](https://flywaydb.org) migrations at server startup, install the `FlywayModule`.
-It will run a Flyway instance with default configurations against the `DbModule`'s `DataSource`.
+To run [Flyway](https://flywaydb.org) migrations at server startup, install the `FlywayModule`. It will run a Flyway
+instance with default configurations against the `DbModule`'s `DataSource`.
 
 To further configure Flyway, bind a `FluentConfiguration` in one of your application module, for example:
+
 ```kotlin
 class MyApplicationPersistenceModule : KotlinModule() {
     override fun configure() {
         install(FlywayModule())
         bind<FluentConfiguration>().toInstance(
-            Flyway.configure().sqlMigrationSuffixes(".sql", ".postgresql")
-                .locations("db/schema") // ... etc
+                Flyway.configure().sqlMigrationSuffixes(".sql", ".postgresql")
+                        .locations("db/schema") // ... etc
         )
     }
 }

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -68,6 +68,15 @@
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
         </dependency>
         <dependency>
             <groupId>com.zaxxer</groupId>

--- a/db/src/main/kotlin/com/trib3/db/config/DbConfig.kt
+++ b/db/src/main/kotlin/com/trib3/db/config/DbConfig.kt
@@ -5,11 +5,16 @@ import com.codahale.metrics.health.HealthCheckRegistry
 import com.trib3.config.ConfigLoader
 import com.trib3.config.extract
 import com.zaxxer.hikari.HikariDataSource
+import org.apache.commons.text.StringEscapeUtils
+import org.jooq.Constants
 import org.jooq.DSLContext
 import org.jooq.SQLDialect
+import org.jooq.conf.Settings
 import org.jooq.impl.DSL
+import java.io.StringReader
 import javax.inject.Inject
 import javax.sql.DataSource
+import javax.xml.bind.JAXB
 
 private const val POSTGRES_DEFAULT_PORT = 5432
 
@@ -70,10 +75,23 @@ class DbConfig
         if (maximumPoolSize != null) {
             hds.maximumPoolSize = maximumPoolSize
         }
+        val jooqSettings = if (config.hasPath("jooq")) {
+            val jooqConfigXml = config.getConfig("jooq").entrySet().joinToString("\n") {
+                "<${it.key}>${StringEscapeUtils.escapeXml11(it.value.unwrapped().toString())}</${it.key}>"
+            }
+            val jooqXml = """
+                <settings xmlns="${Constants.NS_RUNTIME}">
+                $jooqConfigXml
+                </settings>
+            """.trimIndent()
+            JAXB.unmarshal(StringReader(jooqXml), Settings::class.java)
+        } else {
+            Settings()
+        }
 
         dataSource = hds
 
         dialect = config.extract("dialect") ?: SQLDialect.POSTGRES
-        dslContext = DSL.using(dataSource, dialect)
+        dslContext = DSL.using(dataSource, dialect, jooqSettings)
     }
 }

--- a/db/src/test/kotlin/com/trib3/db/modules/NamedDbModuleTest.kt
+++ b/db/src/test/kotlin/com/trib3/db/modules/NamedDbModuleTest.kt
@@ -97,6 +97,8 @@ class NamedDbModuleTest
         }
         assertThat((test2DS as HikariDataSource).jdbcUrl).contains("test2")
         assertThat((test3DS as HikariDataSource).jdbcUrl).isEqualTo("jdbc:postgres://test3:12345/test3")
+        assertThat(defaultDSLContext.settings().fetchSize).isEqualTo(0)
+        assertThat(test3DSLContext.settings().fetchSize).isEqualTo(1000)
     }
 
     @Test

--- a/db/src/test/resources/application.conf
+++ b/db/src/test/resources/application.conf
@@ -8,6 +8,9 @@ test2 {
 
 test3 {
   url: "jdbc:postgres://test3:12345/test3"
+  jooq {
+    fetchSize: 1000
+  }
 }
 
 db {

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -55,6 +55,7 @@
         <version.classgraph>4.8.102</version.classgraph>
         <version.commons-codec>1.15</version.commons-codec>
         <version.commons-io>2.8.0</version.commons-io>
+        <version.commons-text>1.9</version.commons-text>
         <version.config4k>0.4.2</version.config4k>
         <version.detekt>1.15.0</version.detekt>
         <version.dokka>1.4.20</version.dokka>
@@ -457,6 +458,12 @@
                         <artifactId>jakarta.activation-api</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-impl</artifactId>
+                <version>${version.jaxb}</version>
+                <scope>runtime</scope>
             </dependency>
             <dependency>
                 <groupId>jakarta.annotation</groupId>
@@ -916,6 +923,11 @@
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
                 <version>${version.commons-codec}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-text</artifactId>
+                <version>${version.commons-text}</version>
             </dependency>
 
             <!-- guice -->


### PR DESCRIPTION
adds a jooq settings block underneath the db settings block
to allow for setting of any jooq custom settings.

see https://www.jooq.org/doc/latest/manual/sql-building/dsl-context/custom-settings/