### PR TITLE
Bump version.graphql-kotlin from 5.2.0 to 5.3.2

### DIFF
--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -67,7 +67,7 @@
         <version.dropwizard.metrics.guice>4.0.0</version.dropwizard.metrics.guice>
         <version.easymock>4.3</version.easymock>
         <version.flyway>8.5.2</version.flyway>
-        <version.graphql-kotlin>5.2.0</version.graphql-kotlin>
+        <version.graphql-kotlin>5.3.2</version.graphql-kotlin>
         <version.graphql-java>17.3</version.graphql-java>
         <version.graphql-java-extended-scalars>17.0</version.graphql-java-extended-scalars>
         <version.graphql-java.tools>5.2.4</version.graphql-java.tools>


### PR DESCRIPTION
Not sure why dependabot missed these releases
but update to the latest graphql-kotlin