### PR TITLE
Use TestContainers instead of otj-pg-embedded [BREAKING CHANGE] 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,8 @@ orbs:
 
 jobs:
   build:
-    docker:
-      - image: cimg/openjdk:11.0
+    machine:
+      image: ubuntu-2004:202107-02
 
     working_directory: ~/repo
     environment:

--- a/build-resources/pom.xml
+++ b/build-resources/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.trib3</groupId>
     <artifactId>build-resources</artifactId>
-    <version>1.26-SNAPSHOT</version>
+    <version>1.27-SNAPSHOT</version>
 
     <name>Build Resources</name>
     <description>Resources for use during the build process</description>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.26-SNAPSHOT</version>
+        <version>1.27-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/config/src/test/kotlin/com/trib3/config/modules/KMSModuleTest.kt
+++ b/config/src/test/kotlin/com/trib3/config/modules/KMSModuleTest.kt
@@ -3,18 +3,29 @@ package com.trib3.config.modules
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
-import org.testng.annotations.Guice
+import com.google.inject.Guice
+import com.trib3.config.ASSERT_VAL
+import com.trib3.config.KMSStringSelectReader
+import com.trib3.testing.LeakyMock
+import dev.misfitlabs.kotlinguice4.getInstance
+import org.easymock.EasyMock
 import org.testng.annotations.Test
+import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.services.kms.KmsClient
-import javax.inject.Inject
+import software.amazon.awssdk.services.kms.model.DecryptRequest
+import software.amazon.awssdk.services.kms.model.DecryptResponse
 
