### PR TITLE
Port to graphql-kotlin 5 / graphql-java 17 [BREAKING CHANGE]

### DIFF
--- a/graphql/pom.xml
+++ b/graphql/pom.xml
@@ -69,6 +69,10 @@
         </dependency>
         <dependency>
             <groupId>com.graphql-java</groupId>
+            <artifactId>graphql-java-extended-scalars</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.graphql-java</groupId>
             <artifactId>java-dataloader</artifactId>
         </dependency>
         <dependency>

--- a/graphql/src/main/kotlin/com/trib3/graphql/GraphQLConfig.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/GraphQLConfig.kt
@@ -7,19 +7,19 @@ import javax.inject.Inject
 class GraphQLConfig
 @Inject constructor(loader: ConfigLoader) {
     val keepAliveIntervalSeconds: Long
-    val webSocketSubProtocol: String
     val idleTimeout: Long?
     val maxBinaryMessageSize: Int?
     val maxTextMessageSize: Int?
     val checkAuthorization: Boolean
+    val connectionInitWaitTimeout: Long
 
     init {
         val config = loader.load("graphQL")
         keepAliveIntervalSeconds = config.extract("keepAliveIntervalSeconds")
-        webSocketSubProtocol = config.extract("webSocketSubProtocol")
         idleTimeout = config.extract("idleTimeout")
         maxBinaryMessageSize = config.extract("maxBinaryMessageSize")
         maxTextMessageSize = config.extract("maxTextMessageSize")
         checkAuthorization = config.extract("checkAuthorization") ?: config.extract("authorizedWebSocketOnly") ?: false
+        connectionInitWaitTimeout = config.extract("connectionInitWaitTimeout")
     }
 }

--- a/graphql/src/main/kotlin/com/trib3/graphql/execution/ContextScopeFunctionDataFetcher.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/execution/ContextScopeFunctionDataFetcher.kt
@@ -4,6 +4,7 @@ import com.expediagroup.graphql.generator.execution.FunctionDataFetcher
 import com.expediagroup.graphql.generator.execution.SimpleKotlinDataFetcherFactoryProvider
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.trib3.graphql.resources.getInstance
 import graphql.schema.DataFetcherFactory
 import graphql.schema.DataFetchingEnvironment
 import kotlinx.coroutines.CoroutineScope
