### PR TITLE
Build for java 11 targets

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,7 +40,3 @@ updates:
   - dependency-name: jakarta.validation:jakarta.validation-api
     versions:
     - ">= 3.0.0"
-  # caffeine versions above 3 require java 11, we still run on java 8
-  - dependency-name: com.github.ben-manes.caffeine:caffeine
-    versions:
-    - ">= 3.0.0"

--- a/build-resources/pom.xml
+++ b/build-resources/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.trib3</groupId>
     <artifactId>build-resources</artifactId>
-    <version>1.25-SNAPSHOT</version>
+    <version>1.26-SNAPSHOT</version>
 
     <name>Build Resources</name>
     <description>Resources for use during the build process</description>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.25-SNAPSHOT</version>
+        <version>1.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.25-SNAPSHOT</version>
+        <version>1.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/graphql/pom.xml
+++ b/graphql/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.25-SNAPSHOT</version>
+        <version>1.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.25-SNAPSHOT</version>
+        <version>1.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/lambda/pom.xml
+++ b/lambda/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.25-SNAPSHOT</version>
+        <version>1.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.trib3</groupId>
     <artifactId>parent-pom</artifactId>
-    <version>1.25-SNAPSHOT</version>
+    <version>1.26-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Trib3 parent pom</name>
@@ -86,7 +86,7 @@
         <version.jackson.databind>${version.jackson}</version.jackson.databind>
         <version.jackson.hocon>1.1.0</version.jackson.hocon>
         <version.jacoco>0.8.7</version.jacoco>
-        <version.java.release>8</version.java.release>
+        <version.java.release>11</version.java.release>
         <version.javax.inject>1</version.javax.inject>
         <version.jaxb>2.3.3</version.jaxb>
         <version.jaxrs>2.1.6</version.jaxrs>
@@ -1521,7 +1521,7 @@
                                         <arg value="--config-resource"/>
                                         <arg value="detekt-config.yml"/>
                                         <arg value="--jvm-target"/>
-                                        <arg value="1.8"/>
+                                        <arg value="${version.java.release}"/>
                                         <arg value="--classpath"/>
                                         <arg value="${compile_classpath}"/>
                                     </java>
@@ -1557,7 +1557,7 @@
                     <artifactId>kotlin-maven-plugin</artifactId>
                     <version>${version.kotlin}</version>
                     <configuration>
-                        <jvmTarget>1.8</jvmTarget>
+                        <jvmTarget>${version.java.release}</jvmTarget>
                         <args>
                             <arg>-Werror</arg>
                             <arg>-Xopt-in=kotlin.RequiresOptIn</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>1.25-SNAPSHOT</version>
+        <version>1.26-SNAPSHOT</version>
         <relativePath>parent-pom/pom.xml</relativePath>
     </parent>
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.25-SNAPSHOT</version>
+        <version>1.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.25-SNAPSHOT</version>
+        <version>1.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Allows upgrading some dependencies to latest
versions (jooq, caffeine, hikariCP).

Bump minor version for breaking java 8 compat.