### PR TITLE
@GraphQLAuth directive [POSSIBLE BREAKING CHANGE]

### DIFF
--- a/build-resources/pom.xml
+++ b/build-resources/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.trib3</groupId>
     <artifactId>build-resources</artifactId>
-    <version>1.23-SNAPSHOT</version>
+    <version>1.24-SNAPSHOT</version>
 
     <name>Build Resources</name>
     <description>Resources for use during the build process</description>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.23-SNAPSHOT</version>
+        <version>1.24-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.23-SNAPSHOT</version>
+        <version>1.24-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/graphql/pom.xml
+++ b/graphql/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.23-SNAPSHOT</version>
+        <version>1.24-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/graphql/src/main/kotlin/com/trib3/graphql/execution/GraphQLAuthDirectiveWiring.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/execution/GraphQLAuthDirectiveWiring.kt
@@ -1,0 +1,78 @@
+package com.trib3.graphql.execution
+
+import com.expediagroup.graphql.generator.annotations.GraphQLDirective
+import com.expediagroup.graphql.generator.directives.KotlinFieldDirectiveEnvironment
+import com.expediagroup.graphql.generator.directives.KotlinSchemaDirectiveWiring
+import com.trib3.graphql.resources.GraphQLResourceContext
+import graphql.introspection.Introspection
+import graphql.schema.DataFetcher
+import graphql.schema.GraphQLFieldDefinition
+import io.dropwizard.auth.Authorizer
+import mu.KotlinLogging
+import java.security.Principal
+import javax.ws.rs.WebApplicationException
+import javax.ws.rs.core.Response
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Annotation to be used on field definitions to
+ * restrict access based on the context [Principal]'s role.
+ * If no roles are specified, any authenticated [Principal]
+ * will be authorized to access the annotated field.
+ *
+ * Note that such annotated field elements should be nullable,
+ * as failure to auth will result in a null return data value!
+ */
+@GraphQLDirective(
+    name = "auth",
+    description = "only allows given roles to access the annotated element",
+    locations = [Introspection.DirectiveLocation.FIELD_DEFINITION]
+)
+annotation class GraphQLAuth(val roles: Array<String> = [])
+
+/**
+ * Directive wiring that checks for auth before fetching data.
+ *
+ * If no roles or no authorizer are specified, will fetch data as long as a [Principal] is authenticated.
+ * Otherwise will only fetch data if the authenticated [Principal] is assigned any listed role.
+ *
+ * If data is not fetched, then [Response.Status.UNAUTHORIZED] will be returned as an error for an
+ * authenticated but unauthorized user, and [Response.Status.FORBIDDEN] will be returned as an error
+ * for an unauthenticated user.
+ */
+class GraphQLAuthDirectiveWiring(private val authorizer: Authorizer<Principal>?) : KotlinSchemaDirectiveWiring {
+
+    private fun missingAllowedRole(principal: Principal, roles: Array<String>): Boolean {
+        return authorizer != null && roles.isNotEmpty() && roles.none {
+            authorizer.authorize(principal, it, null)
+        }
+    }
+
+    override fun onField(environment: KotlinFieldDirectiveEnvironment): GraphQLFieldDefinition {
+        @Suppress("UNCHECKED_CAST")
+        val roles = environment.directive.getArgument("roles").value as Array<String>
+        val originalDataFetcher = environment.getDataFetcher()
+
+        val authFetcher = DataFetcher { dfe ->
+            val context = try {
+                dfe.getContext<GraphQLResourceContext?>()
+            } catch (e: Exception) {
+                log.warn("Could not get graphql context: ${e.message}, auth will treat principal as null")
+                null
+            }
+            if (context?.principal == null || missingAllowedRole(context.principal, roles)) {
+                val status = if (context?.principal == null) {
+                    Response.Status.UNAUTHORIZED
+                } else {
+                    Response.Status.FORBIDDEN
+                }
+                throw WebApplicationException(status.statusCode)
+            } else {
+                originalDataFetcher.get(dfe)
+            }
+        }
+        environment.setDataFetcher(authFetcher)
+        return super.onField(environment)
+    }
+}

--- a/graphql/src/main/kotlin/com/trib3/graphql/execution/LeakyCauldronHooks.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/execution/LeakyCauldronHooks.kt
@@ -1,12 +1,16 @@
 package com.trib3.graphql.execution
 
