### PR TITLE
Support new graphql-ws websocket protocol

### DIFF
--- a/graphql/src/main/kotlin/com/trib3/graphql/GraphQLConfig.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/GraphQLConfig.kt
@@ -7,19 +7,19 @@ import javax.inject.Inject
 class GraphQLConfig
 @Inject constructor(loader: ConfigLoader) {
     val keepAliveIntervalSeconds: Long
-    val webSocketSubProtocol: String
     val idleTimeout: Long?
     val maxBinaryMessageSize: Int?
     val maxTextMessageSize: Int?
     val checkAuthorization: Boolean
+    val connectionInitWaitTimeout: Long
 
     init {
         val config = loader.load("graphQL")
         keepAliveIntervalSeconds = config.extract("keepAliveIntervalSeconds")
-        webSocketSubProtocol = config.extract("webSocketSubProtocol")
         idleTimeout = config.extract("idleTimeout")
         maxBinaryMessageSize = config.extract("maxBinaryMessageSize")
         maxTextMessageSize = config.extract("maxTextMessageSize")
         checkAuthorization = config.extract("checkAuthorization") ?: config.extract("authorizedWebSocketOnly") ?: false
+        connectionInitWaitTimeout = config.extract("connectionInitWaitTimeout")
     }
 }

--- a/graphql/src/main/kotlin/com/trib3/graphql/execution/MessageGraphQLError.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/execution/MessageGraphQLError.kt
@@ -1,0 +1,22 @@
+package com.trib3.graphql.execution
+
+import graphql.ErrorClassification
+import graphql.GraphQLError
+import graphql.language.SourceLocation
+
+/**
+ * Simple [GraphQLError] implementation that only specified an error message
+ */
+class MessageGraphQLError(private val msg: String?) : GraphQLError {
+    override fun getMessage(): String? {
+        return msg
+    }
+
+    override fun getLocations(): List<SourceLocation> {
+        return listOf()
+    }
+
+    override fun getErrorType(): ErrorClassification? {
+        return null
+    }
+}

--- a/graphql/src/main/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketProtocol.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketProtocol.kt
@@ -2,20 +2,180 @@ package com.trib3.graphql.websocket
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonValue
 import com.trib3.graphql.execution.GraphQLRequest
+import com.trib3.graphql.execution.MessageGraphQLError
 import graphql.ExecutionResult
