### PR TITLE
Fix GraphiQL's schema explorer when using subscriptions

### DIFF
--- a/graphql/src/main/resources/graphiql/index.html
+++ b/graphql/src/main/resources/graphiql/index.html
@@ -20,7 +20,10 @@
           cleanupCallback();
           results = [];
         }
-        var isSubscription = fetcherOpts.documentAST.definitions.some((definition) => definition.operation == 'subscription');
+        // For the Introspection query never use a subscription since the schema is expected
+        // to be returned as a promise, not an Observable
+        var isSubscription = graphQLParams.operationName != 'IntrospectionQuery' &&
+          fetcherOpts.documentAST.definitions.some((definition) => definition.operation == 'subscription');
         if (subscriptionsClient && isSubscription) {
           return {
             subscribe: function (observer) {


### PR DESCRIPTION
The query to get schema from the server is executed with the
documentAST set to the editor pane's query instead of an AST
from the introspection query itself, and the subscription that
the fetcher returns is set up for the UI, not for internal code.
Ensure we always use a standard HTTP fetcher for the introspection
query so that the schema explorer loads properly.

https://www.notion.so/tribedynamics/Pebbles-Auto-Fill-and-Documentation-Helper-are-not-Loading-b5fc5f98a9a14c56bc74f3a85025e658