@@ -56,7 +57,7 @@ open class ContextScopeFunctionDataFetcher(
                 .plus(instanceParameter to instance)
 
             if (fn.isSuspend) {
-                val scope = (environment.getContext<Any?>() as? CoroutineScope) ?: this
+                val scope = environment.graphQlContext.getInstance<CoroutineScope>() ?: this
                 runScopedSuspendingFunction(parameterValues, scope)
             } else {
                 runBlockingFunction(parameterValues)

--- a/graphql/src/main/kotlin/com/trib3/graphql/execution/GraphQLRequest.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/execution/GraphQLRequest.kt
@@ -1,6 +1,7 @@
 package com.trib3.graphql.execution
 
 import com.trib3.graphql.modules.DataLoaderRegistryFactory
+import com.trib3.server.runIf
 import graphql.ExecutionInput
 
 /**
@@ -12,20 +13,18 @@ data class GraphQLRequest(val query: String, val variables: Map<String, Any>?, v
  * Extension function to convert a [GraphQLRequest] to an [ExecutionInput]
  */
 fun GraphQLRequest.toExecutionInput(
-    context: Any? = null,
+    contextMap: Map<*, Any>? = null,
     dataLoaderRegistryFactory: DataLoaderRegistryFactory? = null
 ): ExecutionInput {
     return ExecutionInput.newExecutionInput()
         .query(this.query)
         .variables(this.variables ?: emptyMap())
         .operationName(operationName)
-        .let { builder ->
-            context?.let { ctx ->
-                builder.context(ctx)
-            } ?: builder
+        .runIf(contextMap != null) {
+            graphQLContext(contextMap)
         }.let { builder ->
             dataLoaderRegistryFactory?.let { factory ->
-                builder.dataLoaderRegistry(factory(this, context))
+                builder.dataLoaderRegistry(factory(this, contextMap))
             } ?: builder
         }.build()
 }

--- a/graphql/src/main/kotlin/com/trib3/graphql/execution/LeakyCauldronHooks.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/execution/LeakyCauldronHooks.kt
@@ -4,12 +4,14 @@ import com.expediagroup.graphql.generator.directives.KotlinDirectiveWiringFactor
 import com.expediagroup.graphql.generator.directives.KotlinSchemaDirectiveWiring
 import com.expediagroup.graphql.generator.hooks.FlowSubscriptionSchemaGeneratorHooks
 import graphql.language.StringValue
+import graphql.scalars.ExtendedScalars
 import graphql.schema.Coercing
 import graphql.schema.CoercingSerializeException
 import graphql.schema.GraphQLScalarType
 import graphql.schema.GraphQLType
 import io.dropwizard.auth.Authorizer
 import org.threeten.extra.YearQuarter
+import java.math.BigDecimal
 import java.security.Principal
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -318,6 +320,8 @@ class LeakyCauldronHooks @Inject constructor(
     )
 
     override fun willGenerateGraphQLType(type: KType): GraphQLType? {
+        // TODO: include more from ExtendedScalars?
+        //       Use impls from ExtendedScalars instead of our own for date/time/datetimes?
         return when (type.classifier) {
             Year::class -> YEAR_SCALAR
             YearMonth::class -> YEAR_MONTH_SCALAR
@@ -327,6 +331,7 @@ class LeakyCauldronHooks @Inject constructor(
             LocalTime::class -> LOCAL_TIME_SCALAR
             OffsetDateTime::class -> OFFSET_DATETIME_SCALAR
             UUID::class -> UUID_SCALAR
+            BigDecimal::class -> ExtendedScalars.GraphQLBigDecimal
             else -> null
         }
     }

--- a/graphql/src/main/kotlin/com/trib3/graphql/execution/MessageGraphQLError.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/execution/MessageGraphQLError.kt
@@ -1,0 +1,22 @@
+package com.trib3.graphql.execution
+
+import graphql.ErrorClassification
+import graphql.GraphQLError
+import graphql.language.SourceLocation
+
+/**
+ * Simple [GraphQLError] implementation that only specified an error message
+ */
+class MessageGraphQLError(private val msg: String?) : GraphQLError {
+    override fun getMessage(): String? {
+        return msg
+    }
+
+    override fun getLocations(): List<SourceLocation> {
+        return listOf()
+    }
+
+    override fun getErrorType(): ErrorClassification? {
+        return null
+    }
+}

--- a/graphql/src/main/kotlin/com/trib3/graphql/modules/GraphQLApplicationModule.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/modules/GraphQLApplicationModule.kt
@@ -15,14 +15,14 @@ import java.security.Principal
 import javax.ws.rs.container.ContainerRequestContext
 
 /**
- * Function that takes a [GraphQLRequest] and an optional context
+ * Function that takes a [GraphQLRequest] and an optional contextMap
  * and returns a [DataLoaderRegistry] with registered [org.dataloader.DataLoader]s
  *
  * Invoked per GraphQL request to allow for batching of data fetchers
  */
 typealias DataLoaderRegistryFactory = Function2<
     @JvmSuppressWildcards GraphQLRequest,
-    @JvmSuppressWildcards Any?,
+    @JvmSuppressWildcards Map<*, Any>?,
     @JvmSuppressWildcards DataLoaderRegistry
     >
 

--- a/graphql/src/main/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketConsumer.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketConsumer.kt
@@ -1,12 +1,11 @@
 package com.trib3.graphql.websocket
 
-import com.expediagroup.graphql.generator.execution.GraphQLContext
 import com.trib3.graphql.GraphQLConfig
 import com.trib3.graphql.execution.GraphQLRequest
 import com.trib3.graphql.execution.toExecutionInput
 import com.trib3.graphql.modules.DataLoaderRegistryFactory
 import com.trib3.graphql.modules.GraphQLWebSocketAuthenticator
-import com.trib3.graphql.resources.GraphQLResourceContext
+import com.trib3.graphql.resources.getGraphQLContextMap
 import com.trib3.server.filters.RequestIdFilter
 import graphql.ExecutionResult
 import graphql.GraphQL
@@ -88,7 +87,7 @@ class KeepAliveCoroutine(
 @OptIn(ExperimentalCoroutinesApi::class)
 class QueryCoroutine(
     private val graphQL: GraphQL,
-    context: GraphQLContext,
+    context: Map<*, Any>,
     channel: Channel<OperationMessage<*>>,
     private val messageId: String,
     payload: GraphQLRequest,
@@ -354,7 +353,7 @@ class GraphQLWebSocketConsumer(
         }
         val queryCoroutine = QueryCoroutine(
             graphQL,
-            GraphQLResourceContext(socketPrincipal, adapter),
+            getGraphQLContextMap(adapter, socketPrincipal),
             channel,
             message.id,
             message.payload,

--- a/graphql/src/main/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketProtocol.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketProtocol.kt
@@ -2,20 +2,180 @@ package com.trib3.graphql.websocket
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonValue
 import com.trib3.graphql.execution.GraphQLRequest
+import com.trib3.graphql.execution.MessageGraphQLError
 import graphql.ExecutionResult
+import org.eclipse.jetty.websocket.api.Session
+import org.eclipse.jetty.websocket.api.StatusCode
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.memberProperties
 
 /**
- * Model for a message in the graphql websocket protocol
+ * Encapsulates the different behaviors in the apollo vs/ graphql-ws protocols.
+ * Maps equivalent messages (eg "start" vs "subscribe"), and provides callbacks
+ * for different behaviors (eg end an "error" message vs/ close the connection).
+ *
+ * The WebSocket consumer always works using apollo messages internally, so
+ * the adapter is responsible for translating from/to graphql-ws messages upon
+ * receipt/send events.
+ */
+enum class GraphQLWebSocketSubProtocol(
+    val subProtocol: String,
+    messageMapping: Map<OperationType<*>, OperationType<*>>,
+    private val onInvalidMessageCallback: (String?, String, GraphQLWebSocketAdapter) -> Unit,
+    private val onDuplicateQueryCallback: (OperationMessage<*>, GraphQLWebSocketAdapter) -> Unit,
+    private val onDuplicateInitCallback: (OperationMessage<*>, GraphQLWebSocketAdapter) -> Unit
+) {
+    APOLLO_PROTOCOL(
+        "graphql-ws",
+        mapOf(),
+        { messageId, messageBody, adapter ->
+            adapter.sendMessage(
+                OperationMessage(
+                    OperationType.GQL_ERROR, messageId,
+                    listOf(MessageGraphQLError("Invalid message `$messageBody`"))
+                )
+            )
+        },
+        { message, adapter ->
+            adapter.sendMessage(
+                OperationMessage(
+                    OperationType.GQL_ERROR,
+                    message.id,
+                    listOf(MessageGraphQLError("Query with id ${message.id} already running!"))
+                )
+            )
+        },
+        { message, adapter ->
+            adapter.sendMessage(
+                OperationMessage(
+                    OperationType.GQL_CONNECTION_ERROR,
+                    message.id,
+                    "Already connected!"
+                )
+            )
+        }
+    ),
+    GRAPHQL_WS_PROTOCOL(
+        "graphql-transport-ws",
+        mapOf(
+            OperationType.GQL_START to OperationType.GQL_SUBSCRIBE,
+            OperationType.GQL_DATA to OperationType.GQL_NEXT,
+            OperationType.GQL_STOP to OperationType.GQL_COMPLETE,
+            OperationType.GQL_CONNECTION_KEEP_ALIVE to OperationType.GQL_PONG
+        ),
+        { msgId, msgBody, adapter ->
+            adapter.session?.close(
+                GraphQLWebSocketCloseReason.INVALID_MESSAGE.code,
+                GraphQLWebSocketCloseReason.INVALID_MESSAGE.description.replace("<id>", msgId ?: "")
+                    .replace("<body>", msgBody)
+            )
+        },
+        { message, adapter ->
+            adapter.session?.close(
+                GraphQLWebSocketCloseReason.MULTIPLE_SUBSCRIBER.code,
+                GraphQLWebSocketCloseReason.MULTIPLE_SUBSCRIBER.description.replace(
+                    "<unique-operation-id>",
+                    message.id ?: ""
+                )
+            )
+        },
+        { _, adapter ->
+            adapter.session?.close(GraphQLWebSocketCloseReason.MULTIPLE_INIT)
+        }
+    );
+
+    private val apolloToGraphQlWsMapping = messageMapping.entries.associate { it.key.type to it.value.type }
+
+    private val graphQlWsToApolloMapping = apolloToGraphQlWsMapping.entries.associate {
+        it.value to it.key
+    }.filter {
+        // don't map PONG to KEEPALIVE even though we map outgoing KEEPALIVE messages to PONGs
+        it.key != OperationType.GQL_PONG.type
+    }
+
+    private fun <T : Any> getMessage(message: OperationMessage<T>, mapping: Map<String, String>): OperationMessage<T> {
+        return if (!mapping.containsKey(message.type?.type)) {
+            message
+        } else {
+            message.copy(type = message.type?.copy(type = mapping.getValue(message.type.type)))
+        }
+    }
+
+    /**
+     * Before sending a message to the client, map to the appropriate protocol message
+     */
+    fun <T : Any> getServerToClientMessage(message: OperationMessage<T>): OperationMessage<T> {
+        return getMessage(message, apolloToGraphQlWsMapping)
+    }
+
+    /**
+     * Upon receiving a message from the client, map from appropriate protocol message to an apollo
+     * message for internal consumption
+     */
+    fun <T : Any> getClientToServerMessage(message: OperationMessage<T>): OperationMessage<T> {
+        return getMessage(message, graphQlWsToApolloMapping)
+    }
+
+    /**
+     * graphql-ws closes the connection upon receiving an invalid message, while apollo just sends
+     * an error message in response.
+     */
+    fun onInvalidMessage(messageId: String?, messageBody: String, adapter: GraphQLWebSocketAdapter) {
+        this.onInvalidMessageCallback(messageId, messageBody, adapter)
+    }
+
+    /**
+     * graphql-ws closes the connection upon receiving a duplicate subscription, while apollo just sends
+     * an error message in response.
+     */
+    fun onDuplicateQuery(message: OperationMessage<*>, adapter: GraphQLWebSocketAdapter) {
+        this.onDuplicateQueryCallback(message, adapter)
+    }
+
+    /**
+     * graphql-ws closes the connection upon receiving duplicate connection_init requests, while apollo
+     * just sends an error message in response.
+     */
+    fun onDuplicateInit(message: OperationMessage<*>, adapter: GraphQLWebSocketAdapter) {
+        this.onDuplicateInitCallback(message, adapter)
+    }
+}
+
+/**
+ * Enum of websocket closure reasons from the graphql-ws protocol specification
+ */
+@Suppress("MagicNumber") // constructor values are consts, just put the numbers in instead of declaring const vals.
+enum class GraphQLWebSocketCloseReason(val code: Int, val description: String) {
+    NORMAL(StatusCode.NORMAL, "Normal Closure"),
+    INVALID_MESSAGE(4400, "Invalid Message with id `<id>`: `<body>`"),
+    UNAUTHORIZED(4401, "Unauthorized"),
+    TIMEOUT_INIT(4408, "Connection initialisation timeout"),
+    MULTIPLE_SUBSCRIBER(4409, "Subscriber for <unique-operation-id> already exists"),
+    MULTIPLE_INIT(4429, "Too many initialisation requests")
+    ;
+}
+
+/**
+ * Extension method to close the WebSocket session using a [GraphQLWebSocketCloseReason] instead of
+ * code/description pairs
+ */
+fun Session.close(reason: GraphQLWebSocketCloseReason) {
+    this.close(reason.code, reason.description)
+}
+
+/**
+ * Model for a message in the graphql websocket protocol.  Supports messages for either
+ * the apollo or graphql-ws protocols
  *
  * https://github.com/apollographql/subscriptions-transport-ws/blob/HEAD/PROTOCOL.md
+ * https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md
  */
 data class OperationMessage<T : Any>(
     val type: OperationType<T>?,
@@ -28,16 +188,21 @@ data class OperationMessage<T : Any>(
     )
     @JsonSubTypes(
         Type(name = "start", value = GraphQLRequest::class),
+        Type(name = "subscribe", value = GraphQLRequest::class),
         Type(name = "data", value = ExecutionResult::class),
-        Type(name = "error", value = String::class),
+        Type(name = "next", value = ExecutionResult::class),
+        Type(name = "error", value = List::class),
         Type(name = "connection_init", value = Map::class),
         Type(name = "connection_terminate", value = Nothing::class),
-        Type(name = "connection_ack", value = Nothing::class),
+        Type(name = "connection_ack", value = Map::class),
         Type(name = "connection_error", value = String::class),
         Type(name = "stop", value = Nothing::class),
         Type(name = "complete", value = Nothing::class),
-        Type(name = "ka", value = Nothing::class)
+        Type(name = "ka", value = Nothing::class),
+        Type(name = "ping", value = Map::class),
+        Type(name = "pong", value = Map::class),
     )
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     val payload: T? = null
 )
 
@@ -51,18 +216,24 @@ data class OperationType<T : Any>(
 ) {
     companion object {
         // client -> server
-        val GQL_CONNECTION_INIT = OperationType("connection_init", Map::class)
-        val GQL_START = OperationType("start", GraphQLRequest::class)
-        val GQL_STOP = OperationType("stop", Nothing::class)
-        val GQL_CONNECTION_TERMINATE = OperationType("connection_terminate", Nothing::class)
+        val GQL_CONNECTION_INIT = OperationType("connection_init", Map::class) // shared
+        val GQL_START = OperationType("start", GraphQLRequest::class) // apollo
+        val GQL_SUBSCRIBE = OperationType("subscribe", GraphQLRequest::class) // graphql-ws
+        val GQL_STOP = OperationType("stop", Nothing::class) // apollo-only, graphql-ws uses COMPLETE
+        val GQL_CONNECTION_TERMINATE = OperationType("connection_terminate", Nothing::class) // apollo-only
 
         // server -> client
-        val GQL_CONNECTION_ERROR = OperationType("connection_error", String::class)
-        val GQL_CONNECTION_ACK = OperationType("connection_ack", Nothing::class)
-        val GQL_DATA = OperationType("data", ExecutionResult::class)
-        val GQL_ERROR = OperationType("error", String::class)
-        val GQL_COMPLETE = OperationType("complete", Nothing::class)
-        val GQL_CONNECTION_KEEP_ALIVE = OperationType("ka", Nothing::class)
+        val GQL_CONNECTION_ERROR = OperationType("connection_error", String::class) // apollo-only
+        val GQL_CONNECTION_ACK = OperationType("connection_ack", Map::class) // shared
+        val GQL_DATA = OperationType("data", ExecutionResult::class) // apollo
+        val GQL_NEXT = OperationType("next", ExecutionResult::class) // graphql-ws
+        val GQL_ERROR = OperationType("error", List::class) // shared
+        val GQL_CONNECTION_KEEP_ALIVE = OperationType("ka", Nothing::class) // apollo-only, graphql-ws uses PING/PONG
+
+        // bidirectional
+        val GQL_PING = OperationType("ping", Map::class) // graphql-ws-only, apollo uses CONNECTION_KEEP_ALIVE
+        val GQL_PONG = OperationType("pong", Map::class) // graphql-ws-only, apollo uses CONNECTION_KEEP_ALIVE
+        val GQL_COMPLETE = OperationType("complete", Nothing::class) // shared, but server->client only in apollo
 
         /**
          * Factory method for converting the string type to an [OperationType] instance

--- a/graphql/src/main/resources/graphiql/index.html
+++ b/graphql/src/main/resources/graphiql/index.html
@@ -1,42 +1,45 @@
 <html>
 <head>
     <title>GraphiQL</title>
-    <link href="//unpkg.com/graphiql@1.0.6/graphiql.min.css" rel="stylesheet"/>
+    <link href="//unpkg.com/graphiql@1.4.6/graphiql.min.css" rel="stylesheet"/>
 </head>
 <body style="margin: 0;">
 <div id="graphiql" style="height: 100vh;"></div>
 
-<script crossorigin src="//unpkg.com/react@17.0.1/umd/react.production.min.js"></script>
-<script crossorigin src="//unpkg.com/react-dom@17.0.1/umd/react-dom.production.min.js"></script>
-<script crossorigin src="//unpkg.com/graphiql@1.0.6/graphiql.min.js"></script>
-<script crossorigin src="//unpkg.com/subscriptions-transport-ws@0.9.18/browser/client.js"></script>
+<script crossorigin src="//unpkg.com/react@17.0.2/umd/react.production.min.js"></script>
+<script crossorigin src="//unpkg.com/react-dom@17.0.2/umd/react-dom.production.min.js"></script>
+<script crossorigin src="//unpkg.com/graphiql@1.4.6/graphiql.min.js"></script>
+<script crossorigin src="//unpkg.com/graphql-ws@5.5.5/umd/graphql-ws.min.js"></script>
 
 <script>
     const fetcherFactory = function (subscriptionsClient, fallbackFetcher) {
-      var activeSubscription = null;
+      var cleanupCallback = null;
       var results = [];
-      return function (graphQLParams) {
-        if (subscriptionsClient && activeSubscription !== null) {
-          activeSubscription.unsubscribe();
+      return function (graphQLParams, fetcherOpts) {
+        if (subscriptionsClient && cleanupCallback !== null) {
+          cleanupCallback();
           results = [];
         }
-        if (subscriptionsClient && graphQLParams.query.trim().startsWith("subscription")) {
+        var isSubscription = fetcherOpts.documentAST.definitions.some((definition) => definition.operation == 'subscription');
+        if (subscriptionsClient && isSubscription) {
           return {
             subscribe: function (observer) {
               observer.next('Your subscription data will appear here after server publication!');
-              activeSubscription = subscriptionsClient.request({
+              cleanupCallback = subscriptionsClient.subscribe({
                 query: graphQLParams.query,
                 variables: graphQLParams.variables,
-              }).subscribe(function (result) {
-                results.push(result);
-                if (results.length % 10 == 0) { // debounce
-                  observer.next(results);
-                }
-              }, function(error) {
-                observer.error(error);
-              },
-              function() {
-                observer.next(results); // on completion show all results
+              }, {
+                next: function (result) {
+                  results.push({path: `${results.length}`, ...result});
+                  if (results.length % 10 == 0) { // debounce
+                    observer.next(results);
+                  }
+                }, error: function(error) {
+                  observer.error(error);
+                },
+                complete: function() {
+                  observer.next(results); // on completion show all results
+                },
               });
             },
           };
@@ -45,7 +48,6 @@
         }
       };
     };
-
 
     const graphQLFetcher = graphQLParams =>
       fetch('/app/graphql', {
@@ -59,10 +61,10 @@
     fetch('/app/auth_cookie', {
       method: 'get'
     }).then(response => {
-        const subscriptionsClient = new window.SubscriptionsTransportWs.SubscriptionClient(
-          `${wsproto}://${window.location.host}/app/graphql`,
-          { reconnect: true, timeout: 60000 }
-        );
+        const subscriptionsClient = graphqlWs.createClient({
+            url: `${wsproto}://${window.location.host}/app/graphql`,
+            lazyCloseTimeout: 60000
+        });
         const subscriptionsFetcher = fetcherFactory(subscriptionsClient, graphQLFetcher);
         ReactDOM.render(
           React.createElement(GraphiQL, { fetcher: subscriptionsFetcher }),

--- a/graphql/src/main/resources/reference.conf
+++ b/graphql/src/main/resources/reference.conf
@@ -1,4 +1,4 @@
 graphQL {
   keepAliveIntervalSeconds: 15
-  webSocketSubProtocol: "graphql-ws"
+  connectionInitWaitTimeout: 15
 }

--- a/graphql/src/test/kotlin/com/trib3/graphql/GraphQLConfigTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/GraphQLConfigTest.kt
@@ -15,14 +15,7 @@ class GraphQLConfigTest {
     fun testConfig() {
         val config = GraphQLConfig(ConfigLoader())
         assertThat(config.keepAliveIntervalSeconds).isEqualTo(DEFAULT_KEEPALIVE)
-        assertThat(config.webSocketSubProtocol).isEqualTo("graphql-ws")
-        for (
-            i in listOf(
-                config.idleTimeout,
-                config.maxBinaryMessageSize,
-                config.maxTextMessageSize
-            )
-        ) {
+        for (i in listOf(config.idleTimeout, config.maxBinaryMessageSize, config.maxTextMessageSize)) {
             assertThat(i).isNull()
         }
     }

--- a/graphql/src/test/kotlin/com/trib3/graphql/execution/ContextScopeFunctionDataFetcherTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/execution/ContextScopeFunctionDataFetcherTest.kt
@@ -6,8 +6,9 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import assertk.fail
-import com.trib3.graphql.resources.GraphQLResourceContext
+import com.trib3.graphql.resources.getGraphQLContextMap
 import com.trib3.testing.LeakyMock
+import graphql.GraphQLContext
 import graphql.schema.DataFetchingEnvironment
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelChildren
@@ -44,7 +45,7 @@ class ContextScopeFunctionDataFetcherTest {
     fun testNoTarget() {
         val fetcher = ContextScopeFunctionDataFetcher(null, ContextScopeQuery::coroutine)
         val mockEnv = LeakyMock.mock<DataFetchingEnvironment>()
-        EasyMock.expect(mockEnv.getContext<GraphQLResourceContext>()).andReturn(null)
+        EasyMock.expect(mockEnv.graphQlContext).andReturn(GraphQLContext.newContext().build())
         EasyMock.expect(mockEnv.getSource<Any?>()).andReturn(null)
         EasyMock.replay(mockEnv)
         assertThat(fetcher.get(mockEnv)).isNull()
@@ -54,7 +55,7 @@ class ContextScopeFunctionDataFetcherTest {
     fun testNoScopeSuccess() = runBlocking {
         val fetcher = ContextScopeFunctionDataFetcher(ContextScopeQuery(), ContextScopeQuery::coroutine)
         val mockEnv = LeakyMock.mock<DataFetchingEnvironment>()
-        EasyMock.expect(mockEnv.getContext<GraphQLResourceContext>()).andReturn(null)
+        EasyMock.expect(mockEnv.graphQlContext).andReturn(GraphQLContext.newContext().build())
         EasyMock.replay(mockEnv)
         val future = fetcher.get(mockEnv) as CompletableFuture<*>
         assertThat(future.await()).isEqualTo("coroutine")
@@ -64,7 +65,7 @@ class ContextScopeFunctionDataFetcherTest {
     fun testNoScopeError() = runBlocking {
         val fetcher = ContextScopeFunctionDataFetcher(ContextScopeQuery(), ContextScopeQuery::coroutineExceptionNoCause)
         val mockEnv = LeakyMock.mock<DataFetchingEnvironment>()
-        EasyMock.expect(mockEnv.getContext<GraphQLResourceContext>()).andReturn(null)
+        EasyMock.expect(mockEnv.graphQlContext).andReturn(GraphQLContext.newContext().build())
         EasyMock.replay(mockEnv)
         val future = fetcher.get(mockEnv) as CompletableFuture<*>
         try {
@@ -79,7 +80,7 @@ class ContextScopeFunctionDataFetcherTest {
     fun testNoScopeCancel() = runBlocking {
         val fetcher = ContextScopeFunctionDataFetcher(ContextScopeQuery(), ContextScopeQuery::coroutine)
         val mockEnv = LeakyMock.mock<DataFetchingEnvironment>()
-        EasyMock.expect(mockEnv.getContext<GraphQLResourceContext>()).andReturn(null)
+        EasyMock.expect(mockEnv.graphQlContext).andReturn(GraphQLContext.newContext().build())
         EasyMock.replay(mockEnv)
         val scope = this
         val future = fetcher.get(mockEnv) as CompletableFuture<*>
@@ -94,7 +95,7 @@ class ContextScopeFunctionDataFetcherTest {
         val scope = this
         val fetcher = ContextScopeFunctionDataFetcher(ContextScopeQuery(), ContextScopeQuery::coroutine)
         val mockEnv = LeakyMock.mock<DataFetchingEnvironment>()
-        EasyMock.expect(mockEnv.getContext<GraphQLResourceContext>()).andReturn(GraphQLResourceContext(null, scope))
+        EasyMock.expect(mockEnv.graphQlContext).andReturn(GraphQLContext.of(getGraphQLContextMap(scope)))
         EasyMock.replay(mockEnv)
         val future = fetcher.get(mockEnv) as CompletableFuture<*>
         assertThat(future.await()).isEqualTo("coroutine")
@@ -106,7 +107,7 @@ class ContextScopeFunctionDataFetcherTest {
             val scope = this
             val fetcher = ContextScopeFunctionDataFetcher(ContextScopeQuery(), ContextScopeQuery::coroutineException)
             val mockEnv = LeakyMock.mock<DataFetchingEnvironment>()
-            EasyMock.expect(mockEnv.getContext<GraphQLResourceContext>()).andReturn(GraphQLResourceContext(null, scope))
+            EasyMock.expect(mockEnv.graphQlContext).andReturn(GraphQLContext.of(getGraphQLContextMap(scope)))
             EasyMock.replay(mockEnv)
             val future = fetcher.get(mockEnv) as CompletableFuture<*>
             try {
@@ -124,7 +125,7 @@ class ContextScopeFunctionDataFetcherTest {
             val scope = this
             val fetcher = ContextScopeFunctionDataFetcher(ContextScopeQuery(), ContextScopeQuery::coroutine)
             val mockEnv = LeakyMock.mock<DataFetchingEnvironment>()
-            EasyMock.expect(mockEnv.getContext<GraphQLResourceContext>()).andReturn(GraphQLResourceContext(null, scope))
+            EasyMock.expect(mockEnv.graphQlContext).andReturn(GraphQLContext.of(getGraphQLContextMap(scope)))
             EasyMock.replay(mockEnv)
             val future = fetcher.get(mockEnv) as CompletableFuture<*>
             launch {

--- a/graphql/src/test/kotlin/com/trib3/graphql/execution/GraphQLAuthDirectiveWiringTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/execution/GraphQLAuthDirectiveWiringTest.kt
@@ -11,11 +11,13 @@ import com.expediagroup.graphql.generator.SchemaGeneratorConfig
 import com.expediagroup.graphql.generator.TopLevelObject
 import com.expediagroup.graphql.generator.execution.SimpleKotlinDataFetcherFactoryProvider
 import com.expediagroup.graphql.generator.toSchema
-import com.trib3.graphql.resources.GraphQLResourceContext
+import com.trib3.graphql.resources.getGraphQLContextMap
+import com.trib3.graphql.resources.getInstance
 import com.trib3.json.ObjectMapperProvider
 import graphql.ExecutionInput
 import graphql.ExecutionResult
 import graphql.GraphQL
+import graphql.schema.DataFetchingEnvironment
 import io.dropwizard.auth.Authorizer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -24,8 +26,8 @@ import java.security.Principal
 
 class AuthQuery {
     @GraphQLAuth
-    fun needUser(ctx: GraphQLResourceContext): String? {
-        return ctx.principal?.name
+    fun needUser(dfe: DataFetchingEnvironment): String? {
+        return dfe.graphQlContext.getInstance<Principal>()?.name
     }
 
     fun noUser(): String {
@@ -33,8 +35,8 @@ class AuthQuery {
     }
 
     @GraphQLAuth(["ADMIN"])
-    fun needSuperUser(ctx: GraphQLResourceContext): String? {
-        return ctx.principal?.name
+    fun needSuperUser(dfe: DataFetchingEnvironment): String? {
+        return dfe.graphQlContext.getInstance<Principal>()?.name
     }
 }
 
@@ -64,8 +66,8 @@ class GraphQLGraphQLAuthDirectiveWiringTest {
         ).build().execute(
             ExecutionInput.newExecutionInput()
                 .query("{ needUser noUser needSuperUser }")
-                .context(
-                    GraphQLResourceContext(principal, scope)
+                .graphQLContext(
+                    getGraphQLContextMap(scope, principal)
                 )
                 .build()
         )

--- a/graphql/src/test/kotlin/com/trib3/graphql/execution/GraphQLRequestTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/execution/GraphQLRequestTest.kt
@@ -3,7 +3,6 @@ package com.trib3.graphql.execution
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
-import graphql.GraphQLContext
 import graphql.execution.instrumentation.dataloader.DataLoaderDispatcherInstrumentationState
 import org.dataloader.DataLoaderRegistry
 import org.testng.annotations.Test
@@ -17,14 +16,14 @@ class GraphQLRequestTest {
         assertThat(executionInput.dataLoaderRegistry).isEqualTo(
             DataLoaderDispatcherInstrumentationState.EMPTY_DATALOADER_REGISTRY
         )
-        assertThat(executionInput.context).isInstanceOf(GraphQLContext::class)
 
         val emptyRegistry = DataLoaderRegistry()
-        val executionInputWithArgs = request.toExecutionInput("context object") { _, _ ->
+        val executionInputWithArgs = request.toExecutionInput(mapOf("context key" to "context object")) { _, _ ->
             emptyRegistry
         }
         assertThat(executionInputWithArgs.query).isEqualTo(request.query)
         assertThat(executionInputWithArgs.dataLoaderRegistry).isEqualTo(emptyRegistry)
-        assertThat(executionInputWithArgs.context).isInstanceOf(String::class).isEqualTo("context object")
+        assertThat(executionInputWithArgs.graphQLContext.get<String>("context key")).isInstanceOf(String::class)
+            .isEqualTo("context object")
     }
 }

--- a/graphql/src/test/kotlin/com/trib3/graphql/execution/LeakyCauldronHooksTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/execution/LeakyCauldronHooksTest.kt
@@ -15,6 +15,7 @@ import graphql.GraphQL
 import graphql.schema.CoercingSerializeException
 import org.testng.annotations.Test
 import org.threeten.extra.YearQuarter
+import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -59,6 +60,10 @@ class HooksQuery {
 
     fun existinguuid(uuid: UUID): String {
         return uuid.toString()
+    }
+
+    fun bigDecimal(): BigDecimal {
+        return BigDecimal.TEN
     }
 }
 
@@ -335,5 +340,11 @@ class LeakyCauldronHooksTest {
                 .variables(mapOf("input" to uuid.toString())).build()
         ).getData<Map<String, String>>()
         assertThat(result["existinguuid"]).isEqualTo(uuid.toString())
+    }
+
+    @Test
+    fun testBigDecimal() {
+        val result = graphQL.execute("""query { bigDecimal }""").getData<Map<String, BigDecimal>>()
+        assertThat(result["bigDecimal"]).isEqualTo(BigDecimal.TEN)
     }
 }

--- a/graphql/src/test/kotlin/com/trib3/graphql/resources/GraphQLResourceIntegrationTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/resources/GraphQLResourceIntegrationTest.kt
@@ -20,6 +20,7 @@ import com.trib3.testing.server.JettyWebTestContainerFactory
 import com.trib3.testing.server.ResourceTestBase
 import graphql.GraphQL
 import graphql.execution.AsyncExecutionStrategy
+import graphql.schema.DataFetchingEnvironment
 import io.dropwizard.auth.AuthDynamicFeature
 import io.dropwizard.testing.common.Resource
 import org.eclipse.jetty.http.HttpStatus
@@ -48,12 +49,12 @@ data class UserPrincipal(val user: User) : Principal {
 }
 
 class AuthTestQuery : GraphQLQueryResolver {
-    fun context(context: GraphQLResourceContext): User? {
-        return if (context.principal == null) {
-            context.cookie = NewCookie("testCookie", "testValue")
+    fun context(dfe: DataFetchingEnvironment): User? {
+        return if (dfe.graphQlContext.getInstance<Principal>() == null) {
+            dfe.graphQlContext.setInstance(NewCookie("testCookie", "testValue"))
             null
         } else {
-            (context.principal as UserPrincipal).user
+            (dfe.graphQlContext.getInstance<Principal>() as UserPrincipal).user
         }
     }
 }

--- a/graphql/src/test/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketAdapterTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketAdapterTest.kt
@@ -170,7 +170,7 @@ class SessionTrackingCreator : WebSocketCreator {
     val errors = ConcurrentHashMap<String, Throwable>()
     override fun createWebSocket(req: ServletUpgradeRequest, resp: ServletUpgradeResponse): Any {
         val channel = Channel<OperationMessage<*>>()
-        val adapter = object : GraphQLWebSocketAdapter(channel, mapper) {
+        val adapter = object : GraphQLWebSocketAdapter(GraphQLWebSocketSubProtocol.APOLLO_PROTOCOL, channel, mapper) {
             override fun onWebSocketError(cause: Throwable) {
                 errors[req.queryString] = cause
                 super.onWebSocketError(cause)

--- a/graphql/src/test/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketCreatorTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketCreatorTest.kt
@@ -17,10 +17,10 @@ import org.testng.annotations.Test
 import javax.ws.rs.container.ContainerRequestContext
 
 class GraphQLWebSocketCreatorTest {
-    @Test
-    fun testSocketCreation() {
+    val mapper = ObjectMapper()
+
+    private fun getCreatorAndGraphQL(): Pair<GraphQLWebSocketCreator, GraphQL> {
         val graphQL = LeakyMock.mock<GraphQL>()
-        val mapper = ObjectMapper()
         val creatorFactory = GraphQLWebSocketCreatorFactory(graphQL, mapper, GraphQLConfig(ConfigLoader()))
         val mockContext = LeakyMock.mock<ContainerRequestContext>()
         val creator = creatorFactory.getCreator(mockContext)
@@ -29,13 +29,21 @@ class GraphQLWebSocketCreatorTest {
         assertThat(creator.objectMapper).isEqualTo(mapper)
         assertThat(creator.graphQLConfig.keepAliveIntervalSeconds).isEqualTo(GraphQLConfigTest.DEFAULT_KEEPALIVE)
         assertThat(creator.containerRequestContext).isEqualTo(mockContext)
+        return Pair(creator, graphQL)
+    }
+
+    @Test
+    fun testSocketCreation() {
+        val (creator, graphQL) = getCreatorAndGraphQL()
         // test optional params constructor works fine
+        val mockContext = LeakyMock.mock<ContainerRequestContext>()
         val secondCreator = GraphQLWebSocketCreator(graphQL, mapper, creator.graphQLConfig, mockContext)
         assertThat(secondCreator.graphQL).isEqualTo(graphQL)
         assertThat(secondCreator.graphQLConfig.keepAliveIntervalSeconds).isEqualTo(GraphQLConfigTest.DEFAULT_KEEPALIVE)
 
         val request = LeakyMock.mock<ServletUpgradeRequest>()
         val response = LeakyMock.mock<ServletUpgradeResponse>()
+        EasyMock.expect(request.hasSubProtocol("graphql-transport-ws")).andReturn(false).once()
         EasyMock.expect(response.setAcceptedSubProtocol("graphql-ws")).once()
         EasyMock.replay(graphQL, request, response)
         val socket = creator.createWebSocket(request, response)
@@ -43,6 +51,7 @@ class GraphQLWebSocketCreatorTest {
         assertThat(socket).isInstanceOf(GraphQLWebSocketAdapter::class)
         assertThat((socket as GraphQLWebSocketAdapter).objectMapper).isEqualTo(mapper)
         assertThat(socket.channel).isNotNull()
+        assertThat(socket.subProtocol).isEqualTo(GraphQLWebSocketSubProtocol.APOLLO_PROTOCOL)
         // mapper writes without pretty printing, writer writes with pretty printing
         assertThat(socket.objectMapper.writeValueAsString(mapOf("a" to "b"))).isEqualTo("""{"a":"b"}""")
         assertThat(socket.objectWriter.writeValueAsString(mapOf("a" to "b"))).isEqualTo(
@@ -50,5 +59,22 @@ class GraphQLWebSocketCreatorTest {
             |  "a" : "b"
             |}""".trimMargin()
         )
+    }
+
+    @Test
+    fun testGraphQlWsCreation() {
+        val (creator, graphQL) = getCreatorAndGraphQL()
+
+        val request = LeakyMock.mock<ServletUpgradeRequest>()
+        val response = LeakyMock.mock<ServletUpgradeResponse>()
+        EasyMock.expect(request.hasSubProtocol("graphql-transport-ws")).andReturn(true).once()
+        EasyMock.expect(response.setAcceptedSubProtocol("graphql-transport-ws")).once()
+        EasyMock.replay(graphQL, request, response)
+        val socket = creator.createWebSocket(request, response)
+        EasyMock.verify(response)
+        assertThat(socket).isInstanceOf(GraphQLWebSocketAdapter::class)
+        assertThat((socket as GraphQLWebSocketAdapter).objectMapper).isEqualTo(mapper)
+        assertThat(socket.channel).isNotNull()
+        assertThat(socket.subProtocol).isEqualTo(GraphQLWebSocketSubProtocol.GRAPHQL_WS_PROTOCOL)
     }
 }

--- a/graphql/src/test/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketProtocolTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketProtocolTest.kt
@@ -7,6 +7,7 @@ import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.trib3.graphql.execution.GraphQLRequest
+import com.trib3.graphql.execution.MessageGraphQLError
 import com.trib3.json.ObjectMapperProvider
 import graphql.ExecutionResult
 import org.testng.annotations.Test
@@ -66,6 +67,10 @@ class GraphQLWebSocketProtocolTest {
             String::class to "message",
             GraphQLRequest::class to GraphQLRequest("query {q}", mapOf(), null),
             Map::class to mapOf("a" to "b", "c" to "d"),
+            List::class to listOf(
+                MessageGraphQLError("e").toSpecification(),
+                MessageGraphQLError("f").toSpecification()
+            ),
             ExecutionResult::class to null // only need to support serialization right now, not round trip
         )
         for (

--- a/graphql/src/test/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketTest.kt
@@ -17,11 +17,12 @@ import com.trib3.graphql.GraphQLConfig
 import com.trib3.graphql.execution.GraphQLRequest
 import com.trib3.graphql.execution.RequestIdInstrumentation
 import com.trib3.graphql.modules.GraphQLWebSocketAuthenticator
-import com.trib3.graphql.resources.GraphQLResourceContext
+import com.trib3.graphql.resources.getInstance
 import com.trib3.json.ObjectMapperProvider
 import com.trib3.testing.LeakyMock
 import graphql.ExecutionInput
 import graphql.GraphQL
+import graphql.schema.DataFetchingEnvironment
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -58,8 +59,8 @@ class SocketQuery {
         throw IllegalStateException("forced exception")
     }
 
-    fun u(context: GraphQLResourceContext): String? {
-        return context.principal?.name
+    fun u(dfe: DataFetchingEnvironment): String? {
+        return dfe.graphQlContext.getInstance<Principal>()?.name
     }
 }
 

--- a/graphql/src/test/resources/application.conf
+++ b/graphql/src/test/resources/application.conf
@@ -10,3 +10,9 @@ GraphQLResourceIntegrationTest {
         authorizedWebSocketOnly: true
     }
 }
+
+nokeepalive {
+    graphQL {
+        keepAliveIntervalSeconds: 0
+    }
+}

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -69,10 +69,11 @@
         <version.dropwizard.metrics.guice>4.0.0</version.dropwizard.metrics.guice>
         <version.easymock>4.3</version.easymock>
         <version.flyway>8.0.3</version.flyway>
-        <version.graphql-kotlin>4.0.0</version.graphql-kotlin>
-        <version.graphql-java>16.2</version.graphql-java>
+        <version.graphql-kotlin>5.2.0</version.graphql-kotlin>
+        <version.graphql-java>17.3</version.graphql-java>
+        <version.graphql-java-extended-scalars>17.0</version.graphql-java-extended-scalars>
         <version.graphql-java.tools>5.2.4</version.graphql-java.tools>
-        <version.graphql-java.dataloader>3.1.0</version.graphql-java.dataloader>
+        <version.graphql-java.dataloader>3.1.1</version.graphql-java.dataloader>
         <version.graphql-java.servlet>6.1.3</version.graphql-java.servlet>
         <version.guava>31.0.1-jre</version.guava>
         <version.guice>5.0.1</version.guice>
@@ -1177,6 +1178,11 @@
                         <artifactId>jackson-datatype-jdk8</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.graphql-java</groupId>
+                <artifactId>graphql-java-extended-scalars</artifactId>
+                <version>${version.graphql-java-extended-scalars}</version>
             </dependency>
             <dependency>
                 <groupId>com.graphql-java</groupId>


### PR DESCRIPTION
The graphql-kotlin GraphQLContext interface is deprecated
and replaced with a new class from graphql-java that's backed
by a Map<*, Any>.  Adjust our context for this change.

Also some scalars are removed and moved to an -extended-scalars
package, use that for BigDecimal support.  Might want to use
more of the provided scalars in the future?