### PR TITLE
Fix memory leak when graphql query returns immediately

### DIFF
--- a/graphql/src/test/kotlin/com/trib3/graphql/resources/GraphQLResourceTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/resources/GraphQLResourceTest.kt
@@ -119,9 +119,12 @@ class GraphQLResourceTest {
 
     @Test
     fun testSimpleQuery() = runBlocking {
-        val result = resource.graphQL(Optional.empty(), GraphQLRequest("query {test(value:\"123\")}", null, null))
-        val graphQLResult = result.entity as ExecutionResult
-        assertThat(graphQLResult.getData<Map<String, String>>()["test"]).isEqualTo("123")
+        RequestIdFilter.withRequestId("test-simple-query") {
+            val result = resource.graphQL(Optional.empty(), GraphQLRequest("query {test(value:\"123\")}", null, null))
+            val graphQLResult = result.entity as ExecutionResult
+            assertThat(graphQLResult.getData<Map<String, String>>()["test"]).isEqualTo("123")
+            assertThat(resource.runningFutures["test-simple-query"]).isNull()
+        }
     }
 
     @Test
@@ -194,6 +197,7 @@ class GraphQLResourceTest {
                 assertThat(entity.errors).hasSize(1)
                 assertThat(entity.errors[0].message).contains("was cancelled")
                 assertThat(entity.extensions["RequestId"]).isEqualTo(requestId)
+                assertThat(resource.runningFutures[requestId]).isNull()
                 reached = true
             }
         }
@@ -216,6 +220,7 @@ class GraphQLResourceTest {
                 assertThat(entity.getData<Map<String, String>>()["cancellable"]).isEqualTo("result")
                 assertThat(entity.errors).isEmpty()
                 assertThat(entity.extensions["RequestId"]).isEqualTo(requestId)
+                assertThat(resource.runningFutures[requestId]).isNull()
                 reached = true
             }
         }
@@ -242,6 +247,7 @@ class GraphQLResourceTest {
                 assertThat(entity.getData<Map<String, String>>()["cancellable"]).isEqualTo("result")
                 assertThat(entity.errors).isEmpty()
                 assertThat(entity.extensions["RequestId"]).isEqualTo(requestId)
+                assertThat(resource.runningFutures[requestId]).isNull()
                 reached = true
             }
         }
@@ -273,6 +279,7 @@ class GraphQLResourceTest {
                 assertThat(entity.getData<Map<String, String>>()["cancellable"]).isEqualTo("result")
                 assertThat(entity.errors).isEmpty()
                 assertThat(entity.extensions["RequestId"]).isEqualTo(requestId)
+                assertThat(resource.runningFutures[requestId]).isNull()
                 reached = true
             }
         }


### PR DESCRIPTION
When executing a graphql query that returns immediately (like
an introspection query), we were removing from the query tracking
map before adding to it, so were leaking the coroutine scope and
anything referenced by it.  This changes the tracking map handling
to always remove after awaiting the query execution.