### PR TITLE
Execute GraphiQL queries using WebSocket connection

### DIFF
--- a/graphql/src/main/kotlin/com/trib3/graphql/execution/ContextScopeFunctionDataFetcher.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/execution/ContextScopeFunctionDataFetcher.kt
@@ -11,10 +11,10 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.future.future
+import kotlinx.coroutines.slf4j.MDCContext
 import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.CompletableFuture
 import kotlin.coroutines.CoroutineContext
-import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.callSuspendBy
@@ -70,7 +70,7 @@ open class ContextScopeFunctionDataFetcher(
     protected open fun runScopedSuspendingFunction(
         parameterValues: Map<KParameter, Any?>,
         scope: CoroutineScope,
-        coroutineContext: CoroutineContext = EmptyCoroutineContext,
+        coroutineContext: CoroutineContext = MDCContext(),
         coroutineStart: CoroutineStart = CoroutineStart.DEFAULT
     ): CompletableFuture<Any?> {
         return scope.future(coroutineContext, coroutineStart) {

--- a/graphql/src/main/resources/graphiql/index.html
+++ b/graphql/src/main/resources/graphiql/index.html
@@ -20,30 +20,39 @@
           cleanupCallback();
           results = [];
         }
-        // For the Introspection query never use a subscription since the schema is expected
-        // to be returned as a promise, not an Observable
-        var isSubscription = graphQLParams.operationName != 'IntrospectionQuery' &&
-          fetcherOpts.documentAST.definitions.some((definition) => definition.operation == 'subscription');
-        if (subscriptionsClient && isSubscription) {
+        // Use the subscription client to execute anything that's not a mutation.
+        // Note the IntrospectionQuery is requested with the editor pane documentAST, so can't
+        // use that AST to detect if it's a mutation.  assume IntrospectionQuery is always a query.
+        var isMutation = graphQLParams.operationName != 'IntrospectionQuery' &&
+          fetcherOpts.documentAST.definitions.some((definition) => definition.operation == 'mutation');
+        if (subscriptionsClient && !isMutation) {
           return {
             subscribe: function (observer) {
-              observer.next('Your subscription data will appear here after server publication!');
               cleanupCallback = subscriptionsClient.subscribe({
                 query: graphQLParams.query,
                 variables: graphQLParams.variables,
               }, {
                 next: function (result) {
-                  results.push({path: `${results.length}`, ...result});
+                  results.push(result);
                   if (results.length % 10 == 0) { // debounce
-                    observer.next(results);
+                    observer.next(results.map((r, index) => ({path: `${index}`, ...r})));
                   }
                 }, error: function(error) {
                   observer.error(error);
                 },
                 complete: function() {
-                  observer.next(results); // on completion show all results
+                  // on completion show all results, or just a single result
+                  if (results.length == 1) {
+                    observer.next(results[0])
+                  } else {
+                    observer.next(results.map((r, index) => ({path: `${index}`, ...r})));
+                  }
+                  observer.complete();
                 },
               });
+              return {
+                unsubscribe: cleanupCallback,
+              };
             },
           };
         } else {
@@ -66,7 +75,6 @@
     }).then(response => {
         const subscriptionsClient = graphqlWs.createClient({
             url: `${wsproto}://${window.location.host}/app/graphql`,
-            lazyCloseTimeout: 60000
         });
         const subscriptionsFetcher = fetcherFactory(subscriptionsClient, graphQLFetcher);
         ReactDOM.render(


### PR DESCRIPTION
In GraphiQL, use the WebSocket connection to execute queries
in addition to subscriptions, so that long running queries
don't get killed by the load balancer.  Leave mutations on a
normal HTTP connection so that they can set cookies.

Add MDCContext when calling suspend functions from a GraphQL
resolver so that requestId gets picked up by the instrumentation.