### PR TITLE
Add cloudwatch metrics reporter configuration

### DIFF
--- a/db/src/main/kotlin/com/trib3/db/converters/YearMonthConverter.kt
+++ b/db/src/main/kotlin/com/trib3/db/converters/YearMonthConverter.kt
@@ -13,8 +13,6 @@ class YearMonthConverter : AbstractConverter<LocalDate, YearMonth>(LocalDate::cl
     }
 
     override fun to(yearMonth: YearMonth?): LocalDate? {
-        return yearMonth?.let {
-            it.atDay(1)
-        }
+        return yearMonth?.atDay(1)
     }
 }

--- a/graphql/src/main/kotlin/com/trib3/graphql/resources/GraphQLResource.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/resources/GraphQLResource.kt
@@ -10,6 +10,7 @@ import com.trib3.graphql.websocket.GraphQLContextWebSocketCreatorFactory
 import com.trib3.server.config.TribeApplicationConfig
 import com.trib3.server.coroutine.AsyncDispatcher
 import com.trib3.server.filters.RequestIdFilter
+import com.trib3.server.runIf
 import graphql.GraphQL
 import io.dropwizard.auth.Auth
 import io.swagger.v3.oas.annotations.Hidden
@@ -136,13 +137,9 @@ open class GraphQLResource
             unauthorizedResponse()
         } else {
             Response.ok(result)
-                .let {
-                    // Communicate any set cookie back to the client
-                    if (context.cookie != null) {
-                        it.cookie(context.cookie)
-                    } else {
-                        it
-                    }
+                // Communicate any set cookie back to the client
+                .runIf(context.cookie != null) {
+                    cookie(context.cookie)
                 }.build()
         }
     }

--- a/json/README.md
+++ b/json/README.md
@@ -1,11 +1,14 @@
 Json
 ====
 Provides an injectable `ObjectMapper` that is configured to support:
+
 * Dropwizard object mapper [defaults](https://github.com/dropwizard/dropwizard/blob/HEAD/dropwizard-jackson/src/main/java/io/dropwizard/jackson/Jackson.java)
 * kotlin data classes via the [jackson kotlin module](https://github.com/FasterXML/jackson-module-kotlin)
 * java8 time classes (and [threeten-extra](https://github.com/ThreeTen/threeten-extra) `YearQuarter`s)
 * permissiveness on unknown properties (`FAIL_ON_UNKNOWN_PROPERTIES` set to false)
+* @JacksonInject [delegation to guice bindings](https://github.com/FasterXML/jackson-modules-base/tree/master/guice/)
 
 ##### ThreeTenExtraModule
+
 A jackson module that provides support for serializing and deserializing
 [threeten-extra](https://github.com/ThreeTen/threeten-extra) `YearQuarter`s. 

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -60,6 +60,10 @@
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-kotlin</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-guice</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.threeten</groupId>

--- a/json/src/main/kotlin/com/trib3/json/jackson/DontUseInputGuiceAnnotationIntrospector.kt
+++ b/json/src/main/kotlin/com/trib3/json/jackson/DontUseInputGuiceAnnotationIntrospector.kt
@@ -1,0 +1,22 @@
+package com.trib3.json.jackson
+
+import com.fasterxml.jackson.annotation.JacksonInject
+import com.fasterxml.jackson.databind.introspect.AnnotatedMember
+import com.fasterxml.jackson.module.guice.GuiceAnnotationIntrospector
+
+/**
+ * GuiceAnnotationInspector extension that doesn't ignore [JacksonInject.useInput]
+ * if set, and defaults to false if not set.  This means that by default, values
+ * will be injected instead of read from json if present in both.
+ */
+class DontUseInputGuiceAnnotationIntrospector : GuiceAnnotationIntrospector() {
+    override fun findInjectableValue(m: AnnotatedMember): JacksonInject.Value? {
+        val injectId = super.findInjectableValue(m)
+        return injectId?.let {
+            JacksonInject.Value.construct(
+                it.id,
+                m.getAnnotation(JacksonInject::class.java)?.useInput?.asBoolean() ?: false
+            )
+        }
+    }
+}

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -63,6 +63,7 @@
         <version.dropwizard>2.0.21</version.dropwizard>
         <version.dropwizard.hocon>0.5.1</version.dropwizard.hocon>
         <version.dropwizard.metrics>4.1.21</version.dropwizard.metrics>
+        <version.dropwizard.metrics.cloudwatch>2.0.8</version.dropwizard.metrics.cloudwatch>
         <version.dropwizard.metrics.guice>4.0.0</version.dropwizard.metrics.guice>
         <version.easymock>4.3</version.easymock>
         <version.flyway>7.8.2</version.flyway>
@@ -120,6 +121,7 @@
         <version.maven.shade>3.2.4</version.maven.shade>
         <version.maven.source>3.2.1</version.maven.source>
         <version.maven.surefire>3.0.0-M5</version.maven.surefire>
+        <version.netty>4.1.63.Final</version.netty>
         <version.postgres>42.2.20</version.postgres>
         <version.postgres.embedded>0.13.3</version.postgres.embedded>
         <version.reactivestreams>1.0.3</version.reactivestreams>
@@ -145,10 +147,6 @@
         <repository>
             <id>jcenter</id>
             <url>https://jcenter.bintray.com/</url>
-        </repository>
-        <repository>
-            <id>redshift</id>
-            <url>https://s3.amazonaws.com/redshift-maven-repository/release</url>
         </repository>
     </repositories>
     <pluginRepositories>
@@ -314,6 +312,11 @@
             </dependency>
             <dependency>
                 <groupId>io.dropwizard</groupId>
+                <artifactId>dropwizard-metrics</artifactId>
+                <version>${version.dropwizard}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-jersey</artifactId>
                 <version>${version.dropwizard}</version>
                 <exclusions>
@@ -399,6 +402,11 @@
                         <artifactId>jakarta.activation-api</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard</groupId>
+                <artifactId>dropwizard-validation</artifactId>
+                <version>${version.dropwizard}</version>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>
@@ -824,6 +832,17 @@
             </dependency>
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
+                <artifactId>cloudwatch</artifactId>
+                <version>${version.aws.java}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
                 <artifactId>kms</artifactId>
                 <version>${version.aws.java}</version>
                 <exclusions>
@@ -869,6 +888,21 @@
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
                 <version>${version.httpcomponents.client}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler</artifactId>
+                <version>${version.netty}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http</artifactId>
+                <version>${version.netty}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.azagniotov</groupId>
+                <artifactId>dropwizard-metrics-cloudwatch</artifactId>
+                <version>${version.dropwizard.metrics.cloudwatch}</version>
             </dependency>
 
             <!-- lambda -->

--- a/server/README.md
+++ b/server/README.md
@@ -43,12 +43,12 @@ under the `application.modules`configuration key.
 Example config:
 
 ```hocon
-    application {
-        modules: [
-            "com.example.ExampleApplicationModule",
-            "com.example.ExamplePersistenceModule"
-        ]
-    }
+application {
+    modules: [
+        "com.example.ExampleApplicationModule",
+        "com.example.ExamplePersistenceModule"
+    ]
+}
 ```
 
 ##### JAX-RS Resources
@@ -64,6 +64,50 @@ class ExampleApplicationModule : TribeApplicationModule() {
     resourceBinder().addBinding().to<com.example.server.resources.ExampleResource>()
     // ...
   }
+}
+```
+
+##### Cloudwatch Metrics Reporter
+
+[`CloudWatchReporterFactory`](https://github.com/trib3/leakycauldron/blob/HEAD/server/src/main/kotlin/com/trib3/server/config/dropwizard/CloudWatchReporterFactory.kt)
+allows for configuration based specification of a
+[CloudWatch Reporter](https://github.com/azagniotov/codahale-aggregated-metrics-cloudwatch-reporter). In addition to the
+below example config, an application using the `CloudWatchReporterFactory` must make a `CloudWatchAsyncClient`
+injectable via guice, for example:
+
+```kotlin
+bind<CloudWatchAsyncClient>()
+  .toInstance(
+    CloudWatchAsyncClient.builder().region(Region.US_EAST_1).build()
+  )
+```
+
+Example config:
+
+```hocon
+metrics: {
+    frequency: 10 seconds
+    reporters: [{
+        includes: [] # use to control which metrics to report on
+        excludes: [] # use to control which metrics to report on
+        type: cloudwatch
+        namespace: null # defaults to TribeApplicationConfig.env
+        globalDimensions: ['dim1=val1', 'dim2=val2'] # adds Application=TribeApplicationConfig.appName,Hostname=InetAddress.getLocalHost().hostname
+        percentiles: [P75, P95, P999]
+        dryRun: false
+        meanRate: false # applies to Meters and Timers
+        oneMinuteMeanRate: false # applies to Meters and Timers
+        fiveMinuteMeanRate: false # applies to Meters and Timers
+        fifteenMinuteMeanRate: false # applies to Meters and Timers
+        arithmeticMean: false # applies to Histograms and Timers
+        stdDev: false # applies to Histograms and Timers
+        statisticSet: false # applies to Histograms and Timers
+        zeroValueSubmission: false
+        highResolution: false
+        reportRawCountValue: false
+        jvmMetrics: false
+        meterUnit: null # defaults to durationUnit
+    }]
 }
 ```
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -62,12 +62,32 @@
             <artifactId>dropwizard-auth</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-metrics</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-healthchecks</artifactId>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-annotation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.github.azagniotov</groupId>
+            <artifactId>dropwizard-metrics-cloudwatch</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>cloudwatch</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.activation</groupId>
@@ -96,10 +116,6 @@
         <dependency>
             <groupId>com.palominolabs.metrics</groupId>
             <artifactId>metrics-guice</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>

--- a/server/src/main/kotlin/com/trib3/server/Extensions.kt
+++ b/server/src/main/kotlin/com/trib3/server/Extensions.kt
@@ -1,0 +1,15 @@
+package com.trib3.server
+
+/**
+ * Conditionally calls the specified function [block] with `this` value and returns its result,
+ * or returns `this` value if the [condition] is false.
+ *
+ * Useful for interacting with builder/fluent APIs.
+ */
+fun <T> T.runIf(condition: Boolean, block: T.() -> T): T {
+    return if (condition) {
+        block()
+    } else {
+        this
+    }
+}

--- a/server/src/main/kotlin/com/trib3/server/config/dropwizard/CloudWatchReporterFactory.kt
+++ b/server/src/main/kotlin/com/trib3/server/config/dropwizard/CloudWatchReporterFactory.kt
@@ -1,0 +1,173 @@
+package com.trib3.server.config.dropwizard
+
+import com.codahale.metrics.MetricRegistry
+import com.fasterxml.jackson.annotation.JacksonInject
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonTypeName
+import com.trib3.server.config.TribeApplicationConfig
+import com.trib3.server.runIf
+import io.dropwizard.metrics.BaseReporterFactory
+import io.github.azagniotov.metrics.reporter.cloudwatch.CloudWatchReporter
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient
+import software.amazon.awssdk.services.cloudwatch.model.StandardUnit
+import java.net.InetAddress
+
+/**
+ * [BaseReporterFactory] that creates a [CloudWatchReporter] based
+ * on the dropwizard configuration.
+ *
+ * Use [includes] and [excludes] to control which attributes get
+ * reported to CloudWatch.
+ */
+@JsonTypeName("cloudwatch")
+class CloudWatchReporterFactory(
+    @JacksonInject @JsonIgnore
+    private val appConfig: TribeApplicationConfig,
+    @JacksonInject @JsonIgnore
+    internal val cloudwatch: CloudWatchAsyncClient
+) : BaseReporterFactory() {
+    private val hostname = InetAddress.getLocalHost().hostName
+
+    /**
+     * Sets the cloudwatch namespace, defaults to the [TribeApplicationConfig.env] if unspecified
+     */
+    @JsonProperty
+    private val namespace: String? = null
+
+    /**
+     * Sets dimension values (name=value formatted strings) on all metrics.
+     * Will automatically include Application=[TribeApplicationConfig.appName]
+     * and Hostname=${InetAddress.getLocalHost().hostname} as dimensions.
+     */
+    @JsonProperty
+    private val globalDimensions = listOf<String>()
+
+    /**
+     * Allows config to override the default percentiles (0.75, 0.95 and 0.999) reported
+     * for [com.codahale.metrics.Histogram]s and [com.codahale.metrics.Timer]s
+     */
+    @JsonProperty
+    private val percentiles = listOf<CloudWatchReporter.Percentile>()
+
+    /**
+     * Log instead of actually reporting metrics to CloudWatch
+     */
+    @JsonProperty
+    private val dryRun = false
+
+    /**
+     * Send mean rates for [com.codahale.metrics.Meter]s and [com.codahale.metrics.Timer]s
+     */
+    @JsonProperty
+    private val meanRate = false
+
+    /**
+     * Send one minute mean rates for [com.codahale.metrics.Meter]s and [com.codahale.metrics.Timer]s
+     */
+    @JsonProperty
+    private val oneMinuteMeanRate = false
+
+    /**
+     * Send five minute mean rates for [com.codahale.metrics.Meter]s and [com.codahale.metrics.Timer]s
+     */
+    @JsonProperty
+    private val fiveMinuteMeanRate = false
+
+    /**
+     * Send fifteen minute mean rates for [com.codahale.metrics.Meter]s and [com.codahale.metrics.Timer]s
+     */
+    @JsonProperty
+    private val fifteenMinuteMeanRate = false
+
+    /**
+     * Send arithmetic mean of [com.codahale.metrics.Snapshot] values of
+     * [com.codahale.metrics.Histogram]s and [com.codahale.metrics.Timer]s
+     */
+    @JsonProperty
+    private val arithmeticMean = false
+
+    /**
+     * Send standard deviation of [com.codahale.metrics.Snapshot] values of
+     * [com.codahale.metrics.Histogram]s and [com.codahale.metrics.Timer]s
+     */
+    @JsonProperty
+    private val stdDev = false
+
+    /**
+     * Send [com.codahale.metrics.Snapshot] summary values of
+     * [com.codahale.metrics.Histogram]s and [com.codahale.metrics.Timer]s
+     * as [software.amazon.awssdk.services.cloudwatch.model.StatisticSet]s
+     */
+    @JsonProperty
+    private val statisticSet = false
+
+    /**
+     * Post all values, including zeros, to CloudWatch
+     */
+    @JsonProperty
+    private val zeroValueSubmission = false
+
+    /**
+     * Send metrics as high resolution (1-second storage resolution)
+     * instead of standard resolution (60-second storage resolution)
+     */
+    @JsonProperty
+    private val highResolution = false
+
+    /**
+     * Report on raw metric values instead of the change in value from last report time
+     */
+    @JsonProperty
+    private val reportRawCountValue = false
+
+    /**
+     * Add additional JVM metrics to the reported metrics.
+     */
+    @JsonProperty
+    private val jvmMetrics = false
+
+    /**
+     * Convert [com.codahale.metrics.Meter]s to this unit instead of the [durationUnit]
+     */
+    @JsonProperty
+    private val meterUnit: StandardUnit? = null
+
+    override fun build(registry: MetricRegistry): CloudWatchReporter {
+        val finalDimensions = globalDimensions + listOf("Hostname=$hostname", "Application=${appConfig.appName}")
+        return CloudWatchReporter.forRegistry(registry, cloudwatch, namespace ?: appConfig.env)
+            .withGlobalDimensions(*finalDimensions.toTypedArray())
+            .convertDurationsTo(durationUnit)
+            .convertRatesTo(rateUnit)
+            .filter(filter)
+            .runIf(dryRun) {
+                withDryRun()
+            }.runIf(oneMinuteMeanRate) {
+                withOneMinuteMeanRate()
+            }.runIf(fiveMinuteMeanRate) {
+                withFiveMinuteMeanRate()
+            }.runIf(fifteenMinuteMeanRate) {
+                withFifteenMinuteMeanRate()
+            }.runIf(meanRate) {
+                withMeanRate()
+            }.runIf(arithmeticMean) {
+                withArithmeticMean()
+            }.runIf(stdDev) {
+                withStdDev()
+            }.runIf(statisticSet) {
+                withStatisticSet()
+            }.runIf(zeroValueSubmission) {
+                withZeroValuesSubmission()
+            }.runIf(highResolution) {
+                withHighResolution()
+            }.runIf(jvmMetrics) {
+                withJvmMetrics()
+            }.runIf(reportRawCountValue) {
+                withReportRawCountValue()
+            }.runIf(percentiles.isNotEmpty()) {
+                withPercentiles(*percentiles.toTypedArray())
+            }.runIf(meterUnit != null) {
+                withMeterUnitSentToCW(meterUnit)
+            }.build()
+    }
+}

--- a/server/src/main/kotlin/com/trib3/server/healthchecks/VersionHealthCheck.kt
+++ b/server/src/main/kotlin/com/trib3/server/healthchecks/VersionHealthCheck.kt
@@ -48,11 +48,11 @@ open class VersionHealthCheck : HealthCheck() {
 
     public override fun check(): Result {
         return Result.builder().withMessage(info)
-            .let { builder ->
+            .run {
                 if (healthy) {
-                    builder.healthy()
+                    healthy()
                 } else {
-                    builder.unhealthy()
+                    unhealthy()
                 }
             }.build()
     }

--- a/server/src/main/kotlin/com/trib3/server/resources/AuthCookieResource.kt
+++ b/server/src/main/kotlin/com/trib3/server/resources/AuthCookieResource.kt
@@ -2,6 +2,7 @@ package com.trib3.server.resources
 
 import com.codahale.metrics.annotation.Timed
 import com.trib3.server.config.TribeApplicationConfig
+import com.trib3.server.runIf
 import org.eclipse.jetty.http.HttpStatus
 import java.util.Locale
 import javax.annotation.security.PermitAll
@@ -45,9 +46,9 @@ class AuthCookieResource @Inject constructor(
             .getHeaderString("Authorization")
             ?.split(' ', limit = 2)
         val authToken = authHeaderSplit?.last()
-        return Response.status(HttpStatus.NO_CONTENT_204).let { builder ->
-            if (authToken != null) {
-                builder.cookie(
+        return Response.status(HttpStatus.NO_CONTENT_204)
+            .runIf(authToken != null) {
+                cookie(
                     NewCookie(
                         getCookieName(),
                         authToken,
@@ -61,9 +62,6 @@ class AuthCookieResource @Inject constructor(
                         true
                     )
                 )
-            } else {
-                builder
-            }
-        }.build()
+            }.build()
     }
 }

--- a/server/src/main/resources/META-INF/services/io.dropwizard.metrics.ReporterFactory
+++ b/server/src/main/resources/META-INF/services/io.dropwizard.metrics.ReporterFactory
@@ -1,0 +1,1 @@
+com.trib3.server.config.dropwizard.CloudWatchReporterFactory

--- a/server/src/test/kotlin/com/trib3/server/ExtensionsTest.kt
+++ b/server/src/test/kotlin/com/trib3/server/ExtensionsTest.kt
@@ -1,0 +1,14 @@
+package com.trib3.server
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import org.testng.annotations.Test
+
+class ExtensionsTest {
+    @Test
+    fun testApplyIf() {
+        val s = "test string"
+        assertThat(s.runIf(s.startsWith("test")) { toUpperCase() }).isEqualTo("TEST STRING")
+        assertThat(s.runIf(s.startsWith("string")) { toUpperCase() }).isEqualTo("test string")
+    }
+}

--- a/server/src/test/kotlin/com/trib3/server/config/dropwizard/CloudWatchReporterFactoryTest.kt
+++ b/server/src/test/kotlin/com/trib3/server/config/dropwizard/CloudWatchReporterFactoryTest.kt
@@ -1,0 +1,320 @@
+package com.trib3.server.config.dropwizard
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEmpty
+import com.codahale.metrics.Gauge
+import com.codahale.metrics.MetricRegistry
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.trib3.config.ConfigLoader
+import com.trib3.json.modules.ObjectMapperModule
+import com.trib3.testing.LeakyMock
+import dev.misfitlabs.kotlinguice4.KotlinModule
+import io.dropwizard.validation.BaseValidator
+import org.easymock.Capture
+import org.easymock.EasyMock
+import org.testng.annotations.Guice
+import org.testng.annotations.Test
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient
+import software.amazon.awssdk.services.cloudwatch.model.MetricDatum
+import software.amazon.awssdk.services.cloudwatch.model.PutMetricDataRequest
+import software.amazon.awssdk.services.cloudwatch.model.StandardUnit
+import java.net.InetAddress
+import java.util.concurrent.CompletableFuture
+import javax.inject.Inject
+
+/**
+ * Extension function to make it easier to find the Type dimension
+ * in a MetricDatum for test purposes
+ */
+fun MetricDatum.typeDimension(): String? {
+    return this.dimensions().find { it.name() == "Type" }?.value()
+}
+
+/**
+ * Base test module that configures a mock cloudwatch that expects
+ * to have metric data put during the execution of the test.
+ * Tests using this module can @[Inject] a [Capture<PutMetricDataRequest>]
+ * and perform assertions on the captured metric data.
+ *
+ * Note that each test below has its own unique subclass of this
+ * module so that guice bound values are not shared between tests.
+ */
+open class MockCloudWatchModule : KotlinModule() {
+    override fun configure() {
+        val capture = EasyMock.newCapture<PutMetricDataRequest>()
+        bind<Capture<PutMetricDataRequest>>().toInstance(capture)
+        val mockCloudWatch = LeakyMock.mock<CloudWatchAsyncClient>()
+        EasyMock.expect(mockCloudWatch.putMetricData(EasyMock.capture(capture)))
+            .andReturn(CompletableFuture.completedFuture(null)).atLeastOnce()
+        EasyMock.replay(mockCloudWatch)
+        bind<CloudWatchAsyncClient>().toInstance(mockCloudWatch)
+        install(ObjectMapperModule())
+    }
+}
+
+/**
+ * Base class with methods for running a cloudwatch metric report(),
+ * after which assertions can be made on the catpured metric data
+ */
+open class CloudWatchReporterFactoryTestBase(val mapper: ObjectMapper) {
+    fun runReporter(testCaseConfigPath: String) {
+        val configFactory = HoconConfigurationFactory(
+            CloudWatchReporterFactory::class.java,
+            BaseValidator.newValidator(),
+            mapper,
+            ConfigLoader(testCaseConfigPath)
+        )
+        val factory = configFactory.build()
+        factory.build(getMetricRegistry()).report()
+        EasyMock.verify(factory.cloudwatch)
+    }
+
+    fun getMetricRegistry(): MetricRegistry {
+        return MetricRegistry().also {
+            // create all types of metrics
+            it.gauge("g1") {
+                Gauge { 1 }
+            }
+            it.counter("c1").inc()
+            it.counter("c2").inc()
+            it.histogram("h1").update(1)
+            it.meter("m1").mark()
+            it.meter("m1").mark()
+            it.timer("t1").time().stop()
+        }
+    }
+}
+
+class MockCloudWatchModuleDefault : MockCloudWatchModule()
+
+@Guice(modules = [MockCloudWatchModuleDefault::class])
+class CloudWatchReporterFactoryDefaultTest @Inject constructor(
+    mapper: ObjectMapper,
+    val putCapture: Capture<PutMetricDataRequest>
+) : CloudWatchReporterFactoryTestBase(mapper) {
+    @Test
+    fun testDefaultConfig() {
+        runReporter("emptyTestCase")
+        val metricData = putCapture.value.metricData()
+        assertThat(putCapture.value.namespace()).isEqualTo("dev")
+        assertThat(metricData.size).isEqualTo(11)
+        metricData.forEach {
+            assertThat(it.storageResolution()).isEqualTo(60)
+            assertThat(
+                it.dimensions().first { d -> d.name() == "Hostname" }
+                    ?.value()
+            ).isEqualTo(InetAddress.getLocalHost().hostName)
+            assertThat(
+                it.dimensions().first { d -> d.name() == "Application" }
+                    ?.value()
+            ).isEqualTo("Test")
+        }
+        assertThat(metricData[0].metricName()).isEqualTo("g1")
+        assertThat(metricData[0].typeDimension()).isEqualTo("gauge")
+        assertThat(metricData[1].metricName()).isEqualTo("c1")
+        assertThat(metricData[1].typeDimension()).isEqualTo("count")
+        assertThat(metricData[2].metricName()).isEqualTo("h1")
+        assertThat(metricData[2].typeDimension()).isEqualTo("count")
+        assertThat(metricData[3].metricName()).isEqualTo("h1")
+        assertThat(metricData[3].typeDimension()).isEqualTo("75%")
+        assertThat(metricData[4].metricName()).isEqualTo("h1")
+        assertThat(metricData[4].typeDimension()).isEqualTo("95%")
+        assertThat(metricData[5].metricName()).isEqualTo("h1")
+        assertThat(metricData[5].typeDimension()).isEqualTo("99.9%")
+        assertThat(metricData[6].metricName()).isEqualTo("m1")
+        assertThat(metricData[6].typeDimension()).isEqualTo("count")
+        assertThat(metricData[6].unit()).isEqualTo(StandardUnit.COUNT)
+        assertThat(metricData[7].metricName()).isEqualTo("t1")
+        assertThat(metricData[7].typeDimension()).isEqualTo("count")
+        assertThat(metricData[8].metricName()).isEqualTo("t1")
+        assertThat(metricData[8].typeDimension()).isEqualTo("75%")
+        assertThat(metricData[9].metricName()).isEqualTo("t1")
+        assertThat(metricData[9].typeDimension()).isEqualTo("95%")
+        assertThat(metricData[10].metricName()).isEqualTo("t1")
+        assertThat(metricData[10].typeDimension()).isEqualTo("99.9%")
+    }
+}
+
+class MockCloudWatchModuleNamespace : MockCloudWatchModule()
+
+@Guice(modules = [MockCloudWatchModuleNamespace::class])
+class CloudWatchReporterFactoryNamespaceTest @Inject constructor(
+    mapper: ObjectMapper,
+    val putCapture: Capture<PutMetricDataRequest>
+) : CloudWatchReporterFactoryTestBase(mapper) {
+    @Test
+    fun testNamespace() {
+        runReporter("namespaceTestCase")
+        assertThat(putCapture.value.namespace()).isEqualTo("overrideNamespace")
+    }
+}
+
+class MockCloudWatchModuleMeterRates : MockCloudWatchModule()
+
+@Guice(modules = [MockCloudWatchModuleMeterRates::class])
+class CloudWatchReporterFactoryMeterRatesTest @Inject constructor(
+    mapper: ObjectMapper,
+    val putCapture: Capture<PutMetricDataRequest>
+) : CloudWatchReporterFactoryTestBase(mapper) {
+    @Test
+    fun testMeterRates() {
+        runReporter("meterRatesTestCase")
+        val metricData = putCapture.value.metricData()
+        assertThat(metricData.size).isEqualTo(5)
+        putCapture.value.metricData().forEach {
+            assertThat(it.metricName()).isEqualTo("m1")
+            if (it.dimensions().find { d -> d.name() == "Type" }?.value() == "count") {
+                assertThat(it.unit()).isEqualTo(StandardUnit.COUNT)
+            } else {
+                assertThat(it.unit()).isEqualTo(StandardUnit.MILLISECONDS)
+            }
+        }
+        assertThat(metricData[0].typeDimension()).isEqualTo("count")
+        assertThat(metricData[1].typeDimension()).isEqualTo("1-min-mean-rate [per-second]")
+        assertThat(metricData[2].typeDimension()).isEqualTo("5-min-mean-rate [per-second]")
+        assertThat(metricData[3].typeDimension()).isEqualTo("15-min-mean-rate [per-second]")
+        assertThat(metricData[4].typeDimension()).isEqualTo("mean-rate [per-second]")
+    }
+}
+
+class MockCloudWatchModuleHistogramTimer : MockCloudWatchModule()
+
+@Guice(modules = [MockCloudWatchModuleHistogramTimer::class])
+class CloudWatchReporterFactoryHistogramTimerTest @Inject constructor(
+    mapper: ObjectMapper,
+    val putCapture: Capture<PutMetricDataRequest>
+) : CloudWatchReporterFactoryTestBase(mapper) {
+    @Test
+    fun testHistogramTimer() {
+        runReporter("histoTimerTestCase")
+        val metricData = putCapture.value.metricData()
+        assertThat(metricData.size).isEqualTo(12)
+        assertThat(metricData[0].metricName()).isEqualTo("h1")
+        assertThat(metricData[0].typeDimension()).isEqualTo("count")
+        assertThat(metricData[1].metricName()).isEqualTo("h1")
+        assertThat(metricData[1].typeDimension()).isEqualTo("50%")
+        assertThat(metricData[2].metricName()).isEqualTo("h1")
+        assertThat(metricData[2].typeDimension()).isEqualTo("99%")
+        assertThat(metricData[3].metricName()).isEqualTo("h1")
+        assertThat(metricData[3].typeDimension()).isEqualTo("snapshot-mean")
+        assertThat(metricData[4].metricName()).isEqualTo("h1")
+        assertThat(metricData[4].typeDimension()).isEqualTo("snapshot-std-dev")
+        assertThat(metricData[5].metricName()).isEqualTo("h1")
+        assertThat(metricData[5].typeDimension()).isEqualTo("snapshot-summary")
+        assertThat(metricData[6].metricName()).isEqualTo("t1")
+        assertThat(metricData[6].typeDimension()).isEqualTo("count")
+        assertThat(metricData[7].metricName()).isEqualTo("t1")
+        assertThat(metricData[7].typeDimension()).isEqualTo("50%")
+        assertThat(metricData[8].metricName()).isEqualTo("t1")
+        assertThat(metricData[8].typeDimension()).isEqualTo("99%")
+        assertThat(metricData[9].metricName()).isEqualTo("t1")
+        assertThat(metricData[9].typeDimension()).isEqualTo("snapshot-mean [in-milliseconds]")
+        assertThat(metricData[10].metricName()).isEqualTo("t1")
+        assertThat(metricData[10].typeDimension()).isEqualTo("snapshot-std-dev [in-milliseconds]")
+        assertThat(metricData[11].metricName()).isEqualTo("t1")
+        assertThat(metricData[11].typeDimension()).isEqualTo("snapshot-summary")
+    }
+}
+
+class MockCloudWatchModuleJvmMetrics : MockCloudWatchModule()
+
+@Guice(modules = [MockCloudWatchModuleJvmMetrics::class])
+class CloudWatchReporterFactoryJvmMetricsTest @Inject constructor(
+    mapper: ObjectMapper,
+    val putCapture: Capture<PutMetricDataRequest>
+) : CloudWatchReporterFactoryTestBase(mapper) {
+    @Test
+    fun testJvmMetrics() {
+        runReporter("jvmMetricsTestCase")
+        val metricData = putCapture.value.metricData()
+        assertThat(metricData.filter { it.metricName().startsWith("jvm.") }).isNotEmpty()
+    }
+}
+
+class MockCloudWatchModuleRawCount : MockCloudWatchModule()
+class MockCloudWatchModuleNonRawCount : MockCloudWatchModule()
+
+@Guice(modules = [MockCloudWatchModuleNonRawCount::class])
+class CloudWatchReporterFactoryNonRawCountTest @Inject constructor(
+    mapper: ObjectMapper,
+    val putCapture: Capture<PutMetricDataRequest>
+) : CloudWatchReporterFactoryTestBase(mapper) {
+    @Test
+    fun testNonRawCount() {
+        val factory = HoconConfigurationFactory(
+            CloudWatchReporterFactory::class.java,
+            BaseValidator.newValidator(),
+            mapper,
+            ConfigLoader("nonRawCountTestCase")
+        ).build()
+        val registry = getMetricRegistry()
+        val reporter = factory.build(registry)
+        reporter.report()
+        registry.counter("c1").inc()
+        reporter.report()
+        EasyMock.verify(factory.cloudwatch)
+        assertThat(putCapture.value.metricData()[0].value()).isEqualTo(1.0)
+    }
+}
+
+@Guice(modules = [MockCloudWatchModuleRawCount::class])
+class CloudWatchReporterFactoryRawCountTest @Inject constructor(
+    mapper: ObjectMapper,
+    val putCapture: Capture<PutMetricDataRequest>
+) : CloudWatchReporterFactoryTestBase(mapper) {
+
+    @Test
+    fun testRawCount() {
+        val factory = HoconConfigurationFactory(
+            CloudWatchReporterFactory::class.java,
+            BaseValidator.newValidator(),
+            mapper,
+            ConfigLoader("rawCountTestCase")
+        ).build()
+        val registry = getMetricRegistry()
+        val reporter = factory.build(registry)
+        reporter.report()
+        registry.counter("c1").inc()
+        reporter.report()
+        EasyMock.verify(factory.cloudwatch)
+        assertThat(putCapture.value.metricData()[0].value()).isEqualTo(2.0)
+    }
+}
+
+@Guice(modules = [MockCloudWatchModule::class])
+class CloudWatchReporterFactoryHighResolutionTest @Inject constructor(
+    mapper: ObjectMapper,
+    val putCapture: Capture<PutMetricDataRequest>
+) : CloudWatchReporterFactoryTestBase(mapper) {
+    @Test
+    fun testHighResolution() {
+        runReporter("highResolutionTestCase")
+        val metricData = putCapture.value.metricData()
+        assertThat(putCapture.value.namespace()).isEqualTo("dev")
+        assertThat(metricData.size).isEqualTo(11)
+        metricData.forEach {
+            assertThat(it.storageResolution()).isEqualTo(1)
+        }
+    }
+}
+
+class MockCloudWatchDryRunModule : KotlinModule() {
+    override fun configure() {
+        val mockCloudWatch = LeakyMock.mock<CloudWatchAsyncClient>()
+        EasyMock.replay(mockCloudWatch)
+        bind<CloudWatchAsyncClient>().toInstance(mockCloudWatch)
+        install(ObjectMapperModule())
+    }
+}
+
+@Guice(modules = [MockCloudWatchDryRunModule::class])
+class CloudWatchReporterDryRunFactoryTest @Inject constructor(
+    mapper: ObjectMapper
+) : CloudWatchReporterFactoryTestBase(mapper) {
+
+    @Test
+    fun testDryRun() {
+        runReporter("dryRunTestCase")
+    }
+}

--- a/server/src/test/resources/application.conf
+++ b/server/src/test/resources/application.conf
@@ -14,3 +14,49 @@ withTestModule {
     modules: [com.trib3.config.modules.KMSModule, com.trib3.server.TestModule]
   }
 }
+
+emptyTestCase: {
+}
+dryRunTestCase: {
+  dryRun: true
+}
+namespaceTestCase: {
+  namespace: overrideNamespace
+}
+percentileTestCase: {
+  percentiles: [P50, P99]
+  includes: [h1, t1]
+}
+meterRatesTestCase: {
+  meanRate: true
+  oneMinuteMeanRate: true
+  fiveMinuteMeanRate: true
+  fifteenMinuteMeanRate: true
+  meterUnit: MILLISECONDS
+  zeroValueSubmission: true
+  includes: [m1]
+}
+histoTimerTestCase: {
+  arithmeticMean: true
+  stdDev: true
+  statisticSet: true
+  percentiles: [P50, P99]
+  zeroValueSubmission: true
+  includes: [h1, t1]
+}
+nonRawCountTestCase: {
+  includes: [c1]
+}
+rawCountTestCase: {
+  reportRawCountValue: true
+  includes: [c1]
+}
+jvmMetricsTestCase: {
+  jvmMetrics: true
+}
+highResolutionTestCase: {
+  highResolution: true
+}
+type: cloudwatch
+# exclude c2 from all test cases
+excludes: [c2]


### PR DESCRIPTION
Add a ReporterFactory that allows configuration of a
dropwizard-metrics-cloudwatch reporter with all
currently supported options.

Add a jackson-guice bridge to the ObjectMapperProvider
to allow for @JacksonInject to inject guice bound values
to deserialized json objects.

Add an extension function to make builder-like patterns
a little more usable.