+import org.eclipse.jetty.websocket.api.Session
+import org.eclipse.jetty.websocket.api.StatusCode
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.memberProperties
 
 /**
- * Model for a message in the graphql websocket protocol
+ * Encapsulates the different behaviors in the apollo vs/ graphql-ws protocols.
+ * Maps equivalent messages (eg "start" vs "subscribe"), and provides callbacks
+ * for different behaviors (eg end an "error" message vs/ close the connection).
+ *
+ * The WebSocket consumer always works using apollo messages internally, so
+ * the adapter is responsible for translating from/to graphql-ws messages upon
+ * receipt/send events.
+ */
+enum class GraphQLWebSocketSubProtocol(
+    val subProtocol: String,
+    messageMapping: Map<OperationType<*>, OperationType<*>>,
+    private val onInvalidMessageCallback: (String?, String, GraphQLWebSocketAdapter) -> Unit,
+    private val onDuplicateQueryCallback: (OperationMessage<*>, GraphQLWebSocketAdapter) -> Unit,
+    private val onDuplicateInitCallback: (OperationMessage<*>, GraphQLWebSocketAdapter) -> Unit
+) {
+    APOLLO_PROTOCOL(
+        "graphql-ws",
+        mapOf(),
+        { messageId, messageBody, adapter ->
+            adapter.sendMessage(
+                OperationMessage(
+                    OperationType.GQL_ERROR, messageId,
+                    listOf(MessageGraphQLError("Invalid message `$messageBody`"))
+                )
+            )
+        },
+        { message, adapter ->
+            adapter.sendMessage(
+                OperationMessage(
+                    OperationType.GQL_ERROR,
+                    message.id,
+                    listOf(MessageGraphQLError("Query with id ${message.id} already running!"))
+                )
+            )
+        },
+        { message, adapter ->
+            adapter.sendMessage(
+                OperationMessage(
+                    OperationType.GQL_CONNECTION_ERROR,
+                    message.id,
+                    "Already connected!"
+                )
+            )
+        }
+    ),
+    GRAPHQL_WS_PROTOCOL(
+        "graphql-transport-ws",
+        mapOf(
+            OperationType.GQL_START to OperationType.GQL_SUBSCRIBE,
+            OperationType.GQL_DATA to OperationType.GQL_NEXT,
+            OperationType.GQL_STOP to OperationType.GQL_COMPLETE,
+            OperationType.GQL_CONNECTION_KEEP_ALIVE to OperationType.GQL_PONG
+        ),
+        { msgId, msgBody, adapter ->
+            adapter.session?.close(
+                GraphQLWebSocketCloseReason.INVALID_MESSAGE.code,
+                GraphQLWebSocketCloseReason.INVALID_MESSAGE.description.replace("<id>", msgId ?: "")
+                    .replace("<body>", msgBody)
+            )
+        },
+        { message, adapter ->
+            adapter.session?.close(
+                GraphQLWebSocketCloseReason.MULTIPLE_SUBSCRIBER.code,
+                GraphQLWebSocketCloseReason.MULTIPLE_SUBSCRIBER.description.replace(
+                    "<unique-operation-id>",
+                    message.id ?: ""
+                )
+            )
+        },
+        { _, adapter ->
+            adapter.session?.close(GraphQLWebSocketCloseReason.MULTIPLE_INIT)
+        }
+    );
+
+    private val apolloToGraphQlWsMapping = messageMapping.entries.associate { it.key.type to it.value.type }
+
+    private val graphQlWsToApolloMapping = apolloToGraphQlWsMapping.entries.associate {
+        it.value to it.key
+    }.filter {
+        // don't map PONG to KEEPALIVE even though we map outgoing KEEPALIVE messages to PONGs
+        it.key != OperationType.GQL_PONG.type
+    }
+
+    private fun <T : Any> getMessage(message: OperationMessage<T>, mapping: Map<String, String>): OperationMessage<T> {
+        return if (!mapping.containsKey(message.type?.type)) {
+            message
+        } else {
+            message.copy(type = message.type?.copy(type = mapping.getValue(message.type.type)))
+        }
+    }
+
+    /**
+     * Before sending a message to the client, map to the appropriate protocol message
+     */
+    fun <T : Any> getServerToClientMessage(message: OperationMessage<T>): OperationMessage<T> {
+        return getMessage(message, apolloToGraphQlWsMapping)
+    }
+
+    /**
+     * Upon receiving a message from the client, map from appropriate protocol message to an apollo
+     * message for internal consumption
+     */
+    fun <T : Any> getClientToServerMessage(message: OperationMessage<T>): OperationMessage<T> {
+        return getMessage(message, graphQlWsToApolloMapping)
+    }
+
+    /**
+     * graphql-ws closes the connection upon receiving an invalid message, while apollo just sends
+     * an error message in response.
+     */
+    fun onInvalidMessage(messageId: String?, messageBody: String, adapter: GraphQLWebSocketAdapter) {
+        this.onInvalidMessageCallback(messageId, messageBody, adapter)
+    }
+
+    /**
+     * graphql-ws closes the connection upon receiving a duplicate subscription, while apollo just sends
+     * an error message in response.
+     */
+    fun onDuplicateQuery(message: OperationMessage<*>, adapter: GraphQLWebSocketAdapter) {
+        this.onDuplicateQueryCallback(message, adapter)
+    }
+
+    /**
+     * graphql-ws closes the connection upon receiving duplicate connection_init requests, while apollo
+     * just sends an error message in response.
+     */
+    fun onDuplicateInit(message: OperationMessage<*>, adapter: GraphQLWebSocketAdapter) {
+        this.onDuplicateInitCallback(message, adapter)
+    }
+}
+
+/**
+ * Enum of websocket closure reasons from the graphql-ws protocol specification
+ */
+@Suppress("MagicNumber") // constructor values are consts, just put the numbers in instead of declaring const vals.
+enum class GraphQLWebSocketCloseReason(val code: Int, val description: String) {
+    NORMAL(StatusCode.NORMAL, "Normal Closure"),
+    INVALID_MESSAGE(4400, "Invalid Message with id `<id>`: `<body>`"),
+    UNAUTHORIZED(4401, "Unauthorized"),
+    TIMEOUT_INIT(4408, "Connection initialisation timeout"),
+    MULTIPLE_SUBSCRIBER(4409, "Subscriber for <unique-operation-id> already exists"),
+    MULTIPLE_INIT(4429, "Too many initialisation requests")
+    ;
+}
+
+/**
+ * Extension method to close the WebSocket session using a [GraphQLWebSocketCloseReason] instead of
+ * code/description pairs
+ */
+fun Session.close(reason: GraphQLWebSocketCloseReason) {
+    this.close(reason.code, reason.description)
+}
+
+/**
+ * Model for a message in the graphql websocket protocol.  Supports messages for either
+ * the apollo or graphql-ws protocols
  *
  * https://github.com/apollographql/subscriptions-transport-ws/blob/HEAD/PROTOCOL.md
+ * https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md
  */
 data class OperationMessage<T : Any>(
     val type: OperationType<T>?,
@@ -28,16 +188,21 @@ data class OperationMessage<T : Any>(
     )
     @JsonSubTypes(
         Type(name = "start", value = GraphQLRequest::class),
+        Type(name = "subscribe", value = GraphQLRequest::class),
         Type(name = "data", value = ExecutionResult::class),
-        Type(name = "error", value = String::class),
+        Type(name = "next", value = ExecutionResult::class),
+        Type(name = "error", value = List::class),
         Type(name = "connection_init", value = Map::class),
         Type(name = "connection_terminate", value = Nothing::class),
-        Type(name = "connection_ack", value = Nothing::class),
+        Type(name = "connection_ack", value = Map::class),
         Type(name = "connection_error", value = String::class),
         Type(name = "stop", value = Nothing::class),
         Type(name = "complete", value = Nothing::class),
-        Type(name = "ka", value = Nothing::class)
+        Type(name = "ka", value = Nothing::class),
+        Type(name = "ping", value = Map::class),
+        Type(name = "pong", value = Map::class),
     )
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     val payload: T? = null
 )
 
