### PR TITLE
Bump to graphql-kotlin 4.0.0/graphql-java 16.2 [Breaking changes]

### DIFF
--- a/build-resources/pom.xml
+++ b/build-resources/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.trib3</groupId>
     <artifactId>build-resources</artifactId>
-    <version>1.21-SNAPSHOT</version>
+    <version>1.22-SNAPSHOT</version>
 
     <name>Build Resources</name>
     <description>Resources for use during the build process</description>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.21-SNAPSHOT</version>
+        <version>1.22-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.21-SNAPSHOT</version>
+        <version>1.22-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/graphql/pom.xml
+++ b/graphql/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.21-SNAPSHOT</version>
+        <version>1.22-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/graphql/src/main/kotlin/com/trib3/graphql/execution/LeakyCauldronHooks.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/execution/LeakyCauldronHooks.kt
@@ -1,6 +1,6 @@
 package com.trib3.graphql.execution
 
-import com.expediagroup.graphql.hooks.FlowSubscriptionSchemaGeneratorHooks
+import com.expediagroup.graphql.generator.hooks.FlowSubscriptionSchemaGeneratorHooks
 import graphql.language.StringValue
 import graphql.schema.Coercing
 import graphql.schema.CoercingSerializeException

--- a/graphql/src/main/kotlin/com/trib3/graphql/execution/SanitizedGraphQLError.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/execution/SanitizedGraphQLError.kt
@@ -2,7 +2,7 @@ package com.trib3.graphql.execution
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import graphql.ExceptionWhileDataFetching
-import graphql.execution.ExecutionPath
+import graphql.execution.ResultPath
 import graphql.language.SourceLocation
 
 /**
@@ -10,7 +10,7 @@ import graphql.language.SourceLocation
  * and attempts to bubble up the message from the root cause of the exception
  */
 class SanitizedGraphQLError(
-    path: ExecutionPath,
+    path: ResultPath,
     exception: Throwable,
     sourceLocation: SourceLocation
 ) : ExceptionWhileDataFetching(path, exception, sourceLocation) {

--- a/graphql/src/main/kotlin/com/trib3/graphql/modules/DefaultGraphQLModule.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/modules/DefaultGraphQLModule.kt
@@ -1,9 +1,9 @@
 package com.trib3.graphql.modules
 
-import com.expediagroup.graphql.SchemaGeneratorConfig
-import com.expediagroup.graphql.TopLevelObject
-import com.expediagroup.graphql.execution.FlowSubscriptionExecutionStrategy
-import com.expediagroup.graphql.toSchema
+import com.expediagroup.graphql.generator.SchemaGeneratorConfig
+import com.expediagroup.graphql.generator.TopLevelObject
+import com.expediagroup.graphql.generator.execution.FlowSubscriptionExecutionStrategy
+import com.expediagroup.graphql.generator.toSchema
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.inject.Provides
 import com.google.inject.multibindings.MapBinder

--- a/graphql/src/main/kotlin/com/trib3/graphql/resources/GraphQLResource.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/resources/GraphQLResource.kt
@@ -1,7 +1,7 @@
 package com.trib3.graphql.resources
 
 import com.codahale.metrics.annotation.Timed
-import com.expediagroup.graphql.execution.GraphQLContext
+import com.expediagroup.graphql.generator.execution.GraphQLContext
 import com.trib3.graphql.GraphQLConfig
 import com.trib3.graphql.execution.GraphQLRequest
 import com.trib3.graphql.execution.toExecutionInput

--- a/graphql/src/main/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketConsumer.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketConsumer.kt
@@ -1,6 +1,6 @@
 package com.trib3.graphql.websocket
 
-import com.expediagroup.graphql.execution.GraphQLContext
+import com.expediagroup.graphql.generator.execution.GraphQLContext
 import com.trib3.graphql.GraphQLConfig
 import com.trib3.graphql.execution.GraphQLRequest
 import com.trib3.graphql.execution.toExecutionInput

--- a/graphql/src/test/kotlin/com/trib3/graphql/execution/LeakyCauldronHooksTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/execution/LeakyCauldronHooksTest.kt
@@ -5,10 +5,10 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isFailure
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isSuccess
-import com.expediagroup.graphql.SchemaGeneratorConfig
-import com.expediagroup.graphql.TopLevelObject
-import com.expediagroup.graphql.execution.SimpleKotlinDataFetcherFactoryProvider
-import com.expediagroup.graphql.toSchema
+import com.expediagroup.graphql.generator.SchemaGeneratorConfig
+import com.expediagroup.graphql.generator.TopLevelObject
+import com.expediagroup.graphql.generator.execution.SimpleKotlinDataFetcherFactoryProvider
+import com.expediagroup.graphql.generator.toSchema
 import com.trib3.json.ObjectMapperProvider
 import graphql.ExecutionInput
 import graphql.GraphQL

--- a/graphql/src/test/kotlin/com/trib3/graphql/execution/RequestIdInstrumentationTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/execution/RequestIdInstrumentationTest.kt
@@ -2,9 +2,9 @@ package com.trib3.graphql.execution
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import com.expediagroup.graphql.SchemaGeneratorConfig
-import com.expediagroup.graphql.TopLevelObject
-import com.expediagroup.graphql.toSchema
+import com.expediagroup.graphql.generator.SchemaGeneratorConfig
+import com.expediagroup.graphql.generator.TopLevelObject
+import com.expediagroup.graphql.generator.toSchema
 import graphql.GraphQL
 import org.slf4j.MDC
 import org.testng.annotations.Test

--- a/graphql/src/test/kotlin/com/trib3/graphql/resources/GraphQLResourceIntegrationTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/resources/GraphQLResourceIntegrationTest.kt
@@ -6,9 +6,9 @@ import assertk.assertions.isFailure
 import assertk.assertions.isNull
 import assertk.assertions.messageContains
 import com.coxautodev.graphql.tools.GraphQLQueryResolver
-import com.expediagroup.graphql.SchemaGeneratorConfig
-import com.expediagroup.graphql.TopLevelObject
-import com.expediagroup.graphql.toSchema
+import com.expediagroup.graphql.generator.SchemaGeneratorConfig
+import com.expediagroup.graphql.generator.TopLevelObject
+import com.expediagroup.graphql.generator.toSchema
 import com.trib3.config.ConfigLoader
 import com.trib3.graphql.GraphQLConfig
 import com.trib3.graphql.execution.CustomDataFetcherExceptionHandler

--- a/graphql/src/test/kotlin/com/trib3/graphql/resources/GraphQLResourceTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/resources/GraphQLResourceTest.kt
@@ -13,9 +13,9 @@ import assertk.assertions.isSuccess
 import assertk.assertions.isTrue
 import assertk.assertions.prop
 import com.coxautodev.graphql.tools.GraphQLQueryResolver
-import com.expediagroup.graphql.SchemaGeneratorConfig
-import com.expediagroup.graphql.TopLevelObject
-import com.expediagroup.graphql.toSchema
+import com.expediagroup.graphql.generator.SchemaGeneratorConfig
+import com.expediagroup.graphql.generator.TopLevelObject
+import com.expediagroup.graphql.generator.toSchema
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.trib3.config.ConfigLoader
 import com.trib3.graphql.GraphQLConfig

--- a/graphql/src/test/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketTest.kt
@@ -7,11 +7,11 @@ import assertk.assertions.isFalse
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import assertk.assertions.isTrue
-import com.expediagroup.graphql.SchemaGeneratorConfig
-import com.expediagroup.graphql.TopLevelObject
-import com.expediagroup.graphql.execution.FlowSubscriptionExecutionStrategy
-import com.expediagroup.graphql.hooks.FlowSubscriptionSchemaGeneratorHooks
-import com.expediagroup.graphql.toSchema
+import com.expediagroup.graphql.generator.SchemaGeneratorConfig
+import com.expediagroup.graphql.generator.TopLevelObject
+import com.expediagroup.graphql.generator.execution.FlowSubscriptionExecutionStrategy
+import com.expediagroup.graphql.generator.hooks.FlowSubscriptionSchemaGeneratorHooks
+import com.expediagroup.graphql.generator.toSchema
 import com.trib3.config.ConfigLoader
 import com.trib3.graphql.GraphQLConfig
 import com.trib3.graphql.execution.GraphQLRequest

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.21-SNAPSHOT</version>
+        <version>1.22-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/lambda/pom.xml
+++ b/lambda/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.21-SNAPSHOT</version>
+        <version>1.22-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.trib3</groupId>
     <artifactId>parent-pom</artifactId>
-    <version>1.21-SNAPSHOT</version>
+    <version>1.22-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Trib3 parent pom</name>
@@ -66,8 +66,8 @@
         <version.dropwizard.metrics.guice>4.0.0</version.dropwizard.metrics.guice>
         <version.easymock>4.3</version.easymock>
         <version.flyway>7.8.1</version.flyway>
-        <version.graphql-kotlin>3.7.0</version.graphql-kotlin>
-        <version.graphql-java>15.0</version.graphql-java>
+        <version.graphql-kotlin>4.0.0</version.graphql-kotlin>
+        <version.graphql-java>16.2</version.graphql-java>
         <version.graphql-java.tools>5.2.4</version.graphql-java.tools>
         <version.graphql-java.dataloader>2.2.3</version.graphql-java.dataloader>
         <version.graphql-java.servlet>6.1.3</version.graphql-java.servlet>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>1.21-SNAPSHOT</version>
+        <version>1.22-SNAPSHOT</version>
         <relativePath>parent-pom/pom.xml</relativePath>
     </parent>
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.21-SNAPSHOT</version>
+        <version>1.22-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.21-SNAPSHOT</version>
+        <version>1.22-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Update package/class names to match upstream changes.

Bump version due to upstream breaking changes:
 - addition of generator subpackage to graphql-kotlin
 - ExecutionPath -> ResultPath in graphql-java
 - selectionSet.fields behavior change in graphql-java