-@Guice(modules = [KMSModule::class])
-class KMSModuleTest
-@Inject constructor(
-    val kmsClient: KmsClient
-) {
+class KMSModuleTest {
     @Test
     fun testBind() {
+        val fakeKms = LeakyMock.mock<KmsClient>().also {
+            EasyMock.expect(it.decrypt(EasyMock.anyObject(DecryptRequest::class.java)))
+                .andReturn(DecryptResponse.builder().plaintext(SdkBytes.fromUtf8String(ASSERT_VAL)).build()).anyTimes()
+            EasyMock.replay(it)
+        }
+        // construct a KMSStringSelectReader to fill in _INSTANCE kms so real kms doesn't get inserted for other tests
+        KMSStringSelectReader(fakeKms)
+        val kmsClient = Guice.createInjector(KMSModule()).getInstance<KmsClient>()
         assertThat(kmsClient).isNotNull()
     }
 

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.26-SNAPSHOT</version>
+        <version>1.27-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -104,12 +104,6 @@
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
-        </dependency>
-
-        <!-- test -->
-        <dependency>
-            <groupId>com.opentable.components</groupId>
-            <artifactId>otj-pg-embedded</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/graphql/pom.xml
+++ b/graphql/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.26-SNAPSHOT</version>
+        <version>1.27-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.26-SNAPSHOT</version>
+        <version>1.27-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/lambda/pom.xml
+++ b/lambda/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.26-SNAPSHOT</version>
+        <version>1.27-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.trib3</groupId>
     <artifactId>parent-pom</artifactId>
-    <version>1.26-SNAPSHOT</version>
+    <version>1.27-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Trib3 parent pom</name>
@@ -93,6 +93,7 @@
         <version.jersey>2.35</version.jersey>
         <version.jetbrains.annotations>13.0</version.jetbrains.annotations>
         <version.jetty>9.4.44.v20210927</version.jetty>
+        <version.jna>5.8.0</version.jna>
         <version.joda>2.10.13</version.joda>
         <version.jooq>3.15.4</version.jooq>
         <version.jsr305>3.0.2</version.jsr305>
@@ -126,12 +127,12 @@
         <version.maven.surefire>3.0.0-M5</version.maven.surefire>
         <version.netty>4.1.70.Final</version.netty>
         <version.postgres>42.3.1</version.postgres>
-        <version.postgres.embedded>0.13.4</version.postgres.embedded>
         <version.reactivestreams>1.0.3</version.reactivestreams>
         <version.redshift>2.1.0.1</version.redshift>
         <version.servlet>4.0.4</version.servlet>
         <version.slf4j>1.7.32</version.slf4j>
         <version.swagger>2.1.11</version.swagger>
+        <version.testcontainers>1.16.2</version.testcontainers>
         <version.testng>7.3.0</version.testng>
         <version.threeten>1.7.0</version.threeten>
         <version.typesafe.config>1.4.1</version.typesafe.config>
@@ -1039,6 +1040,16 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>net.java.dev.jna</groupId>
+                <artifactId>jna</artifactId>
+                <version>${version.jna}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.java.dev.jna</groupId>
+                <artifactId>jna-platform</artifactId>
+                <version>${version.jna}</version>
+            </dependency>
 
             <!-- db -->
             <dependency>
@@ -1149,9 +1160,9 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>com.opentable.components</groupId>
-                <artifactId>otj-pg-embedded</artifactId>
-                <version>${version.postgres.embedded}</version>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>${version.testcontainers}</version>
                 <scope>test</scope>
             </dependency>
 
@@ -1345,7 +1356,8 @@
                                     <exclude>org.glassfish:javax.el</exclude>
                                     <exclude>jakarta.el:jakarta.el-api</exclude> <!-- el impl includes el-api -->
                                     <exclude>jakarta.activation:jakarta.activation-api</exclude> <!-- use com.sun -->
-                                    <exclude>com.sun.xml.bind:jaxb-impl</exclude> <!-- use org.glassfish.jaxb:jaxb-runtime -->
+                                    <exclude>com.sun.xml.bind:jaxb-impl
+                                    </exclude> <!-- use org.glassfish.jaxb:jaxb-runtime -->
                                 </excludes>
                             </bannedDependencies>
                         </rules>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>1.26-SNAPSHOT</version>
+        <version>1.27-SNAPSHOT</version>
         <relativePath>parent-pom/pom.xml</relativePath>
     </parent>
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.26-SNAPSHOT</version>
+        <version>1.27-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/testing/README.md
+++ b/testing/README.md
@@ -5,31 +5,32 @@ Classes that enhance writing unit tests.
 ### TestBase classes
 
 #### DAOTestBase
-Base class for writing DAO tests.  Uses [OpenTable Embedded PostgreSQL](https://github.com/opentable/otj-pg-embedded/)
-to set up a [jOOQ](https://www.jooq.org) `DSLContext` and a jdbc `DataSource` that can 
-be used by tests, and runs any [Flyway](https://flywaydb.org) migrations found on the 
-classpath.
+
+Base class for writing DAO tests. Uses [Testcontainers](https://testcontainers.org/)
+to set up a [jOOQ](https://www.jooq.org) `DSLContext` and a jdbc `DataSource` that can be used by tests, and runs
+any [Flyway](https://flywaydb.org) migrations found on the classpath.
 
 #### ResourceTestBase
-Base class for writing Resource tests.  Implement `getResource()` to return the
-JAX-RS resource being tested.  Uses an `InMemoryTestContainer` by default, but can be 
-overriden by implementing `getContainerFactory()`.  If additional jersey resources need
-to be added to the container, override `buildAdditionalResources()` to configure them.
 
+Base class for writing Resource tests. Implement `getResource()` to return the JAX-RS resource being tested. Uses
+an `InMemoryTestContainer` by default, but can be overriden by implementing `getContainerFactory()`. If additional
+jersey resources need to be added to the container, override `buildAdditionalResources()` to configure them.
 
 ### Utility classes
 
 #### JettyWebTestContainerFactory
-A `TestContainerFactory` that supports servlet features (eg, injection of 
-`@Context HttpServletRequest` params, etc) on top of a [Jetty](https://www.eclipse.org/jetty/) 
+
+A `TestContainerFactory` that supports servlet features (eg, injection of
+`@Context HttpServletRequest` params, etc) on top of a [Jetty](https://www.eclipse.org/jetty/)
 web server.
 
 #### LeakyMock
-Enhancements to [EasyMock](http://easymock.org/) for a more usable kotlin experience.  Makes mock
-creation more concise, and provides a number of matchers that return non-null values to work better
-with kotlin's nullability checks.
+
+Enhancements to [EasyMock](http://easymock.org/) for a more usable kotlin experience. Makes mock creation more concise,
+and provides a number of matchers that return non-null values to work better with kotlin's nullability checks.
 
 Create mocks with type inference (Avoid this [issue](https://github.com/easymock/easymock/issues/239)):
+
 ```kotlin
 // all these options also work for niceMock
 val mock = LeakyMock.mock<ClassToMock>() // mock will be inferred to be of type ClassToMock
@@ -40,7 +41,9 @@ val mock4 = support.mock<ClassToMock>() // mock 4 is a ClassToMock, and tracked 
 // compare this with:
 val nonLeakyMock = EasyMock.mock<ClassToMock>(ClassToMock::class.java)
 ```
+
 Match on objects without violating kotlin null checks (Avoid `EasyMock.anyObject() must not be null`):
+
 ```kotlin
 EasyMock.expect(mock.doSomethingWithNonNullable(LeakyMock.anyObject())).and ...
 // compare this with:

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.26-SNAPSHOT</version>
+        <version>1.27-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -102,9 +102,14 @@
             <artifactId>flyway-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.opentable.components</groupId>
-            <artifactId>otj-pg-embedded</artifactId>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>


### PR DESCRIPTION
Stands up docker based postgres db instead of a
process based one, which should work on eg, M1.
Requires using a machine circle image instad of
a docker circle image, so bump version.

Clean up KMSModuleTest to ensure a mock KMS gets
used to prevent ordering issue resulting in a real
KMS getting used in tests in some cases.