@@ -51,18 +216,24 @@ data class OperationType<T : Any>(
 ) {
     companion object {
         // client -> server
-        val GQL_CONNECTION_INIT = OperationType("connection_init", Map::class)
-        val GQL_START = OperationType("start", GraphQLRequest::class)
-        val GQL_STOP = OperationType("stop", Nothing::class)
-        val GQL_CONNECTION_TERMINATE = OperationType("connection_terminate", Nothing::class)
+        val GQL_CONNECTION_INIT = OperationType("connection_init", Map::class) // shared
+        val GQL_START = OperationType("start", GraphQLRequest::class) // apollo
+        val GQL_SUBSCRIBE = OperationType("subscribe", GraphQLRequest::class) // graphql-ws
+        val GQL_STOP = OperationType("stop", Nothing::class) // apollo-only, graphql-ws uses COMPLETE
+        val GQL_CONNECTION_TERMINATE = OperationType("connection_terminate", Nothing::class) // apollo-only
 
         // server -> client
-        val GQL_CONNECTION_ERROR = OperationType("connection_error", String::class)
-        val GQL_CONNECTION_ACK = OperationType("connection_ack", Nothing::class)
-        val GQL_DATA = OperationType("data", ExecutionResult::class)
-        val GQL_ERROR = OperationType("error", String::class)
-        val GQL_COMPLETE = OperationType("complete", Nothing::class)
-        val GQL_CONNECTION_KEEP_ALIVE = OperationType("ka", Nothing::class)
+        val GQL_CONNECTION_ERROR = OperationType("connection_error", String::class) // apollo-only
+        val GQL_CONNECTION_ACK = OperationType("connection_ack", Map::class) // shared
+        val GQL_DATA = OperationType("data", ExecutionResult::class) // apollo
+        val GQL_NEXT = OperationType("next", ExecutionResult::class) // graphql-ws
+        val GQL_ERROR = OperationType("error", List::class) // shared
+        val GQL_CONNECTION_KEEP_ALIVE = OperationType("ka", Nothing::class) // apollo-only, graphql-ws uses PING/PONG
+
+        // bidirectional
+        val GQL_PING = OperationType("ping", Map::class) // graphql-ws-only, apollo uses CONNECTION_KEEP_ALIVE
+        val GQL_PONG = OperationType("pong", Map::class) // graphql-ws-only, apollo uses CONNECTION_KEEP_ALIVE
+        val GQL_COMPLETE = OperationType("complete", Nothing::class) // shared, but server->client only in apollo
 
         /**
          * Factory method for converting the string type to an [OperationType] instance

--- a/graphql/src/main/resources/graphiql/index.html
+++ b/graphql/src/main/resources/graphiql/index.html
@@ -6,37 +6,39 @@
 <body style="margin: 0;">
 <div id="graphiql" style="height: 100vh;"></div>
 
-<script crossorigin src="//unpkg.com/react@17.0.1/umd/react.production.min.js"></script>
-<script crossorigin src="//unpkg.com/react-dom@17.0.1/umd/react-dom.production.min.js"></script>
-<script crossorigin src="//unpkg.com/graphiql@1.0.6/graphiql.min.js"></script>
-<script crossorigin src="//unpkg.com/subscriptions-transport-ws@0.9.18/browser/client.js"></script>
+<script crossorigin src="//unpkg.com/react@17.0.2/umd/react.production.min.js"></script>
+<script crossorigin src="//unpkg.com/react-dom@17.0.2/umd/react-dom.production.min.js"></script>
+<script crossorigin src="//unpkg.com/graphiql@1.4.6/graphiql.js"></script>
+<script crossorigin src="//unpkg.com/graphql-ws@5.5.5/umd/graphql-ws.js"></script>
 
 <script>
     const fetcherFactory = function (subscriptionsClient, fallbackFetcher) {
-      var activeSubscription = null;
+      var cleanupCallback = null;
       var results = [];
       return function (graphQLParams) {
-        if (subscriptionsClient && activeSubscription !== null) {
-          activeSubscription.unsubscribe();
+        if (subscriptionsClient && cleanupCallback !== null) {
+          cleanupCallback();
           results = [];
         }
         if (subscriptionsClient && graphQLParams.query.trim().startsWith("subscription")) {
           return {
             subscribe: function (observer) {
               observer.next('Your subscription data will appear here after server publication!');
-              activeSubscription = subscriptionsClient.request({
+              cleanupCallback = subscriptionsClient.subscribe({
                 query: graphQLParams.query,
                 variables: graphQLParams.variables,
-              }).subscribe(function (result) {
-                results.push(result);
-                if (results.length % 10 == 0) { // debounce
-                  observer.next(results);
-                }
-              }, function(error) {
-                observer.error(error);
-              },
-              function() {
-                observer.next(results); // on completion show all results
+              }, {
+                next: function (result) {
+                  results.push({path: `${results.length}`, ...result});
+                  if (results.length % 10 == 0) { // debounce
+                    observer.next(results);
+                  }
+                }, error: function(error) {
+                  observer.error(error);
+                },
+                complete: function() {
+                  observer.next(results); // on completion show all results
+                },
               });
             },
           };
@@ -59,10 +61,10 @@
     fetch('/app/auth_cookie', {
       method: 'get'
     }).then(response => {
-        const subscriptionsClient = new window.SubscriptionsTransportWs.SubscriptionClient(
-          `${wsproto}://${window.location.host}/app/graphql`,
-          { reconnect: true, timeout: 60000 }
-        );
+        const subscriptionsClient = graphqlWs.createClient({
+            url: `${wsproto}://${window.location.host}/app/graphql`,
+            lazyCloseTimeout: 60000
+        });
         const subscriptionsFetcher = fetcherFactory(subscriptionsClient, graphQLFetcher);
         ReactDOM.render(
           React.createElement(GraphiQL, { fetcher: subscriptionsFetcher }),

--- a/graphql/src/main/resources/reference.conf
+++ b/graphql/src/main/resources/reference.conf
@@ -1,4 +1,4 @@
 graphQL {
   keepAliveIntervalSeconds: 15
-  webSocketSubProtocol: "graphql-ws"
+  connectionInitWaitTimeout: 15
 }

--- a/graphql/src/test/kotlin/com/trib3/graphql/GraphQLConfigTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/GraphQLConfigTest.kt
@@ -15,14 +15,7 @@ class GraphQLConfigTest {
     fun testConfig() {
         val config = GraphQLConfig(ConfigLoader())
         assertThat(config.keepAliveIntervalSeconds).isEqualTo(DEFAULT_KEEPALIVE)
-        assertThat(config.webSocketSubProtocol).isEqualTo("graphql-ws")
-        for (
-            i in listOf(
-                config.idleTimeout,
-                config.maxBinaryMessageSize,
-                config.maxTextMessageSize
-            )
-        ) {
+        for (i in listOf(config.idleTimeout, config.maxBinaryMessageSize, config.maxTextMessageSize)) {
             assertThat(i).isNull()
         }
     }

--- a/graphql/src/test/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketAdapterTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketAdapterTest.kt
@@ -170,7 +170,7 @@ class SessionTrackingCreator : WebSocketCreator {
     val errors = ConcurrentHashMap<String, Throwable>()
     override fun createWebSocket(req: ServletUpgradeRequest, resp: ServletUpgradeResponse): Any {
         val channel = Channel<OperationMessage<*>>()
-        val adapter = object : GraphQLWebSocketAdapter(channel, mapper) {
+        val adapter = object : GraphQLWebSocketAdapter(GraphQLWebSocketSubProtocol.APOLLO_PROTOCOL, channel, mapper) {
             override fun onWebSocketError(cause: Throwable) {
                 errors[req.queryString] = cause
                 super.onWebSocketError(cause)

--- a/graphql/src/test/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketCreatorTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketCreatorTest.kt
@@ -17,10 +17,10 @@ import org.testng.annotations.Test
 import javax.ws.rs.container.ContainerRequestContext
 
 class GraphQLWebSocketCreatorTest {
-    @Test
-    fun testSocketCreation() {
+    val mapper = ObjectMapper()
+
+    private fun getCreatorAndGraphQL(): Pair<GraphQLWebSocketCreator, GraphQL> {
         val graphQL = LeakyMock.mock<GraphQL>()
-        val mapper = ObjectMapper()
         val creatorFactory = GraphQLWebSocketCreatorFactory(graphQL, mapper, GraphQLConfig(ConfigLoader()))
         val mockContext = LeakyMock.mock<ContainerRequestContext>()
         val creator = creatorFactory.getCreator(mockContext)
@@ -29,13 +29,21 @@ class GraphQLWebSocketCreatorTest {
         assertThat(creator.objectMapper).isEqualTo(mapper)
         assertThat(creator.graphQLConfig.keepAliveIntervalSeconds).isEqualTo(GraphQLConfigTest.DEFAULT_KEEPALIVE)
         assertThat(creator.containerRequestContext).isEqualTo(mockContext)
+        return Pair(creator, graphQL)
+    }
+
+    @Test
+    fun testSocketCreation() {
+        val (creator, graphQL) = getCreatorAndGraphQL()
         // test optional params constructor works fine
+        val mockContext = LeakyMock.mock<ContainerRequestContext>()
         val secondCreator = GraphQLWebSocketCreator(graphQL, mapper, creator.graphQLConfig, mockContext)
         assertThat(secondCreator.graphQL).isEqualTo(graphQL)
         assertThat(secondCreator.graphQLConfig.keepAliveIntervalSeconds).isEqualTo(GraphQLConfigTest.DEFAULT_KEEPALIVE)
 
         val request = LeakyMock.mock<ServletUpgradeRequest>()
         val response = LeakyMock.mock<ServletUpgradeResponse>()
+        EasyMock.expect(request.hasSubProtocol("graphql-transport-ws")).andReturn(false).once()
         EasyMock.expect(response.setAcceptedSubProtocol("graphql-ws")).once()
         EasyMock.replay(graphQL, request, response)
         val socket = creator.createWebSocket(request, response)
@@ -43,6 +51,7 @@ class GraphQLWebSocketCreatorTest {
         assertThat(socket).isInstanceOf(GraphQLWebSocketAdapter::class)
         assertThat((socket as GraphQLWebSocketAdapter).objectMapper).isEqualTo(mapper)
         assertThat(socket.channel).isNotNull()
+        assertThat(socket.subProtocol).isEqualTo(GraphQLWebSocketSubProtocol.APOLLO_PROTOCOL)
         // mapper writes without pretty printing, writer writes with pretty printing
         assertThat(socket.objectMapper.writeValueAsString(mapOf("a" to "b"))).isEqualTo("""{"a":"b"}""")
         assertThat(socket.objectWriter.writeValueAsString(mapOf("a" to "b"))).isEqualTo(
@@ -50,5 +59,22 @@ class GraphQLWebSocketCreatorTest {
             |  "a" : "b"
             |}""".trimMargin()
         )
+    }
+
+    @Test
+    fun testGraphQlWsCreation() {
+        val (creator, graphQL) = getCreatorAndGraphQL()
+
+        val request = LeakyMock.mock<ServletUpgradeRequest>()
+        val response = LeakyMock.mock<ServletUpgradeResponse>()
+        EasyMock.expect(request.hasSubProtocol("graphql-transport-ws")).andReturn(true).once()
+        EasyMock.expect(response.setAcceptedSubProtocol("graphql-transport-ws")).once()
+        EasyMock.replay(graphQL, request, response)
+        val socket = creator.createWebSocket(request, response)
+        EasyMock.verify(response)
+        assertThat(socket).isInstanceOf(GraphQLWebSocketAdapter::class)
+        assertThat((socket as GraphQLWebSocketAdapter).objectMapper).isEqualTo(mapper)
+        assertThat(socket.channel).isNotNull()
+        assertThat(socket.subProtocol).isEqualTo(GraphQLWebSocketSubProtocol.GRAPHQL_WS_PROTOCOL)
     }
 }

--- a/graphql/src/test/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketProtocolTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketProtocolTest.kt
@@ -7,6 +7,7 @@ import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.trib3.graphql.execution.GraphQLRequest
+import com.trib3.graphql.execution.MessageGraphQLError
 import com.trib3.json.ObjectMapperProvider
 import graphql.ExecutionResult
 import org.testng.annotations.Test
@@ -66,6 +67,10 @@ class GraphQLWebSocketProtocolTest {
             String::class to "message",
             GraphQLRequest::class to GraphQLRequest("query {q}", mapOf(), null),
             Map::class to mapOf("a" to "b", "c" to "d"),
+            List::class to listOf(
+                MessageGraphQLError("e").toSpecification(),
+                MessageGraphQLError("f").toSpecification()
+            ),
             ExecutionResult::class to null // only need to support serialization right now, not round trip
         )
         for (

--- a/graphql/src/test/resources/application.conf
+++ b/graphql/src/test/resources/application.conf
@@ -10,3 +10,9 @@ GraphQLResourceIntegrationTest {
         authorizedWebSocketOnly: true
     }
 }
+
+nokeepalive {
+    graphQL {
+        keepAliveIntervalSeconds: 0
+    }
+}


### PR DESCRIPTION
The existing subscriptions-transport-ws protocol is deprecated.
Introduce the new protocol by mapping operations and adhering
to the stricter semantics of the new protocol.  Update embedded
GraphiQL to use the new protocol.

Use existing tests to cover most corner cases, but add tests
of the new protocol's stricter semantics in addition to testing
the basic subscription workflow.