### PR TITLE
Switch jaxb jar to the new one [Potentially breaking change]

### DIFF
--- a/build-resources/pom.xml
+++ b/build-resources/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.trib3</groupId>
     <artifactId>build-resources</artifactId>
-    <version>1.20-SNAPSHOT</version>
+    <version>1.21-SNAPSHOT</version>
 
     <name>Build Resources</name>
     <description>Resources for use during the build process</description>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.20-SNAPSHOT</version>
+        <version>1.21-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.20-SNAPSHOT</version>
+        <version>1.21-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -71,8 +71,8 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/graphql/pom.xml
+++ b/graphql/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.20-SNAPSHOT</version>
+        <version>1.21-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.20-SNAPSHOT</version>
+        <version>1.21-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/lambda/pom.xml
+++ b/lambda/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.20-SNAPSHOT</version>
+        <version>1.21-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.trib3</groupId>
     <artifactId>parent-pom</artifactId>
-    <version>1.20-SNAPSHOT</version>
+    <version>1.21-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Trib3 parent pom</name>
@@ -455,8 +455,8 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>com.sun.xml.bind</groupId>
-                <artifactId>jaxb-impl</artifactId>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-runtime</artifactId>
                 <version>${version.jaxb}</version>
                 <scope>runtime</scope>
             </dependency>
@@ -1296,6 +1296,7 @@
                                     <exclude>org.glassfish:javax.el</exclude>
                                     <exclude>jakarta.el:jakarta.el-api</exclude> <!-- el impl includes el-api -->
                                     <exclude>jakarta.activation:jakarta.activation-api</exclude> <!-- use com.sun -->
+                                    <exclude>com.sun.xml.bind:jaxb-impl</exclude> <!-- use org.glassfish.jaxb:jaxb-runtime -->
                                 </excludes>
                             </bannedDependencies>
                         </rules>
@@ -1697,6 +1698,7 @@
                                 <Git-Commit-Time>${git.commit.time}</Git-Commit-Time>
                                 <Implementation-Version>${git.commit.id.describe}</Implementation-Version>
                                 <Specification-Version>${project.version}</Specification-Version>
+                                <Multi-Release>true</Multi-Release>
                             </manifestEntries>
                         </archive>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>1.20-SNAPSHOT</version>
+        <version>1.21-SNAPSHOT</version>
         <relativePath>parent-pom/pom.xml</relativePath>
     </parent>
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.20-SNAPSHOT</version>
+        <version>1.21-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.20-SNAPSHOT</version>
+        <version>1.21-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
com.sun...:jaxb-impl is replaced with org.glassfish..:jaxb-runtime
add com.sun one to banned dependencies and bump version.
Also set Multi-Release=true to avoid deprecated reflection warning