### PR TITLE
Add support for graphql-sse protocols

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,9 +17,9 @@ jobs:
       # handle dependency caching and run build
       - restore_cache:
           keys:
-            - v3-dependencies-{{ .Branch }}-{{ .Revision }}
-            - v3-dependencies-{{ .Branch }}
-            - v3-dependencies-
+            - v4-dependencies-{{ .Branch }}-{{ .Revision }}
+            - v4-dependencies-{{ .Branch }}
+            - v4-dependencies-
       - run:
           name: Setup GPG
           command: |
@@ -63,7 +63,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2
-          key: v3-dependencies-{{ .Branch }}-{{ .Revision }}
+          key: v4-dependencies-{{ .Branch }}-{{ .Revision }}
       # collect test results and upload coverage
       - run: mkdir -p ~/test_results
       - run: find . -type f -regex ".*/target/surefire-reports/junitreports/.*xml" -exec cp {} ~/test_results/ \;

--- a/graphql/README.md
+++ b/graphql/README.md
@@ -3,24 +3,27 @@ Graphql
 Provides the application infrastructure for adding [GraphQL](https://graphql.org) support to
 a [server](https://github.com/trib3/leakycauldron/blob/HEAD/server) application.
 
-* GraphQL endpoints:
-  * UUID, java8 time, and
-    threeten-extra [Scalars](https://github.com/trib3/leakycauldron/blob/HEAD/graphql/src/main/kotlin/com/trib3/graphql/execution/LeakyCauldronHooks.kt)
-  * [Request Ids](https://github.com/trib3/leakycauldron/blob/HEAD/graphql/src/main/kotlin/com/trib3/graphql/execution/RequestIdInstrumentation.kt)
-    attached to the GraphQL response extensions
-  * Any guice bound Query, Subscription or Mutation Resolvers
-  * Supports websockets using
-    the [Apollo Protocol](https://github.com/apollographql/subscriptions-transport-ws/blob/HEAD/PROTOCOL.md)
-    or the new [GraphQL over WebSocket Protocol](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md)
-  * Supports subscriptions via [coroutine](https://github.com/kotlin/kotlinx.coroutines/) Flows for any Resolvers that
-    return a `Publisher<T>`
-  * Supports [Dropwizard Authentication](https://www.dropwizard.io/en/latest/manual/auth.html) Principals passed through
-    to Resolvers
-    via [GraphQLContext](https://github.com/ExpediaGroup/graphql-kotlin/blob/HEAD/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/execution/GraphQLContext.kt)
-  * Supports [coroutine](https://github.com/kotlin/kotlinx.coroutines/) structured concurrency and cancellation of
-    POSTed GraphQL queries for Resolvers implemented as `suspend` functions
+* GraphQL endpoint at `/app/graphql`:
+    * UUID, java8 time, and
+      threeten-extra [Scalars](https://github.com/trib3/leakycauldron/blob/HEAD/graphql/src/main/kotlin/com/trib3/graphql/execution/LeakyCauldronHooks.kt)
+    * [Request Ids](https://github.com/trib3/leakycauldron/blob/HEAD/graphql/src/main/kotlin/com/trib3/graphql/execution/RequestIdInstrumentation.kt)
+      attached to the GraphQL response extensions
+    * Any guice bound Query, Subscription or Mutation Resolvers
+    * Supports websockets using
+      the [Apollo Protocol](https://github.com/apollographql/subscriptions-transport-ws/blob/HEAD/PROTOCOL.md)
+      or the new [GraphQL over WebSocket Protocol](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md)
+    * Supports the
+      [GraphQL over Server-Sent Events Protocol](https://github.com/enisdenjo/graphql-sse/blob/master/PROTOCOL.md)
+      at `/app/graphql/stream` in both Single Connection Mode and Distinct Connections Mode
+    * Supports subscriptions via [coroutine](https://github.com/kotlin/kotlinx.coroutines/) Flows for any Resolvers that
+      return a `Flow<T>` or `Publisher<T>` (`Flow` preferred)
+    * Supports [Dropwizard Authentication](https://www.dropwizard.io/en/latest/manual/auth.html) Principals passed
+      through to Resolvers
+      via [GraphQLContext](https://github.com/ExpediaGroup/graphql-kotlin/blob/HEAD/graphql-kotlin-schema-generator/src/main/kotlin/com/expediagroup/graphql/execution/GraphQLContext.kt)
+    * Supports [coroutine](https://github.com/kotlin/kotlinx.coroutines/) structured concurrency and cancellation of
+      POSTed GraphQL queries for Resolvers implemented as `suspend` functions
 * Admin:
-  * [GraphiQL](https://github.com/graphql/graphiql) available at `/admin/graphiql`
+    * [GraphiQL](https://github.com/graphql/graphiql) available at `/admin/graphiql`
 
 ### Configuration
 
@@ -31,15 +34,14 @@ exposes binders for commonly bound objects. Additionally, some parameters are se
 Default config:
 
 ```hocon
-    graphql {
-        keepAliveIntervalSeconds: 15  # interval to send keepalive messages over apollo websocket protocol in seconds
-        webSocketSubProtocol: "graphql-ws"  # apollo websocket subprotocol to identify as
-        idleTimeout: null  # allows override of jetty websocket policy idleTimeout
-        maxBinaryMessageSize: null  # allows override of jetty websocket policy maxBinaryMessageSize
-        maxTextMessageSize: null  # allows override of jetty websocket policy maxTextMessageSize
-        checkAuthorization: false  # whether to kick unauthenticated clients off websocket sessions (allow by default)
-        connectionInitWaitTimeout: 15  # when using graphql-ws protocol, must receive the connection_init message within this many seconds
-    }
+graphql {
+  keepAliveIntervalSeconds: 15  # interval to send keepalive messages over websocket/sse protocols in seconds
+  idleTimeout: null  # allows override of jetty websocket policy idleTimeout
+  maxBinaryMessageSize: null  # allows override of jetty websocket policy maxBinaryMessageSize
+  maxTextMessageSize: null  # allows override of jetty websocket policy maxTextMessageSize
+  checkAuthorization: false  # whether to kick unauthenticated clients off websocket/sse sessions (allow by default)
+  connectionInitWaitTimeout: 15  # when using graphql-ws protocol, must receive the connection_init message within this many seconds
+}
 ```
 
 ### GraphQL Resolvers
@@ -52,16 +54,16 @@ the `graphQLSubscriptionsBinder()`, and Mutations to the `graphQLMutationsBinder
 
 ```kotlin
 class ExampleApplicationModule : GraphQLApplicationModule() {
-  override fun configureApplication() {
-    // ...
-    graphQLPackagesBinder().addBinding().toInstance("com.example.api")
-    graphQLPackagesBinder().addBinding().toInstance("com.example.server.graphql")
+    override fun configureApplication() {
+        // ...
+        graphQLPackagesBinder().addBinding().toInstance("com.example.api")
+        graphQLPackagesBinder().addBinding().toInstance("com.example.server.graphql")
 
-    graphQLQueriesBinder().addBinding().to<com.example.server.graphql.Query>()
-    graphQLMutationsBinder().addBinding().to<com.example.server.graphql.Mutation>()
-    graphQLSubscriptionsBinder().addBinding().to<com.example.server.graphql.Subscription>()
-    // ...
-  }
+        graphQLQueriesBinder().addBinding().to<com.example.server.graphql.Query>()
+        graphQLMutationsBinder().addBinding().to<com.example.server.graphql.Mutation>()
+        graphQLSubscriptionsBinder().addBinding().to<com.example.server.graphql.Subscription>()
+        // ...
+    }
 }
 ```
 
@@ -78,42 +80,45 @@ a `CookieTokenAuthFilter` for auth).
 
 ```kotlin
 class ExampleLoginMutations : GraphQLQueryResolver {
-  fun login(dfe: DataFetchingEnvironment, email: String, pass: String): Boolean {
-    if (dfe.graphQlContext.getInstance<Principal> == null) {
-      // log in!
-      val userSession = authenticate(email, pass)
-      if (userSession == null) {
-        return false
-      }
-      // cookie will be set in response
-      dfe.graphQlContext.setInstance(NewCookie("example-app-session-id", userSession.id))
-    } else {
-      // already logged in
+    fun login(dfe: DataFetchingEnvironment, email: String, pass: String): Boolean {
+        if (dfe.graphQlContext.getInstance<Principal> == null) {
+            // log in!
+            val userSession = authenticate(email, pass)
+            if (userSession == null) {
+                return false
+            }
+            // cookie will be set in response
+            dfe.graphQlContext.setInstance(NewCookie("example-app-session-id", userSession.id))
+        } else {
+            // already logged in
+        }
+        return true
     }
-    return true
-  }
 
-  fun logout(dfe: DataFetchingEnvironment): Boolean {
-    if (dfe.graphQlContext.getInstance<Principal> != null) {
-      deleteSession(dfe.graphQlContext.getInstance<Principal>)
-      dfe.graphQlContext.setInstance(
-        NewCookie(
-          Cookie("example-app-session-id", ""),
-          null,
-          -1,
-          Date(0), // 1970
-          false,
-          false
-        )
-      )
+    fun logout(dfe: DataFetchingEnvironment): Boolean {
+        if (dfe.graphQlContext.getInstance<Principal> != null) {
+            deleteSession(dfe.graphQlContext.getInstance<Principal>)
+            dfe.graphQlContext.setInstance(
+                NewCookie(
+                    Cookie("example-app-session-id", ""),
+                    null,
+                    -1,
+                    Date(0), // 1970
+                    false,
+                    false
+                )
+            )
+        }
+        return true
     }
-    return true
-  }
 }
 ```
 
 When using the WebSocket transport, credentials can be provided in HTTP headers/cookies of the upgrade request, or
 provided in the payload of the `connection_init` message.
+
+When using the Server-Sent Events transport's Single Connection Mode, credentials provided in the HTTP headers/cookies
+of the reservation request are carried over to any requests made with the returned stream token.
 
 #### Auth Schema Directive
 
@@ -129,19 +134,19 @@ auth will also result in Unauthorized/Forbidden errors in the GraphQL result.
 
 ```kotlin
 class ExampleAuthedQuery : GraphQLQueryResolver {
-  fun openField(): String {
-    return "anyone can access this"
-  }
+    fun openField(): String {
+        return "anyone can access this"
+    }
 
-  @GraphQLAuth
-  fun protectedField(): String? {
-    return "only logged in users can access this"
-  }
+    @GraphQLAuth
+    fun protectedField(): String? {
+        return "only logged in users can access this"
+    }
 
-  @GraphQLAuth(roles = ["ADMIN", "SPECIAL"])
-  fun protectedField(): String? {
-    return "only logged in ADMIN and SPECIAL users can access this, assuming an Authorizer binding is provided"
-  }
+    @GraphQLAuth(roles = ["ADMIN", "SPECIAL"])
+    fun protectedField(): String? {
+        return "only logged in ADMIN and SPECIAL users can access this, assuming an Authorizer binding is provided"
+    }
 }
 ```
 
@@ -153,19 +158,19 @@ will be run in this scope. A `DELETE` call to
 
 ```kotlin
 class ExampleSuspendQuery : GraphQLQueryResolver {
-  suspend fun coroutineMethod(): String {
-    return coroutineScope {
-      // new scope whose parent scope is the in GraphQLContext map
-      val job1 = async {
-        // do stuff asynchronously
-        "value1"
-      }
-      val job2 = async {
-        // do more stuff asynchronously, concurrently
-        "value2"
-      }
-      "${job1.await()}:${job2.await()}"
+    suspend fun coroutineMethod(): String {
+        return coroutineScope {
+            // new scope whose parent scope is the in GraphQLContext map
+            val job1 = async {
+                // do stuff asynchronously
+                "value1"
+            }
+            val job2 = async {
+                // do more stuff asynchronously, concurrently
+                "value2"
+            }
+            "${job1.await()}:${job2.await()}"
+        }
     }
-  }
 }
 ```

--- a/graphql/pom.xml
+++ b/graphql/pom.xml
@@ -179,6 +179,11 @@
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-sse</artifactId>
+            <scope>runtime</scope>
+        </dependency>
 
         <dependency>
             <groupId>com.trib3</groupId>

--- a/graphql/src/main/kotlin/com/trib3/graphql/execution/GraphQLRequest.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/execution/GraphQLRequest.kt
@@ -5,9 +5,14 @@ import com.trib3.server.runIf
 import graphql.ExecutionInput
 
 /**
- * A generic GraphQL Request object that includes query, variable, and operationName components
+ * A generic GraphQL Request object that includes query, variable, operationName and extensions components
  */
-data class GraphQLRequest(val query: String, val variables: Map<String, Any>?, val operationName: String?)
+data class GraphQLRequest(
+    val query: String,
+    val variables: Map<String, Any>?,
+    val operationName: String?,
+    val extensions: Map<String, String> = mapOf()
+)
 
 /**
  * Extension function to convert a [GraphQLRequest] to an [ExecutionInput]

--- a/graphql/src/main/kotlin/com/trib3/graphql/modules/DefaultGraphQLModule.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/modules/DefaultGraphQLModule.kt
@@ -14,6 +14,7 @@ import com.trib3.graphql.execution.JsonSafeExecutionResultMixin
 import com.trib3.graphql.execution.LeakyCauldronHooks
 import com.trib3.graphql.execution.RequestIdInstrumentation
 import com.trib3.graphql.resources.GraphQLResource
+import com.trib3.graphql.resources.GraphQLSseResource
 import com.trib3.graphql.websocket.GraphQLContextWebSocketCreatorFactory
 import com.trib3.graphql.websocket.GraphQLWebSocketCreatorFactory
 import com.trib3.graphql.websocket.GraphQLWebSocketDropwizardAuthenticator
@@ -54,6 +55,7 @@ class DefaultGraphQLModule : GraphQLApplicationModule() {
         dataFetcherExceptionHandlerBinder().setDefault().to<CustomDataFetcherExceptionHandler>()
 
         resourceBinder().addBinding().to<GraphQLResource>()
+        resourceBinder().addBinding().to<GraphQLSseResource>()
 
         // Ensure graphql binders are set up
         graphQLPackagesBinder()

--- a/graphql/src/main/kotlin/com/trib3/graphql/resources/GraphQLResource.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/resources/GraphQLResource.kt
@@ -78,10 +78,19 @@ fun getGraphQLContextMap(
 }
 
 /**
+ * Returns a response telling the browser that basic authorization is required
+ */
+internal fun unauthorizedResponse(): Response {
+    return Response.status(HttpStatus.UNAUTHORIZED_401).header(
+        "WWW-Authenticate", "Basic realm=\"realm\""
+    ).build()
+}
+
+/**
  * Jersey Resource entry point to GraphQL execution.  Configures the graphql schemas at
  * injection time and then executes a [GraphQLRequest] specified query when requested.
  */
-@Path("/")
+@Path("/graphql")
 @Produces(MediaType.APPLICATION_JSON)
 open class GraphQLResource
 @Inject constructor(
@@ -118,19 +127,9 @@ open class GraphQLResource
     }
 
     /**
-     * Returns a response telling the browser that basic authorization is required
-     */
-    private fun unauthorizedResponse(): Response {
-        return Response.status(HttpStatus.UNAUTHORIZED_401).header(
-            "WWW-Authenticate", "Basic realm=\"realm\""
-        ).build()
-    }
-
-    /**
      * Execute the query specified by the [GraphQLRequest]
      */
     @POST
-    @Path("/graphql")
     @Timed
     @AsyncDispatcher("IO")
     open suspend fun graphQL(
@@ -168,7 +167,6 @@ open class GraphQLResource
      * Allow cancellation of running queries by [requestId].
      */
     @DELETE
-    @Path("/graphql")
     fun cancel(
         @Parameter(hidden = true) @Auth principal: Optional<Principal>,
         @QueryParam("id") requestId: String
@@ -187,7 +185,6 @@ open class GraphQLResource
      * For websocket subscriptions, support upgrading from GET to a websocket
      */
     @GET
-    @Path("/graphql")
     @Timed
     open fun graphQLUpgrade(
         @Parameter(hidden = true) @Auth principal: Optional<Principal>,

--- a/graphql/src/main/kotlin/com/trib3/graphql/resources/GraphQLSseResource.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/resources/GraphQLSseResource.kt
@@ -1,0 +1,297 @@
+package com.trib3.graphql.resources
+
+import com.codahale.metrics.annotation.Timed
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.trib3.graphql.GraphQLConfig
+import com.trib3.graphql.execution.GraphQLRequest
+import com.trib3.graphql.execution.toExecutionInput
+import com.trib3.graphql.modules.DataLoaderRegistryFactory
+import com.trib3.server.coroutine.AsyncDispatcher
+import com.trib3.server.filters.RequestIdFilter
+import graphql.ExecutionInput
+import graphql.ExecutionResult
+import graphql.ExecutionResultImpl
+import graphql.GraphQL
+import graphql.GraphqlErrorBuilder
+import io.dropwizard.auth.Auth
+import io.swagger.v3.oas.annotations.Parameter
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.slf4j.MDCContext
+import kotlinx.coroutines.yield
+import mu.KotlinLogging
+import org.eclipse.jetty.http.HttpStatus
+import java.security.Principal
+import java.util.Optional
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import javax.annotation.Nullable
+import javax.inject.Inject
+import javax.ws.rs.DELETE
+import javax.ws.rs.GET
+import javax.ws.rs.HeaderParam
+import javax.ws.rs.POST
+import javax.ws.rs.PUT
+import javax.ws.rs.Path
+import javax.ws.rs.Produces
+import javax.ws.rs.QueryParam
+import javax.ws.rs.WebApplicationException
+import javax.ws.rs.core.Context
+import javax.ws.rs.core.MediaType
+import javax.ws.rs.core.Response
+import javax.ws.rs.sse.Sse
+import javax.ws.rs.sse.SseEventSink
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
+
+private val log = KotlinLogging.logger {}
+
+private const val STREAM_TOKEN_HEADER = "x-graphql-event-stream-token"
+private const val STREAM_TOKEN_QUERY_PARAM = "token"
+
+/**
+ * Connection level metadata for active streams to facilitate asynchronous processing
+ */
+internal data class StreamInfo(
+    val scope: CoroutineScope,
+    val principal: Principal?,
+    val eventSink: SseEventSink,
+    val sse: Sse
+)
+
+/**
+ * Implements the graphql-sse protocol from https://github.com/enisdenjo/graphql-sse/blob/master/PROTOCOL.md
+ * Both "Single connection mode" and "Distinct connections mode" are supported at the /app/graphql/stream endpoint.
+ *
+ * Single connection mode client request flow:
+ * PUT -> x-graphql-event-stream-token 201 response
+ * GET text/event-stream w/ x-graphql-event-stream-token -> open sse stream 200 response
+ * POST {query, extensions: {operationId: xyz}}w/ x-graphql-event-stream-token -> 202 response
+ */
+@Path("/graphql/stream")
+@Produces(MediaType.APPLICATION_JSON)
+open class GraphQLSseResource @Inject constructor(
+    private val graphQL: GraphQL,
+    private val graphQLConfig: GraphQLConfig,
+    private val objectMapper: ObjectMapper,
+    @Nullable val dataLoaderRegistryFactory: DataLoaderRegistryFactory? = null
+) {
+    private val reservedStreams = ConcurrentHashMap<UUID, Optional<Principal>>()
+    internal val activeStreams = ConcurrentHashMap<UUID, StreamInfo>()
+    internal val runningOperations = ConcurrentHashMap<UUID, MutableMap<String, CoroutineScope>>()
+
+    /**
+     * Launch a coroutine that sends periodic SSE comments to keep the connection alive.
+     * This will get cancelled when the surrounding scope is (eg client disconnection)
+     */
+    private fun CoroutineScope.launchKeepAlive(eventSink: SseEventSink, sse: Sse): Job {
+        return launch(MDCContext()) {
+            while (isActive) {
+                if (graphQLConfig.keepAliveIntervalSeconds > 0) {
+                    eventSink.send(sse.newEventBuilder().comment("ka").build())
+                }
+                delay(graphQLConfig.keepAliveIntervalSeconds.toDuration(DurationUnit.SECONDS))
+            }
+        }
+    }
+
+    /**
+     * Execute a graphql query and send results to the [eventSink]
+     */
+    private suspend fun runQuery(input: ExecutionInput, eventSink: SseEventSink, sse: Sse, operationId: String?) {
+        try {
+            val result = graphQL.execute(input)
+            // if result data is a Flow, collect it as a flow
+            // if it's not, just collect the result itself
+            val flow = try {
+                result.getData<Flow<ExecutionResult>>() ?: flowOf(result)
+            } catch (e: Exception) {
+                log.debug("Could not get Flow result, collecting result directly", e)
+                flowOf(result)
+            }
+            flow.onEach {
+                yield()
+                val nextMessage: Any = if (operationId != null) {
+                    mapOf(
+                        "id" to operationId,
+                        "payload" to it
+                    )
+                } else {
+                    it
+                }
+                eventSink.send(
+                    sse.newEventBuilder().name("next").data(
+                        objectMapper.writeValueAsString(
+                            nextMessage
+                        )
+                    ).build()
+                )
+            }.collect()
+        } catch (e: Exception) {
+            log.warn("Error running sse query: ${e.message}", e)
+            val gqlError = ExecutionResultImpl.newExecutionResult()
+                .addError(GraphqlErrorBuilder.newError().message(e.message).build()).build()
+            val nextMessage: Any = if (operationId != null) {
+                mapOf(
+                    "id" to operationId,
+                    "payload" to gqlError
+                )
+            } else {
+                gqlError
+            }
+            eventSink.send(
+                sse.newEventBuilder().name("next").data(
+                    objectMapper.writeValueAsString(
+                        nextMessage
+                    )
+                ).build()
+            )
+        } finally {
+            log.info("Query ${operationId ?: RequestIdFilter.getRequestId()} completed.")
+            val completeMessage = if (operationId != null) {
+                objectMapper.writeValueAsString(
+                    mapOf("id" to operationId)
+                )
+            } else {
+                ""
+            }
+            eventSink.send(sse.newEventBuilder().name("complete").data(completeMessage).build())
+        }
+    }
+
+    /**
+     * Creates a stream reservation and returns the stream token as text
+     */
+    @PUT
+    @Produces(MediaType.TEXT_PLAIN)
+    @Timed
+    open fun reserveEventStream(
+        @Parameter(hidden = true) @Auth principal: Optional<Principal>
+    ): Response {
+        if (principal.isEmpty && graphQLConfig.checkAuthorization) {
+            return unauthorizedResponse()
+        }
+        val reservation = UUID.randomUUID()
+        reservedStreams[reservation] = principal
+        return Response.status(HttpStatus.CREATED_201).entity(reservation.toString()).build()
+    }
+
+    /**
+     * Given a stream reservation, open an SSE stream that will publish SSE events for
+     * queries that are executed on the stream
+     */
+    @GET
+    @Produces(MediaType.SERVER_SENT_EVENTS)
+    @AsyncDispatcher("IO")
+    open suspend fun eventStream(
+        @Context eventSink: SseEventSink,
+        @Context sse: Sse,
+        @HeaderParam(STREAM_TOKEN_HEADER) headerToken: UUID?,
+        @QueryParam(STREAM_TOKEN_QUERY_PARAM) paramToken: UUID?
+    ) {
+        val streamToken = headerToken ?: paramToken
+        val principal = if (streamToken != null) {
+            reservedStreams.remove(streamToken)
+        } else {
+            null
+        }
+        if (streamToken == null || principal == null) {
+            eventSink.close()
+            return
+        }
+        try {
+            coroutineScope {
+                activeStreams[streamToken] = StreamInfo(this, principal.orElse(null), eventSink, sse)
+                launchKeepAlive(eventSink, sse)
+            }
+        } finally {
+            activeStreams.remove(streamToken)
+            runningOperations.remove(streamToken)
+        }
+    }
+
+    /**
+     * Given a stream reservation with an active SSE connection, execute a query
+     * and send its result(s) to the SSE connection.  The [query] should have an
+     * `operationId` specified in its `extensions` map, which will be used in the
+     * streamed results.  If no `operationId` is specified, the response `X-Request-Id`
+     * header will contain a generated `operationId`.
+     */
+    @POST
+    @Timed
+    open fun queryOpenStream(
+        @Parameter(hidden = true) @Auth principal: Optional<Principal>,
+        query: GraphQLRequest,
+        @HeaderParam(STREAM_TOKEN_HEADER) headerToken: UUID?,
+        @QueryParam(STREAM_TOKEN_QUERY_PARAM) paramToken: UUID?
+    ): Response {
+        val streamToken = headerToken ?: paramToken ?: throw WebApplicationException(unauthorizedResponse())
+        val streamInfo = activeStreams[streamToken]
+        val contextPrincipal = principal.orElse(streamInfo?.principal)
+        if (streamInfo == null || (contextPrincipal == null && graphQLConfig.checkAuthorization)) {
+            return unauthorizedResponse()
+        }
+        val operationId = query.extensions["operationId"] ?: RequestIdFilter.getRequestId().toString()
+        val newQueryMap = ConcurrentHashMap<String, CoroutineScope>()
+        val queryMap = runningOperations.putIfAbsent(streamToken, newQueryMap) ?: newQueryMap
+        // launch in the connection's scope so this POST can return immediately with 202
+        streamInfo.scope.launch(MDCContext()) {
+            try {
+                queryMap[operationId] = this
+                val contextMap = getGraphQLContextMap(this, contextPrincipal)
+                val input = query.toExecutionInput(contextMap, dataLoaderRegistryFactory)
+                runQuery(input, streamInfo.eventSink, streamInfo.sse, operationId)
+            } finally {
+                queryMap.remove(operationId)
+            }
+        }
+        return Response.status(HttpStatus.ACCEPTED_202).build()
+    }
+
+    /**
+     * Given a stream reservation and `operationId`, cancel any running query.
+     */
+    @DELETE
+    open fun cancelOperation(
+        @QueryParam("operationId") operationId: String,
+        @HeaderParam(STREAM_TOKEN_HEADER) headerToken: UUID?,
+        @QueryParam(STREAM_TOKEN_QUERY_PARAM) paramToken: UUID?
+    ) {
+        val streamToken = headerToken ?: paramToken ?: throw WebApplicationException(unauthorizedResponse())
+        runningOperations[streamToken]?.get(operationId)?.cancel()
+    }
+
+    /**
+     * Implements the "Distinct connections mode" SSE request.  Accepts a POST body
+     * containing the graphql request, and executes it, sending results as SSE events.
+     */
+    @POST
+    @Produces(MediaType.SERVER_SENT_EVENTS)
+    @Timed
+    @AsyncDispatcher("IO")
+    open suspend fun querySse(
+        @Context eventSink: SseEventSink,
+        @Context sse: Sse,
+        @Parameter(hidden = true) @Auth principal: Optional<Principal>,
+        query: GraphQLRequest
+    ) = coroutineScope {
+        val contextMap = getGraphQLContextMap(this, principal.orElse(null))
+        val ka = launchKeepAlive(eventSink, sse)
+        try {
+            val input = query.toExecutionInput(contextMap, dataLoaderRegistryFactory)
+            runQuery(input, eventSink, sse, null)
+        } finally {
+            ka.cancel()
+            eventSink.close()
+        }
+    }
+}

--- a/graphql/src/main/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketConsumer.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketConsumer.kt
@@ -35,6 +35,8 @@ import org.glassfish.jersey.server.ContainerRequest
 import java.security.Principal
 import java.time.Duration
 import javax.ws.rs.container.ContainerRequestContext
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 private val log = KotlinLogging.logger {}
 
@@ -68,7 +70,7 @@ class KeepAliveCoroutine(
 ) : GraphQLCoroutine(channel) {
     override suspend fun run() {
         while (true) {
-            delay(Duration.ofSeconds(graphQLConfig.keepAliveIntervalSeconds).toMillis())
+            delay(graphQLConfig.keepAliveIntervalSeconds.toDuration(DurationUnit.SECONDS))
             log.trace("WebSocket connection keepalive ping")
             queueMessage(
                 OperationMessage(

--- a/graphql/src/main/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketProtocol.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketProtocol.kt
@@ -35,7 +35,7 @@ enum class GraphQLWebSocketSubProtocol(
     APOLLO_PROTOCOL(
         "graphql-ws",
         mapOf(),
-        { messageId, messageBody, adapter ->
+        onInvalidMessageCallback = { messageId, messageBody, adapter ->
             adapter.sendMessage(
                 OperationMessage(
                     OperationType.GQL_ERROR, messageId,
@@ -43,7 +43,7 @@ enum class GraphQLWebSocketSubProtocol(
                 )
             )
         },
-        { message, adapter ->
+        onDuplicateQueryCallback = { message, adapter ->
             adapter.sendMessage(
                 OperationMessage(
                     OperationType.GQL_ERROR,
@@ -52,7 +52,7 @@ enum class GraphQLWebSocketSubProtocol(
                 )
             )
         },
-        { message, adapter ->
+        onDuplicateInitCallback = { message, adapter ->
             adapter.sendMessage(
                 OperationMessage(
                     OperationType.GQL_CONNECTION_ERROR,
@@ -70,14 +70,14 @@ enum class GraphQLWebSocketSubProtocol(
             OperationType.GQL_STOP to OperationType.GQL_COMPLETE,
             OperationType.GQL_CONNECTION_KEEP_ALIVE to OperationType.GQL_PONG
         ),
-        { msgId, msgBody, adapter ->
+        onInvalidMessageCallback = { msgId, msgBody, adapter ->
             adapter.session?.close(
                 GraphQLWebSocketCloseReason.INVALID_MESSAGE.code,
                 GraphQLWebSocketCloseReason.INVALID_MESSAGE.description.replace("<id>", msgId ?: "")
                     .replace("<body>", msgBody)
             )
         },
-        { message, adapter ->
+        onDuplicateQueryCallback = { message, adapter ->
             adapter.session?.close(
                 GraphQLWebSocketCloseReason.MULTIPLE_SUBSCRIBER.code,
                 GraphQLWebSocketCloseReason.MULTIPLE_SUBSCRIBER.description.replace(
@@ -86,7 +86,7 @@ enum class GraphQLWebSocketSubProtocol(
                 )
             )
         },
-        { _, adapter ->
+        onDuplicateInitCallback = { _, adapter ->
             adapter.session?.close(GraphQLWebSocketCloseReason.MULTIPLE_INIT)
         }
     );

--- a/graphql/src/test/kotlin/com/trib3/graphql/resources/GraphQLResourceIntegrationTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/resources/GraphQLResourceIntegrationTest.kt
@@ -64,6 +64,9 @@ class AuthTestQuery : GraphQLQueryResolver {
  * websocket upgrades and authentication
  */
 class GraphQLResourceIntegrationTest : ResourceTestBase<GraphQLResource>() {
+    init {
+        System.setProperty("sun.net.http.allowRestrictedHeaders", "true")
+    }
 
     override fun getResource(): GraphQLResource {
         return rawResource
@@ -162,7 +165,6 @@ class GraphQLResourceIntegrationTest : ResourceTestBase<GraphQLResource>() {
 
     @Test
     fun testWebSocketUpgradeUnauthenticated() {
-        System.setProperty("sun.net.http.allowRestrictedHeaders", "true")
         val result = resource.target("/graphql").queryParam("fail", "true")
             .request().header("Origin", "https://blah.com").get()
         assertThat(result.status).isEqualTo(HttpStatus.UNAUTHORIZED_401)

--- a/graphql/src/test/kotlin/com/trib3/graphql/resources/GraphQLSseResourceIntegrationTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/resources/GraphQLSseResourceIntegrationTest.kt
@@ -1,0 +1,349 @@
+package com.trib3.graphql.resources
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isGreaterThanOrEqualTo
+import assertk.assertions.isLessThan
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import com.expediagroup.graphql.generator.SchemaGeneratorConfig
+import com.expediagroup.graphql.generator.TopLevelObject
+import com.expediagroup.graphql.generator.execution.FlowSubscriptionExecutionStrategy
+import com.expediagroup.graphql.generator.hooks.FlowSubscriptionSchemaGeneratorHooks
+import com.expediagroup.graphql.generator.toSchema
+import com.trib3.config.ConfigLoader
+import com.trib3.graphql.GraphQLConfig
+import com.trib3.graphql.execution.CustomDataFetcherExceptionHandler
+import com.trib3.graphql.execution.RequestIdInstrumentation
+import com.trib3.json.ObjectMapperProvider
+import com.trib3.testing.server.JettyWebTestContainerFactory
+import com.trib3.testing.server.ResourceTestBase
+import graphql.GraphQL
+import graphql.execution.AsyncExecutionStrategy
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import org.glassfish.jersey.media.sse.EventInput
+import org.glassfish.jersey.test.spi.TestContainerFactory
+import org.testng.annotations.Test
+import java.util.UUID
+import javax.ws.rs.client.Entity
+import javax.ws.rs.core.MediaType
+
+class SseQuery {
+    fun hello(): String {
+        return "world"
+    }
+
+    fun error(): String {
+        throw IllegalStateException("Forced Error")
+    }
+}
+
+class SseSubscription {
+    fun three(): Flow<Int> {
+        return flowOf(1, 2, 3)
+    }
+
+    fun inf(): Flow<Int> {
+        return flow {
+            var i = 0
+            while (true) {
+                delay(10)
+                emit(i++)
+            }
+        }
+    }
+
+    fun serror(): Flow<Int> {
+        throw IllegalStateException("Forced Error")
+    }
+}
+
+class GraphQLSseResourceIntegrationTest : ResourceTestBase<GraphQLSseResource>() {
+    override fun getResource(): GraphQLSseResource {
+        return rawResource
+    }
+
+    override fun getContainerFactory(): TestContainerFactory {
+        return JettyWebTestContainerFactory()
+    }
+
+    private val graphQL = GraphQL.newGraphQL(
+        toSchema(
+            SchemaGeneratorConfig(
+                listOf(this::class.java.packageName),
+                hooks = FlowSubscriptionSchemaGeneratorHooks()
+            ),
+            listOf(TopLevelObject(SseQuery())),
+            listOf(),
+            listOf(TopLevelObject(SseSubscription()))
+        )
+    )
+        .queryExecutionStrategy(AsyncExecutionStrategy(CustomDataFetcherExceptionHandler()))
+        .subscriptionExecutionStrategy(FlowSubscriptionExecutionStrategy(CustomDataFetcherExceptionHandler()))
+        .instrumentation(RequestIdInstrumentation())
+        .build()
+
+    private val rawResource = GraphQLSseResource(
+        graphQL,
+        GraphQLConfig(ConfigLoader("GraphSSEQLResourceIntegrationTest")),
+        ObjectMapperProvider().get()
+    )
+
+    private val target by lazy { resource.target("/graphql/stream") }
+
+    private fun readEventInput(eventInput: EventInput, completePayload: String): List<String> {
+        val events = mutableListOf<String>()
+        while (!eventInput.isClosed) {
+            val event = eventInput.read()
+            if (event?.name == "complete") {
+                assertThat(event.readData()).isEqualTo(completePayload)
+                eventInput.close()
+            } else if (event?.name == "next") {
+                events.add(event.readData())
+            }
+        }
+        return events
+    }
+
+    private fun waitForStreamReady(tokenUUID: UUID) {
+        // wait up to 4 seconds for the stream to be ready
+        val now = System.currentTimeMillis()
+        while (rawResource.activeStreams[tokenUUID] == null) {
+            assertThat(System.currentTimeMillis() - now).isLessThan(4000)
+            Thread.sleep(10)
+        }
+    }
+
+    @Test
+    fun testSseQuery() {
+        val result = target.request().accept(MediaType.SERVER_SENT_EVENTS)
+            .post(Entity.json("""{"query":"query {hello}"}"""), EventInput::class.java)
+        val events = readEventInput(result, "")
+        assertThat(events).hasSize(1)
+        assertThat(events[0]).contains(""""data":{"hello":"world"}""")
+    }
+
+    @Test
+    fun testSseSubscription() {
+        val result = target.request().accept(MediaType.SERVER_SENT_EVENTS)
+            .post(Entity.json("""{"query":"subscription {three}"}"""), EventInput::class.java)
+        val events = readEventInput(result, "")
+        assertThat(events).hasSize(3)
+        for (i in 0..2) {
+            assertThat(events[i]).contains(""""data":{"three":${i + 1}}""")
+        }
+    }
+
+    @Test
+    fun testSseError() {
+        val result = target.request().accept(MediaType.SERVER_SENT_EVENTS)
+            .post(Entity.json("""{"query":"query {error}"}"""), EventInput::class.java)
+        val events = readEventInput(result, "")
+        assertThat(events).hasSize(1)
+        assertThat(events[0]).contains(""""message":"Forced Error"""")
+        assertThat(events[0]).contains(""""data":null""")
+    }
+
+    @Test
+    fun testSseSubError() {
+        val result = target.request().accept(MediaType.SERVER_SENT_EVENTS)
+            .post(Entity.json("""{"query":"subscription {serror}"}"""), EventInput::class.java)
+        val events = readEventInput(result, "")
+        assertThat(events).hasSize(1)
+        assertThat(events[0]).contains(""""message":"Forced Error"""")
+        assertThat(events[0]).contains(""""data":null""")
+    }
+
+    @Test
+    fun testSingleConnQuery() {
+        val tokenResponse = target.request().put(Entity.text(""))
+        val token = tokenResponse.readEntity(String::class.java)
+        assertThat(tokenResponse.status).isEqualTo(201)
+        val tokenUUID = UUID.fromString(token)
+
+        val eventInput = target.request().header("x-graphql-event-stream-token", token).get(EventInput::class.java)
+        waitForStreamReady(tokenUUID)
+        val query = target.request().header("x-graphql-event-stream-token", token)
+            .post(Entity.json("""{"query":"query {hello}", "extensions":{"operationId":"clientspecified"}}"""))
+        assertThat(query.status).isEqualTo(202)
+        assertThat(rawResource.activeStreams[tokenUUID]).isNotNull()
+        assertThat(rawResource.runningOperations[tokenUUID]).isNotNull()
+        val query2 = target.request().header("x-graphql-event-stream-token", token)
+            .post(Entity.json("""{"query":"query {hello}", "extensions":{"operationId":"clientspecified2"}}"""))
+        assertThat(query2.status).isEqualTo(202)
+        var completeEvents = 0
+        val events = mutableListOf<String>()
+        while (!eventInput.isClosed) {
+            val event = eventInput.read()
+            if (event?.name == "complete") {
+                completeEvents++
+                if (completeEvents >= 2) {
+                    eventInput.close()
+                }
+            } else if (event?.name == "next") {
+                events.add(event.readData())
+            }
+        }
+        assertThat(events).hasSize(2)
+        assertThat(events.first { it.contains("clientspecified\"") }).contains(""""data":{"hello":"world"}""")
+        assertThat(events.first { it.contains("clientspecified2") }).contains(""""data":{"hello":"world"}""")
+        val now = System.currentTimeMillis()
+        // wait up to 4 seconds for the stream to be closed
+        while (rawResource.activeStreams[tokenUUID] != null) {
+            assertThat(System.currentTimeMillis() - now).isLessThan(4000)
+            Thread.sleep(10)
+        }
+        assertThat(rawResource.activeStreams[tokenUUID]).isNull()
+        assertThat(rawResource.runningOperations[tokenUUID]).isNull()
+    }
+
+    @Test
+    fun testSingleConnSub() {
+        val tokenResponse = target.request().put(Entity.text(""))
+        val token = tokenResponse.readEntity(String::class.java)
+        assertThat(tokenResponse.status).isEqualTo(201)
+        val tokenUUID = UUID.fromString(token)
+
+        val eventInput = target.queryParam("token", token).request().get(EventInput::class.java)
+        waitForStreamReady(tokenUUID)
+        val query = target.queryParam("token", token).request()
+            .post(Entity.json("""{"query":"subscription {three}", "extensions":{"operationId":"clientspecified"}}"""))
+        assertThat(query.status).isEqualTo(202)
+        val events = readEventInput(eventInput, """{"id":"clientspecified"}""")
+        assertThat(events).hasSize(3)
+        for (i in 0..2) {
+            assertThat(events[i]).contains(""""id":"clientspecified"""")
+            assertThat(events[i]).contains(""""data":{"three":${i + 1}}""")
+        }
+    }
+
+    @Test
+    fun testSingleConnError() {
+        val tokenResponse = target.request().put(Entity.text(""))
+        val token = tokenResponse.readEntity(String::class.java)
+        assertThat(tokenResponse.status).isEqualTo(201)
+        val tokenUUID = UUID.fromString(token)
+
+        val eventInput = target.request().header("x-graphql-event-stream-token", token).get(EventInput::class.java)
+        waitForStreamReady(tokenUUID)
+        val query = target.request().header("x-graphql-event-stream-token", token)
+            .post(Entity.json("""{"query":"query {error}", "extensions":{"operationId":"clientspecified"}}"""))
+        assertThat(query.status).isEqualTo(202)
+        val events = readEventInput(eventInput, """{"id":"clientspecified"}""")
+        assertThat(events).hasSize(1)
+        assertThat(events[0]).contains(""""id":"clientspecified"""")
+        assertThat(events[0]).contains(""""message":"Forced Error"""")
+    }
+
+    @Test
+    fun testSingleConnSubError() {
+        val tokenResponse = target.request().put(Entity.text(""))
+        val token = tokenResponse.readEntity(String::class.java)
+        assertThat(tokenResponse.status).isEqualTo(201)
+        val tokenUUID = UUID.fromString(token)
+
+        val eventInput = target.queryParam("token", token).request().get(EventInput::class.java)
+        waitForStreamReady(tokenUUID)
+        val query = target.queryParam("token", token).request()
+            .post(Entity.json("""{"query":"subscription {serror}", "extensions":{"operationId":"clientspecified"}}"""))
+        assertThat(query.status).isEqualTo(202)
+        val events = readEventInput(eventInput, """{"id":"clientspecified"}""")
+        assertThat(events).hasSize(1)
+        assertThat(events[0]).contains(""""id":"clientspecified"""")
+        assertThat(events[0]).contains(""""message":"Forced Error"""")
+    }
+
+    @Test
+    fun testSingleConnCancellation() {
+
+        val tokenResponse = target.request().put(Entity.text(""))
+        val token = tokenResponse.readEntity(String::class.java)
+        assertThat(tokenResponse.status).isEqualTo(201)
+        val tokenUUID = UUID.fromString(token)
+
+        val eventInput = target.request().header("x-graphql-event-stream-token", token).get(EventInput::class.java)
+        waitForStreamReady(tokenUUID)
+        val query = target.request().header("x-graphql-event-stream-token", token)
+            .post(Entity.json("""{"query":"subscription {inf}", "extensions":{"operationId":"infinitequery"}}"""))
+        assertThat(query.status).isEqualTo(202)
+        while (!eventInput.isClosed) {
+            val event = eventInput.read()
+            if (event?.name == "next") {
+                break
+            }
+        }
+        val cancel = target.queryParam("operationId", "infinitequery")
+            .request()
+            .header("x-graphql-event-stream-token", token)
+            .delete()
+        assertThat(cancel.status).isEqualTo(204)
+        val moreEvents = readEventInput(eventInput, """{"id":"infinitequery"}""")
+        assertThat(moreEvents.size).isGreaterThanOrEqualTo(0)
+    }
+
+    @Test
+    fun testSingleConnEndpointsNoToken() {
+        val eventInput = target.request().get(EventInput::class.java)
+        val events = readEventInput(eventInput, "")
+        assertThat(events).isEmpty()
+
+        val query = target.request()
+            .post(Entity.json("""{"query":"subscription {serror}", "extensions":{"operationId":"clientspecified"}}"""))
+        assertThat(query.status).isEqualTo(401)
+    }
+
+    @Test
+    fun testSingleConnEndpointsBadToken() {
+        val eventInput = target.queryParam("token", UUID.randomUUID().toString()).request().get(EventInput::class.java)
+        val events = readEventInput(eventInput, "")
+        assertThat(events).isEmpty()
+
+        val query = target.queryParam("token", UUID.randomUUID().toString()).request()
+            .post(Entity.json("""{"query":"subscription {serror}", "extensions":{"operationId":"clientspecified"}}"""))
+        assertThat(query.status).isEqualTo(401)
+    }
+
+    @Test
+    fun testSingleConnBadCancellation() = runBlocking {
+        val cancelNoToken = target.queryParam("operationId", "badValue")
+            .request()
+            .delete()
+        assertThat(cancelNoToken.status).isEqualTo(401)
+
+        val cancelBadTokenHeader = target.queryParam("operationId", "badValue")
+            .request()
+            .header("x-graphql-event-stream-token", UUID.randomUUID())
+            .delete()
+        assertThat(cancelBadTokenHeader.status).isEqualTo(204)
+
+        val cancelBadTokenQueryParam = target.queryParam("operationId", "badValue")
+            .queryParam("token", UUID.randomUUID())
+            .request()
+            .delete()
+        assertThat(cancelBadTokenQueryParam.status).isEqualTo(204)
+
+        val tokenResponse = target.request().put(Entity.text(""))
+        val token = tokenResponse.readEntity(String::class.java)
+        val tokenUUID = UUID.fromString(token)
+        assertThat(tokenResponse.status).isEqualTo(201)
+
+        val eventInput = target.request().header("x-graphql-event-stream-token", token).get(EventInput::class.java)
+        waitForStreamReady(tokenUUID)
+        val query = target.request().header("x-graphql-event-stream-token", token)
+            .post(Entity.json("""{"query":"query {hello}", "extensions":{"operationId":"clientspecified"}}"""))
+        assertThat(query.status).isEqualTo(202)
+        val cancelGoodTokenBadOperationId = target.queryParam("operationId", "badValue")
+            .queryParam("token", token)
+            .request()
+            .delete()
+        assertThat(cancelGoodTokenBadOperationId.status).isEqualTo(204)
+        eventInput.close()
+    }
+}

--- a/graphql/src/test/kotlin/com/trib3/graphql/resources/GraphQLSseResourceTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/resources/GraphQLSseResourceTest.kt
@@ -1,0 +1,126 @@
+package com.trib3.graphql.resources
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.isEqualTo
+import assertk.assertions.isSuccess
+import com.trib3.config.ConfigLoader
+import com.trib3.graphql.GraphQLConfig
+import com.trib3.graphql.execution.GraphQLRequest
+import com.trib3.json.ObjectMapperProvider
+import com.trib3.server.filters.RequestIdFilter
+import com.trib3.testing.LeakyMock
+import graphql.ExecutionInput
+import graphql.ExecutionResult
+import graphql.ExecutionResultImpl
+import graphql.GraphQL
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.easymock.CaptureType
+import org.easymock.EasyMock
+import org.glassfish.jersey.media.sse.OutboundEvent
+import org.testng.annotations.Test
+import java.util.Optional
+import java.util.UUID
+import javax.ws.rs.sse.OutboundSseEvent
+import javax.ws.rs.sse.Sse
+import javax.ws.rs.sse.SseEventSink
+
+/**
+ * Most functional tests of SSE handling are in [GraphQLSseResourceIntegrationTest], but some
+ * corner cases are easier to trigger with unit tests/mocks
+ */
+class GraphQLSseResourceTest {
+
+    private val resource: GraphQLSseResource
+    private val principal = UserPrincipal(User("bill"))
+
+    init {
+        val mockFlow = flow<ExecutionResult> {
+            throw IllegalArgumentException("fake error")
+        }
+        val graphQL = LeakyMock.mock<GraphQL>()
+        val executionResult = ExecutionResultImpl.newExecutionResult().data(mockFlow).build()
+
+        EasyMock.expect(graphQL.execute(EasyMock.anyObject<ExecutionInput>()))
+            .andReturn(executionResult).anyTimes()
+
+        EasyMock.replay(graphQL)
+
+        resource = GraphQLSseResource(
+            graphQL,
+            GraphQLConfig(ConfigLoader("GraphQLSseResourceTest")),
+            ObjectMapperProvider().get()
+        )
+    }
+
+    @Test
+    fun testFlowError() = runBlocking {
+        val eventCapture = EasyMock.newCapture<OutboundSseEvent>(CaptureType.ALL)
+        val mockSink = LeakyMock.mock<SseEventSink>()
+        EasyMock.expect(mockSink.send(EasyMock.capture(eventCapture))).andReturn(null).anyTimes()
+        EasyMock.expect(mockSink.close())
+        val mockSse = LeakyMock.mock<Sse>()
+        EasyMock.expect(mockSse.newEventBuilder()).andReturn(OutboundEvent.Builder()).anyTimes()
+        EasyMock.replay(mockSink, mockSse)
+        assertThat {
+            resource.querySse(
+                mockSink,
+                mockSse,
+                Optional.of(principal),
+                GraphQLRequest("query", mapOf(), null)
+            )
+        }.isSuccess()
+        assertThat(eventCapture.values[0].name).isEqualTo("next")
+        assertThat(eventCapture.values[0].data.toString()).contains(""""message":"fake error"""")
+        assertThat(eventCapture.values[1].name).isEqualTo("complete")
+        assertThat(eventCapture.values[1].data.toString()).isEqualTo("")
+    }
+
+    @Test
+    fun testFlowErrorSingleConn() = runBlocking {
+        val eventCapture = EasyMock.newCapture<OutboundSseEvent>(CaptureType.ALL)
+        val mockSink = LeakyMock.mock<SseEventSink>()
+        EasyMock.expect(mockSink.send(EasyMock.capture(eventCapture))).andReturn(null).anyTimes()
+        EasyMock.expect(mockSink.close())
+        val mockSse = LeakyMock.mock<Sse>()
+        EasyMock.expect(mockSse.newEventBuilder()).andReturn(OutboundEvent.Builder()).anyTimes()
+        EasyMock.replay(mockSink, mockSse)
+        val token = UUID.fromString(resource.reserveEventStream(Optional.of(principal)).entity.toString())
+        val stream = launch(Dispatchers.IO) {
+            resource.eventStream(mockSink, mockSse, token, null)
+        }
+        // wait for stream to fully open
+        while (resource.activeStreams[token] == null) {
+            delay(10)
+        }
+        RequestIdFilter.withRequestId("querytofail") {
+            resource.queryOpenStream(
+                Optional.empty(),
+                GraphQLRequest("query", mapOf(), null),
+                token,
+                null
+            )
+            // wait for stream events
+            while (eventCapture.values.size < 2) {
+                delay(10)
+            }
+            stream.cancel()
+            val events = eventCapture.values
+            assertThat(events[0].name).isEqualTo("next")
+            assertThat(events[0].data.toString()).contains(""""message":"fake error"""")
+            assertThat(events[0].data.toString()).contains(""""id":"querytofail"""")
+            assertThat(events[1].name).isEqualTo("complete")
+            assertThat(events[1].data.toString()).isEqualTo("""{"id":"querytofail"}""")
+        }
+    }
+
+    @Test
+    fun testReservationAuth() {
+        assertThat(resource.reserveEventStream(Optional.empty()).status).isEqualTo(401)
+        assertThat(resource.reserveEventStream(Optional.of(principal)).status).isEqualTo(201)
+    }
+}

--- a/graphql/src/test/resources/application.conf
+++ b/graphql/src/test/resources/application.conf
@@ -1,18 +1,31 @@
 GraphQLResourceTest {
-    graphQL {
-        idleTimeout: 200000
-        maxBinaryMessageSize: 300000
-        maxTextMessageSize: 400000
-    }
+  graphQL {
+    idleTimeout: 200000
+    maxBinaryMessageSize: 300000
+    maxTextMessageSize: 400000
+  }
 }
 GraphQLResourceIntegrationTest {
-    graphQL {
-        authorizedWebSocketOnly: true
-    }
+  graphQL {
+    authorizedWebSocketOnly: true
+  }
+}
+
+GraphQLSseResourceTest {
+  graphQL {
+    keepAliveIntervalSeconds: 0
+    authorizedWebSocketOnly: true
+  }
+}
+
+GraphSSEQLResourceIntegrationTest {
+  graphQL {
+    keepAliveIntervalSeconds: 1
+  }
 }
 
 nokeepalive {
-    graphQL {
-        keepAliveIntervalSeconds: 0
-    }
+  graphQL {
+    keepAliveIntervalSeconds: 0
+  }
 }

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -654,6 +654,17 @@
                 </exclusions>
             </dependency>
             <dependency>
+                <groupId>org.glassfish.jersey.media</groupId>
+                <artifactId>jersey-media-sse</artifactId>
+                <version>${version.jersey}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.glassfish.hk2.external</groupId>
+                        <artifactId>jakarta.inject</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
                 <groupId>org.glassfish.jersey.test-framework</groupId>
                 <artifactId>jersey-test-framework-core</artifactId>
                 <version>${version.jersey}</version>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -259,5 +259,10 @@
             <artifactId>kotlinx-coroutines-swing</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-sse</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/server/src/main/resources/reference.conf
+++ b/server/src/main/resources/reference.conf
@@ -16,6 +16,12 @@ server {
   requestLog {
     type: filtered-logback-access
   }
+  gzip {
+    # gzip compression doesn't play well with sse events unless syncFlush is enabled
+    # https://github.com/eclipse-ee4j/jersey/issues/3272 and https://github.com/dropwizard/dropwizard/issues/1673
+    # can remove once we update to jetty 10 which excludes sse mime type from gzip by default
+    syncFlush: true
+  }
 }
 
 logging {

--- a/server/src/test/kotlin/com/trib3/server/coroutine/CoroutineModelProcessorTest.kt
+++ b/server/src/test/kotlin/com/trib3/server/coroutine/CoroutineModelProcessorTest.kt
@@ -18,6 +18,9 @@ import javax.inject.Provider
 import javax.ws.rs.GET
 import javax.ws.rs.Path
 import javax.ws.rs.QueryParam
+import javax.ws.rs.core.Context
+import javax.ws.rs.sse.Sse
+import javax.ws.rs.sse.SseEventSink
 
 @Path("/")
 class ProcessorTestResource {
@@ -33,70 +36,62 @@ class ProcessorTestResource {
         delay(1)
         return "coroutine${a.orElse("null")}"
     }
+
+    @GET
+    @Path("/sse")
+    suspend fun sseMethod(
+        @Context sseEventSink: SseEventSink,
+        @Context sse: Sse
+    ) {
+        delay(1)
+        sseEventSink.send(sse.newEvent("data", "value"))
+        sseEventSink.close()
+    }
 }
 
 class CoroutineModelProcessorTest {
     @Test
-    fun testBuildResource() {
+    fun testBuildResourceAndSubResources() {
         val mockInjector = LeakyMock.mock<InjectionManager>()
         val mockAsyncProvider = LeakyMock.mock<Provider<AsyncContext>>()
         EasyMock.expect(mockInjector.getInstance(ProcessorTestResource::class.java)).andReturn(ProcessorTestResource())
         EasyMock.replay(mockInjector, mockAsyncProvider)
-        val resourceModel = ResourceModel.Builder(
-            listOf(
-                Resource.builder(ProcessorTestResource::class.java).build()
+        val resourceList = listOf(
+            Resource.builder(ProcessorTestResource::class.java).build()
+        )
+        val processor = CoroutineModelProcessor(mockInjector, mockAsyncProvider)
+        val builtResources = listOf(
+            processor.processResourceModel(
+                ResourceModel.Builder(resourceList, false).build(),
+                ResourceConfig()
             ),
-            false
-        ).build()
-        val builtResource =
-            CoroutineModelProcessor(mockInjector, mockAsyncProvider).processResourceModel(
-                resourceModel,
+            processor.processSubResource(
+                ResourceModel.Builder(resourceList, true).build(),
                 ResourceConfig()
             )
-        assertThat(builtResource.resources).hasSize(1)
-        for (childResource in builtResource.resources[0].childResources) {
-            for (method in childResource.resourceMethods) {
-                if (method.invocable.handlingMethod.name == "coroutineMethod") {
-                    assertThat(method.invocable.parameters).hasSize(1)
-                    assertThat(method.invocable.parameters[0].getAnnotation(QueryParam::class.java).value)
-                        .isEqualTo("a")
-                    assertThat(method.invocable.parameters[0].type.typeName)
-                        .isEqualTo("java.util.Optional<java.lang.String>")
-                } else {
-                    assertThat(method.invocable.parameters).isEmpty()
-                }
-            }
-        }
-    }
-
-    @Test
-    fun testBuildSubResource() {
-        val mockInjector = LeakyMock.mock<InjectionManager>()
-        val mockAsyncProvider = LeakyMock.mock<Provider<AsyncContext>>()
-        EasyMock.expect(mockInjector.getInstance(ProcessorTestResource::class.java)).andReturn(ProcessorTestResource())
-        EasyMock.replay(mockInjector, mockAsyncProvider)
-        val resourceModel = ResourceModel.Builder(
-            listOf(
-                Resource.builder(ProcessorTestResource::class.java).build()
-            ),
-            true
-        ).build()
-        val builtResource =
-            CoroutineModelProcessor(mockInjector, mockAsyncProvider).processSubResource(
-                resourceModel,
-                ResourceConfig()
-            )
-        assertThat(builtResource.resources).hasSize(1)
-        for (childResource in builtResource.resources[0].childResources) {
-            for (method in childResource.resourceMethods) {
-                if (method.invocable.handlingMethod.name == "coroutineMethod") {
-                    assertThat(method.invocable.parameters).hasSize(1)
-                    assertThat(method.invocable.parameters[0].getAnnotation(QueryParam::class.java).value)
-                        .isEqualTo("a")
-                    assertThat(method.invocable.parameters[0].type.typeName)
-                        .isEqualTo("java.util.Optional<java.lang.String>")
-                } else {
-                    assertThat(method.invocable.parameters).isEmpty()
+        )
+        builtResources.forEach { builtResource ->
+            assertThat(builtResource.resources).hasSize(1)
+            for (childResource in builtResource.resources[0].childResources) {
+                for (method in childResource.resourceMethods) {
+                    when (method.invocable.handlingMethod.name) {
+                        "coroutineMethod" -> {
+                            assertThat(method.invocable.parameters).hasSize(1)
+                            assertThat(method.invocable.parameters[0].getAnnotation(QueryParam::class.java).value)
+                                .isEqualTo("a")
+                            assertThat(method.invocable.parameters[0].type.typeName)
+                                .isEqualTo("java.util.Optional<java.lang.String>")
+                            assertThat(method.invocable.responseType).isEqualTo(String::class.java)
+                        }
+                        "sseMethod" -> {
+                            assertThat(method.invocable.parameters).hasSize(2)
+                            assertThat(method.invocable.responseType).isEqualTo(Void.TYPE)
+                        }
+                        "simpleMethod" -> {
+                            assertThat(method.invocable.parameters).isEmpty()
+                            assertThat(method.invocable.responseType).isEqualTo(String::class.java)
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Allow for processing [graphql requests over SSE](https://github.com/enisdenjo/graphql-sse/blob/master/PROTOCOL.md), both in
'single connection mode' and 'distinct connections mode'
at the /app/graphql/stream endpoint.

Update jersey coroutine support to get method return types
correct and cancel running coroutines on client disconnect.