+import com.expediagroup.graphql.generator.directives.KotlinDirectiveWiringFactory
+import com.expediagroup.graphql.generator.directives.KotlinSchemaDirectiveWiring
 import com.expediagroup.graphql.generator.hooks.FlowSubscriptionSchemaGeneratorHooks
 import graphql.language.StringValue
 import graphql.schema.Coercing
 import graphql.schema.CoercingSerializeException
 import graphql.schema.GraphQLScalarType
 import graphql.schema.GraphQLType
+import io.dropwizard.auth.Authorizer
 import org.threeten.extra.YearQuarter
+import java.security.Principal
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -14,6 +18,8 @@ import java.time.OffsetDateTime
 import java.time.Year
 import java.time.YearMonth
 import java.util.UUID
+import javax.annotation.Nullable
+import javax.inject.Inject
 import kotlin.reflect.KType
 
 internal val YEAR_SCALAR = GraphQLScalarType.newScalar()
@@ -296,8 +302,21 @@ internal val UUID_SCALAR = GraphQLScalarType.newScalar()
 
 /**
  * Schema generator hooks implementation that defines scalars for java.time (and threeten-extras) objects
+ * and wires up the @[GraphQLAuth] directive.
  */
-class LeakyCauldronHooks : FlowSubscriptionSchemaGeneratorHooks() {
+class LeakyCauldronHooks @Inject constructor(
+    @Nullable authorizer: Authorizer<Principal>?,
+    manualWiring: Map<String, KotlinSchemaDirectiveWiring>
+) :
+    FlowSubscriptionSchemaGeneratorHooks() {
+    constructor() : this(null, emptyMap())
+
+    override val wiringFactory = KotlinDirectiveWiringFactory(
+        mapOf(
+            "auth" to GraphQLAuthDirectiveWiring(authorizer)
+        ) + manualWiring
+    )
+
     override fun willGenerateGraphQLType(type: KType): GraphQLType? {
         return when (type.classifier) {
             Year::class -> YEAR_SCALAR

--- a/graphql/src/main/kotlin/com/trib3/graphql/modules/DefaultGraphQLModule.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/modules/DefaultGraphQLModule.kt
@@ -51,12 +51,14 @@ class DefaultGraphQLModule : GraphQLApplicationModule() {
             .to<GraphQLWebSocketDropwizardAuthenticator>()
 
         resourceBinder().addBinding().to<GraphQLResource>()
+
         // Ensure graphql binders are set up
         graphQLPackagesBinder()
         graphQLQueriesBinder()
         graphQLMutationsBinder()
         graphQLSubscriptionsBinder()
         graphQLInstrumentationsBinder()
+        schemaDirectivesBinder()
 
         adminServletBinder().addBinding().toInstance(
             ServletConfig(
@@ -90,9 +92,9 @@ class DefaultGraphQLModule : GraphQLApplicationModule() {
         @Named(GRAPHQL_SUBSCRIPTIONS_BIND_NAME)
         subscriptions: Set<Any>,
         instrumentations: Set<Instrumentation>,
-        mapper: ObjectMapper
+        mapper: ObjectMapper,
+        hooks: LeakyCauldronHooks = LeakyCauldronHooks()
     ): GraphQL {
-        val hooks = LeakyCauldronHooks()
         val config = SchemaGeneratorConfig(
             graphQLPackages.toList(),
             hooks = hooks,

--- a/graphql/src/main/kotlin/com/trib3/graphql/modules/GraphQLApplicationModule.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/modules/GraphQLApplicationModule.kt
@@ -1,9 +1,11 @@
 package com.trib3.graphql.modules
 
+import com.expediagroup.graphql.generator.directives.KotlinSchemaDirectiveWiring
 import com.google.inject.name.Names
 import com.trib3.graphql.execution.GraphQLRequest
 import com.trib3.server.modules.DefaultApplicationModule
 import com.trib3.server.modules.TribeApplicationModule
+import dev.misfitlabs.kotlinguice4.multibindings.KotlinMapBinder
 import dev.misfitlabs.kotlinguice4.multibindings.KotlinMultibinder
 import dev.misfitlabs.kotlinguice4.multibindings.KotlinOptionalBinder
 import graphql.execution.instrumentation.Instrumentation
@@ -118,5 +120,13 @@ abstract class GraphQLApplicationModule : TribeApplicationModule() {
      */
     fun graphQLInstrumentationsBinder(): KotlinMultibinder<Instrumentation> {
         return KotlinMultibinder.newSetBinder(kotlinBinder)
+    }
+
+    /**
+     * Binder for Schema Directives.  By default an "auth" directive is registered;
+     * additional schema directives can be registered via this binder.
+     */
+    fun schemaDirectivesBinder(): KotlinMapBinder<String, KotlinSchemaDirectiveWiring> {
+        return KotlinMapBinder.newMapBinder(kotlinBinder)
     }
 }

--- a/graphql/src/test/kotlin/com/trib3/graphql/execution/GraphQLAuthDirectiveWiringTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/execution/GraphQLAuthDirectiveWiringTest.kt
@@ -1,0 +1,179 @@
+package com.trib3.graphql.execution
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import com.expediagroup.graphql.generator.SchemaGeneratorConfig
+import com.expediagroup.graphql.generator.TopLevelObject
+import com.expediagroup.graphql.generator.execution.SimpleKotlinDataFetcherFactoryProvider
+import com.expediagroup.graphql.generator.toSchema
+import com.trib3.graphql.resources.GraphQLResourceContext
+import com.trib3.json.ObjectMapperProvider
+import graphql.ExecutionInput
+import graphql.ExecutionResult
+import graphql.GraphQL
+import io.dropwizard.auth.Authorizer
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.testng.annotations.Test
+import java.security.Principal
+
+class AuthQuery {
+    @GraphQLAuth
+    fun needUser(ctx: GraphQLResourceContext): String? {
+        return ctx.principal?.name
+    }
+
+    fun noUser(): String {
+        return "nope"
+    }
+
+    @GraphQLAuth(["ADMIN"])
+    fun needSuperUser(ctx: GraphQLResourceContext): String? {
+        return ctx.principal?.name
+    }
+}
+
+class TestAuthorizer : Authorizer<Principal> {
+    override fun authorize(principal: Principal, role: String): Boolean {
+        return role != "ADMIN" || principal.name == "ADMIN"
+    }
+}
+
+class GraphQLGraphQLAuthDirectiveWiringTest {
+    val scope = CoroutineScope(Dispatchers.Default)
+    val regularUser = Principal { "bill" }
+    val superUser = Principal { "ADMIN" }
+
+    fun query(principal: Principal?, authorizer: Authorizer<Principal>? = TestAuthorizer()): ExecutionResult {
+        val hooks = LeakyCauldronHooks(authorizer, emptyMap())
+        val config =
+            SchemaGeneratorConfig(
+                listOf(this::class.java.packageName),
+                hooks = hooks,
+                dataFetcherFactoryProvider = SimpleKotlinDataFetcherFactoryProvider(
+                    ObjectMapperProvider().get()
+                )
+            )
+        return GraphQL.newGraphQL(
+            toSchema(config, listOf(TopLevelObject(AuthQuery())))
+        ).build().execute(
+            ExecutionInput.newExecutionInput()
+                .query("{ needUser noUser needSuperUser }")
+                .context(
+                    GraphQLResourceContext(principal, scope)
+                )
+                .build()
+        )
+    }
+
+    @Test
+    fun testRegularUser() {
+        val result = query(regularUser)
+        val data = result.getData<Map<String, String>>()
+        val errors = result.errors
+        assertThat(data["needUser"]).isEqualTo(regularUser.name)
+        assertThat(data["noUser"]).isEqualTo("nope")
+        assertThat(data["needSuperUser"]).isNull()
+        assertThat(errors).hasSize(1)
+        assertThat(errors[0].path[0]).isEqualTo("needSuperUser")
+        assertThat(errors[0].message).isNotNull().contains("HTTP 403 Forbidden")
+    }
+
+    @Test
+    fun testSuperUser() {
+        val result = query(superUser)
+        val data = result.getData<Map<String, String>>()
+        val errors = result.errors
+        assertThat(data["needUser"]).isEqualTo(superUser.name)
+        assertThat(data["noUser"]).isEqualTo("nope")
+        assertThat(data["needSuperUser"]).isEqualTo(superUser.name)
+        assertThat(errors).isEmpty()
+    }
+
+    @Test
+    fun testNoUser() {
+        val result = query(null)
+        val data = result.getData<Map<String, String>>()
+        val errors = result.errors
+        assertThat(data["needUser"]).isNull()
+        assertThat(data["noUser"]).isEqualTo("nope")
+        assertThat(data["needSuperUser"]).isNull()
+        assertThat(errors).hasSize(2)
+        assertThat(errors[0].path[0]).isEqualTo("needUser")
+        assertThat(errors[0].message).isNotNull().contains("HTTP 401 Unauthorized")
+        assertThat(errors[1].path[0]).isEqualTo("needSuperUser")
+        assertThat(errors[1].message).isNotNull().contains("HTTP 401 Unauthorized")
+    }
+
+    @Test
+    fun testRegularUserNoAuthorizer() {
+        val result = query(regularUser, null)
+        val data = result.getData<Map<String, String>>()
+        val errors = result.errors
+        assertThat(data["needUser"]).isEqualTo(regularUser.name)
+        assertThat(data["noUser"]).isEqualTo("nope")
+        assertThat(data["needSuperUser"]).isEqualTo(regularUser.name)
+        assertThat(errors).isEmpty()
+    }
+
+    @Test
+    fun testSuperUserNoAuthorizer() {
+        val result = query(superUser, null)
+        val data = result.getData<Map<String, String>>()
+        val errors = result.errors
+        assertThat(data["needUser"]).isEqualTo(superUser.name)
+        assertThat(data["noUser"]).isEqualTo("nope")
+        assertThat(data["needSuperUser"]).isEqualTo(superUser.name)
+        assertThat(errors).isEmpty()
+    }
+
+    @Test
+    fun testNoUserNoAuthorizer() {
+        val result = query(null, null)
+        val data = result.getData<Map<String, String>>()
+        val errors = result.errors
+        assertThat(data["needUser"]).isNull()
+        assertThat(data["noUser"]).isEqualTo("nope")
+        assertThat(data["needSuperUser"]).isNull()
+        assertThat(errors).hasSize(2)
+        assertThat(errors[0].path[0]).isEqualTo("needUser")
+        assertThat(errors[0].message).isNotNull().contains("HTTP 401 Unauthorized")
+        assertThat(errors[1].path[0]).isEqualTo("needSuperUser")
+        assertThat(errors[1].message).isNotNull().contains("HTTP 401 Unauthorized")
+    }
+
+    @Test
+    fun testNoContext() {
+        val hooks = LeakyCauldronHooks(null, emptyMap())
+        val config =
+            SchemaGeneratorConfig(
+                listOf(this::class.java.packageName),
+                hooks = hooks,
+                dataFetcherFactoryProvider = SimpleKotlinDataFetcherFactoryProvider(
+                    ObjectMapperProvider().get()
+                )
+            )
+        val result = GraphQL.newGraphQL(
+            toSchema(config, listOf(TopLevelObject(AuthQuery())))
+        ).build().execute(
+            ExecutionInput.newExecutionInput()
+                .query("{ needUser noUser needSuperUser }")
+                .build()
+        )
+        val data = result.getData<Map<String, String>>()
+        val errors = result.errors
+        assertThat(data["needUser"]).isNull()
+        assertThat(data["noUser"]).isEqualTo("nope")
+        assertThat(data["needSuperUser"]).isNull()
+        assertThat(errors).hasSize(2)
+        assertThat(errors[0].path[0]).isEqualTo("needUser")
+        assertThat(errors[0].message).isNotNull().contains("HTTP 401 Unauthorized")
+        assertThat(errors[1].path[0]).isEqualTo("needSuperUser")
+        assertThat(errors[1].message).isNotNull().contains("HTTP 401 Unauthorized")
+    }
+}

--- a/graphql/src/test/kotlin/com/trib3/graphql/execution/LeakyCauldronHooksTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/execution/LeakyCauldronHooksTest.kt
@@ -66,7 +66,7 @@ class LeakyCauldronHooksTest {
     val hooks = LeakyCauldronHooks()
     val config =
         SchemaGeneratorConfig(
-            listOf(),
+            listOf(this::class.java.packageName),
             hooks = hooks,
             dataFetcherFactoryProvider = SimpleKotlinDataFetcherFactoryProvider(
                 ObjectMapperProvider().get()

--- a/graphql/src/test/kotlin/com/trib3/graphql/execution/RequestIdInstrumentationTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/execution/RequestIdInstrumentationTest.kt
@@ -17,7 +17,7 @@ class Query {
 
 class RequestIdInstrumentationTest {
     val config =
-        SchemaGeneratorConfig(listOf())
+        SchemaGeneratorConfig(listOf(this::class.java.packageName))
     val graphQL =
         GraphQL.newGraphQL(
             toSchema(

--- a/graphql/src/test/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketTest.kt
@@ -120,7 +120,7 @@ class GraphQLWebSocketTest {
 
     val testGraphQL = GraphQL.newGraphQL(
         toSchema(
-            SchemaGeneratorConfig(listOf(), hooks = FlowSubscriptionSchemaGeneratorHooks()),
+            SchemaGeneratorConfig(listOf(this::class.java.packageName), hooks = FlowSubscriptionSchemaGeneratorHooks()),
             listOf(TopLevelObject(SocketQuery())),
             listOf(),
             listOf(TopLevelObject(SocketSubscription()))

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.23-SNAPSHOT</version>
+        <version>1.24-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/lambda/pom.xml
+++ b/lambda/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.23-SNAPSHOT</version>
+        <version>1.24-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.trib3</groupId>
     <artifactId>parent-pom</artifactId>
-    <version>1.23-SNAPSHOT</version>
+    <version>1.24-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Trib3 parent pom</name>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>1.23-SNAPSHOT</version>
+        <version>1.24-SNAPSHOT</version>
         <relativePath>parent-pom/pom.xml</relativePath>
     </parent>
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.23-SNAPSHOT</version>
+        <version>1.24-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/server/src/main/kotlin/com/trib3/server/modules/DefaultApplicationModule.kt
+++ b/server/src/main/kotlin/com/trib3/server/modules/DefaultApplicationModule.kt
@@ -65,9 +65,11 @@ class DefaultApplicationModule : TribeApplicationModule() {
         bind<HealthCheckRegistry>().`in`(Scopes.SINGLETON)
 
         // Ensure @Auth annotations can be used as long as downstream binds an AuthFilter implementation
+        // (and optionally an Authorizer implementation)
         resourceBinder().addBinding().toInstance(RolesAllowedDynamicFeature::class.java)
         resourceBinder().addBinding().toInstance(AuthValueFactoryProvider.Binder(Principal::class.java))
         authFilterBinder().setDefault().toProvider(Provider { null })
+        authorizerBinder().setDefault().toProvider(Provider { null })
     }
 
     /**

--- a/server/src/main/kotlin/com/trib3/server/modules/TribeApplicationModule.kt
+++ b/server/src/main/kotlin/com/trib3/server/modules/TribeApplicationModule.kt
@@ -5,6 +5,8 @@ import dev.misfitlabs.kotlinguice4.KotlinModule
 import dev.misfitlabs.kotlinguice4.multibindings.KotlinMultibinder
 import dev.misfitlabs.kotlinguice4.multibindings.KotlinOptionalBinder
 import io.dropwizard.auth.AuthFilter
+import io.dropwizard.auth.Authorizer
+import java.security.Principal
 import javax.servlet.Servlet
 
 data class ServletConfig(
@@ -60,6 +62,13 @@ open class TribeApplicationModule : KotlinModule() {
      * Optional binder for dropwizard AuthFilter
      */
     fun authFilterBinder(): KotlinOptionalBinder<AuthFilter<*, *>> {
+        return KotlinOptionalBinder.newOptionalBinder(kotlinBinder)
+    }
+
+    /**
+     * Optional binder for the role based principal authorizer
+     */
+    fun authorizerBinder(): KotlinOptionalBinder<Authorizer<Principal>> {
         return KotlinOptionalBinder.newOptionalBinder(kotlinBinder)
     }
 }

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.23-SNAPSHOT</version>
+        <version>1.24-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Add a schema directive that allows GraphQL schema fields
to be protected by role based auth.  Any field annotated
with @GraphQLAuth will only be returned to authenticated
users.  If an Authorizer binding is provided, then roles
passed to the @GraphQLAuth annotation will be enforced.

Bump version due to the Authorizer optional binding being
added by default, which may conflict with any existing
Authorizer bindings downstream.

Fix graphql tests to not scan the entire classpath,
saving memory when running tests.