### PR TITLE
Use graphql-java-extended-scalars implementations [BREAKING CHANGE]

### DIFF
--- a/build-resources/pom.xml
+++ b/build-resources/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.trib3</groupId>
     <artifactId>build-resources</artifactId>
-    <version>1.30-SNAPSHOT</version>
+    <version>1.31-SNAPSHOT</version>
 
     <name>Build Resources</name>
     <description>Resources for use during the build process</description>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.30-SNAPSHOT</version>
+        <version>1.31-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.30-SNAPSHOT</version>
+        <version>1.31-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/graphql/pom.xml
+++ b/graphql/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.30-SNAPSHOT</version>
+        <version>1.31-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/graphql/src/main/kotlin/com/trib3/graphql/execution/LeakyCauldronHooks.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/execution/LeakyCauldronHooks.kt
@@ -6,6 +6,8 @@ import com.expediagroup.graphql.generator.hooks.FlowSubscriptionSchemaGeneratorH
 import graphql.language.StringValue
 import graphql.scalars.ExtendedScalars
 import graphql.schema.Coercing
+import graphql.schema.CoercingParseLiteralException
+import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
 import graphql.schema.GraphQLScalarType
 import graphql.schema.GraphQLType
@@ -19,6 +21,7 @@ import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.Year
 import java.time.YearMonth
+import java.time.format.DateTimeFormatter
 import java.util.UUID
 import javax.annotation.Nullable
 import javax.inject.Inject
@@ -29,22 +32,22 @@ internal val YEAR_SCALAR = GraphQLScalarType.newScalar()
     .description("Year, for example 2019")
     .coercing(
         object : Coercing<Year, String> {
-            private fun parse(input: String): Year {
+            private fun parse(input: String, exceptionConstructor: (String, Throwable) -> Exception): Year {
                 return try {
                     Year.parse(input)
                 } catch (e: Exception) {
-                    throw CoercingSerializeException("can't parse $input", e)
+                    throw exceptionConstructor("can't parse $input", e)
                 }
             }
 
             override fun parseValue(input: Any): Year {
-                return parse(input.toString())
+                return parse(input.toString(), ::CoercingParseValueException)
             }
 
             override fun parseLiteral(input: Any): Year {
                 return when (input) {
-                    is StringValue -> parse(input.value)
-                    else -> throw CoercingSerializeException("can't parse $input")
+                    is StringValue -> parse(input.value, ::CoercingParseLiteralException)
+                    else -> throw CoercingParseLiteralException("can't parse $input")
                 }
             }
 
@@ -63,22 +66,22 @@ internal val YEAR_MONTH_SCALAR = GraphQLScalarType.newScalar()
     .description("Year + Month, for example 2019-01")
     .coercing(
         object : Coercing<YearMonth, String> {
-            private fun parse(input: String): YearMonth {
+            private fun parse(input: String, exceptionConstructor: (String, Throwable) -> Exception): YearMonth {
                 return try {
                     YearMonth.parse(input)
                 } catch (e: Exception) {
-                    throw CoercingSerializeException("can't parse $input", e)
+                    throw exceptionConstructor("can't parse $input", e)
                 }
             }
 
             override fun parseValue(input: Any): YearMonth {
-                return parse(input.toString())
+                return parse(input.toString(), ::CoercingParseValueException)
             }
 
             override fun parseLiteral(input: Any): YearMonth {
                 return when (input) {
-                    is StringValue -> parse(input.value)
-                    else -> throw CoercingSerializeException("can't parse $input")
+                    is StringValue -> parse(input.value, ::CoercingParseLiteralException)
+                    else -> throw CoercingParseLiteralException("can't parse $input")
                 }
             }
 
@@ -97,22 +100,22 @@ internal val YEAR_QUARTER_SCALAR = GraphQLScalarType.newScalar()
     .description("Year + Quarter, for example 2019-Q1")
     .coercing(
         object : Coercing<YearQuarter, String> {
-            private fun parse(input: String): YearQuarter {
+            private fun parse(input: String, exceptionConstructor: (String, Throwable) -> Exception): YearQuarter {
                 return try {
                     YearQuarter.parse(input)
                 } catch (e: Exception) {
-                    throw CoercingSerializeException("can't parse $input", e)
+                    throw exceptionConstructor("can't parse $input", e)
                 }
             }
 
             override fun parseValue(input: Any): YearQuarter {
-                return parse(input.toString())
+                return parse(input.toString(), ::CoercingParseValueException)
             }
 
             override fun parseLiteral(input: Any): YearQuarter {
                 return when (input) {
-                    is StringValue -> parse(input.value)
-                    else -> throw CoercingSerializeException("can't parse $input")
+                    is StringValue -> parse(input.value, ::CoercingParseLiteralException)
+                    else -> throw CoercingParseLiteralException("can't parse $input")
                 }
             }
 
@@ -134,167 +137,28 @@ internal val LOCAL_DATETIME_SCALAR = GraphQLScalarType.newScalar()
     )
     .coercing(
         object : Coercing<LocalDateTime, String> {
-            private fun parse(input: String): LocalDateTime {
+            private fun parse(input: String, exceptionConstructor: (String, Throwable) -> Exception): LocalDateTime {
                 return try {
                     LocalDateTime.parse(input)
                 } catch (e: Exception) {
-                    throw CoercingSerializeException("can't parse $input", e)
+                    throw exceptionConstructor("can't parse $input", e)
                 }
             }
 
             override fun parseValue(input: Any): LocalDateTime {
-                return parse(input.toString())
+                return parse(input.toString(), ::CoercingParseValueException)
             }
 
             override fun parseLiteral(input: Any): LocalDateTime {
                 return when (input) {
-                    is StringValue -> parse(input.value)
-                    else -> throw CoercingSerializeException("can't parse $input")
+                    is StringValue -> parse(input.value, ::CoercingParseLiteralException)
+                    else -> throw CoercingParseLiteralException("can't parse $input")
                 }
             }
 
             override fun serialize(dataFetcherResult: Any): String {
                 return when (dataFetcherResult) {
-                    is LocalDateTime -> dataFetcherResult.toString()
-                    else -> throw CoercingSerializeException("can't serialize ${dataFetcherResult::class}")
-                }
-            }
-        }
-    )
-    .build()
-
-internal val LOCAL_DATE_SCALAR = GraphQLScalarType.newScalar()
-    .name("LocalDate")
-    .description("Year + Month + Day Of Month, for example 2019-10-31")
-    .coercing(
-        object : Coercing<LocalDate, String> {
-            private fun parse(input: String): LocalDate {
-                return try {
-                    LocalDate.parse(input)
-                } catch (e: Exception) {
-                    throw CoercingSerializeException("can't parse $input", e)
-                }
-            }
-
-            override fun parseValue(input: Any): LocalDate {
-                return parse(input.toString())
-            }
-
-            override fun parseLiteral(input: Any): LocalDate {
-                return when (input) {
-                    is StringValue -> parse(input.value)
-                    else -> throw CoercingSerializeException("can't parse $input")
-                }
-            }
-
-            override fun serialize(dataFetcherResult: Any): String {
-                return when (dataFetcherResult) {
-                    is LocalDate -> dataFetcherResult.toString()
-                    else -> throw CoercingSerializeException("can't serialize ${dataFetcherResult::class}")
-                }
-            }
-        }
-    )
-    .build()
-
-internal val LOCAL_TIME_SCALAR = GraphQLScalarType.newScalar()
-    .name("LocalTime")
-    .description("Hour + Minute + Optional (Second + Millisecond) , for example 12:31:45.129")
-    .coercing(
-        object : Coercing<LocalTime, String> {
-            private fun parse(input: String): LocalTime {
-                return try {
-                    LocalTime.parse(input)
-                } catch (e: Exception) {
-                    throw CoercingSerializeException("can't parse $input", e)
-                }
-            }
-
-            override fun parseValue(input: Any): LocalTime {
-                return parse(input.toString())
-            }
-
-            override fun parseLiteral(input: Any): LocalTime {
-                return when (input) {
-                    is StringValue -> parse(input.value)
-                    else -> throw CoercingSerializeException("can't parse $input")
-                }
-            }
-
-            override fun serialize(dataFetcherResult: Any): String {
-                return when (dataFetcherResult) {
-                    is LocalTime -> dataFetcherResult.toString()
-                    else -> throw CoercingSerializeException("can't serialize ${dataFetcherResult::class}")
-                }
-            }
-        }
-    )
-    .build()
-
-internal val OFFSET_DATETIME_SCALAR = GraphQLScalarType.newScalar()
-    .name("OffsetDateTime")
-    .description(
-        "Year + Month + Day Of Month + Time (Hour:Minute + Optional(Second.Milliseconds)) " +
-            "+ Offset, for example 2019-10-31T12:31:45.129-07:00"
-    )
-    .coercing(
-        object : Coercing<OffsetDateTime, String> {
-            private fun parse(input: String): OffsetDateTime {
-                return try {
-                    OffsetDateTime.parse(input)
-                } catch (e: Exception) {
-                    throw CoercingSerializeException("can't parse $input", e)
-                }
-            }
-
-            override fun parseValue(input: Any): OffsetDateTime {
-                return parse(input.toString())
-            }
-
-            override fun parseLiteral(input: Any): OffsetDateTime {
-                return when (input) {
-                    is StringValue -> parse(input.value)
-                    else -> throw CoercingSerializeException("can't parse $input")
-                }
-            }
-
-            override fun serialize(dataFetcherResult: Any): String {
-                return when (dataFetcherResult) {
-                    is OffsetDateTime -> dataFetcherResult.toString()
-                    else -> throw CoercingSerializeException("can't serialize ${dataFetcherResult::class}")
-                }
-            }
-        }
-    )
-    .build()
-
-internal val UUID_SCALAR = GraphQLScalarType.newScalar()
-    .name("UUID")
-    .description("String representation of a UUID")
-    .coercing(
-        object : Coercing<UUID, String> {
-            private fun parse(input: String): UUID {
-                try {
-                    return UUID.fromString(input)
-                } catch (e: Exception) {
-                    throw CoercingSerializeException("can't parse $input", e)
-                }
-            }
-
-            override fun parseValue(input: Any): UUID {
-                return parse(input.toString())
-            }
-
-            override fun parseLiteral(input: Any): UUID {
-                return when (input) {
-                    is StringValue -> parse(input.value)
-                    else -> throw CoercingSerializeException("can't parse $input")
-                }
-            }
-
-            override fun serialize(dataFetcherResult: Any): String {
-                return when (dataFetcherResult) {
-                    is UUID -> dataFetcherResult.toString()
+                    is LocalDateTime -> DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(dataFetcherResult)
                     else -> throw CoercingSerializeException("can't serialize ${dataFetcherResult::class}")
                 }
             }
@@ -321,16 +185,15 @@ class LeakyCauldronHooks @Inject constructor(
 
     override fun willGenerateGraphQLType(type: KType): GraphQLType? {
         // TODO: include more from ExtendedScalars?
-        //       Use impls from ExtendedScalars instead of our own for date/time/datetimes?
         return when (type.classifier) {
             Year::class -> YEAR_SCALAR
             YearMonth::class -> YEAR_MONTH_SCALAR
             YearQuarter::class -> YEAR_QUARTER_SCALAR
             LocalDateTime::class -> LOCAL_DATETIME_SCALAR
-            LocalDate::class -> LOCAL_DATE_SCALAR
-            LocalTime::class -> LOCAL_TIME_SCALAR
-            OffsetDateTime::class -> OFFSET_DATETIME_SCALAR
-            UUID::class -> UUID_SCALAR
+            LocalDate::class -> ExtendedScalars.Date
+            LocalTime::class -> ExtendedScalars.LocalTime
+            OffsetDateTime::class -> ExtendedScalars.DateTime
+            UUID::class -> ExtendedScalars.UUID
             BigDecimal::class -> ExtendedScalars.GraphQLBigDecimal
             else -> null
         }

--- a/graphql/src/test/kotlin/com/trib3/graphql/execution/LeakyCauldronHooksTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/execution/LeakyCauldronHooksTest.kt
@@ -10,6 +10,7 @@ import com.expediagroup.graphql.generator.TopLevelObject
 import com.expediagroup.graphql.generator.execution.SimpleKotlinDataFetcherFactoryProvider
 import com.expediagroup.graphql.generator.toSchema
 import com.trib3.json.ObjectMapperProvider
+import graphql.ErrorType
 import graphql.ExecutionInput
 import graphql.GraphQL
 import graphql.schema.CoercingSerializeException
@@ -22,7 +23,6 @@ import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.Year
 import java.time.YearMonth
-import java.time.ZoneOffset
 import java.util.UUID
 
 class HooksQuery {
@@ -82,16 +82,21 @@ class LeakyCauldronHooksTest {
             toSchema(config, listOf(TopLevelObject(HooksQuery())))
         ).build()
 
+    /**
+     * Assert that executing each of the [invalidQueries] results in a validation error
+     */
+    private fun assertValidationErrors(vararg invalidQueries: String) {
+        for (query in invalidQueries) {
+            val result = graphQL.execute(query)
+            assertThat(result.errors[0].errorType).isEqualTo(ErrorType.ValidationError)
+        }
+    }
+
     @Test
     fun testYear() {
         val result = graphQL.execute("""query {year(y:"2019")}""").getData<Map<String, String>>()
         assertThat(result["year"]).isEqualTo("2020")
-        assertThat {
-            graphQL.execute("""query {year(y:123)}""")
-        }.isFailure().isInstanceOf(CoercingSerializeException::class)
-        assertThat {
-            graphQL.execute("""query {year(y:"123")}""")
-        }.isFailure().isInstanceOf(CoercingSerializeException::class)
+        assertValidationErrors("""query {year(y:123)}""", """query {year(y:"123")}""")
 
         assertThat {
             YEAR_SCALAR.coercing.serialize(123)
@@ -116,12 +121,7 @@ class LeakyCauldronHooksTest {
     fun testQuarter() {
         val result = graphQL.execute("""query {quarter(q:"2019-Q1")}""").getData<Map<String, String>>()
         assertThat(result["quarter"]).isEqualTo("2019-Q2")
-        assertThat {
-            graphQL.execute("""query {quarter(q:123)}""")
-        }.isFailure().isInstanceOf(CoercingSerializeException::class)
-        assertThat {
-            graphQL.execute("""query {quarter(q:"123")}""")
-        }.isFailure().isInstanceOf(CoercingSerializeException::class)
+        assertValidationErrors("""query {quarter(q:123)}""", """query {quarter(q:"123")}""")
 
         assertThat {
             YEAR_QUARTER_SCALAR.coercing.serialize(123)
@@ -146,13 +146,7 @@ class LeakyCauldronHooksTest {
     fun testMonth() {
         val result = graphQL.execute("""query {month(m:"2019-01")}""").getData<Map<String, String>>()
         assertThat(result["month"]).isEqualTo("2019-02")
-        assertThat {
-            graphQL.execute("""query {month(m:123)}""")
-        }.isFailure().isInstanceOf(CoercingSerializeException::class)
-
-        assertThat {
-            graphQL.execute("""query {month(m:"123")}""")
-        }.isFailure().isInstanceOf(CoercingSerializeException::class)
+        assertValidationErrors("""query {month(m:123)}""", """query {month(m:"123")}""")
 
         assertThat {
             YEAR_MONTH_SCALAR.coercing.serialize(123)
@@ -177,14 +171,8 @@ class LeakyCauldronHooksTest {
     fun testLocalDateTime() {
         val result = graphQL.execute("""query {localDateTime(l:"2019-10-30T00:01")}""")
             .getData<Map<String, String>>()
-        assertThat(result["localDateTime"]).isEqualTo("2019-10-31T01:01")
-        assertThat {
-            graphQL.execute("""query {localDateTime(l:123)}""")
-        }.isFailure().isInstanceOf(CoercingSerializeException::class)
-
-        assertThat {
-            graphQL.execute("""query {localDateTime(l:"123")}""")
-        }.isFailure().isInstanceOf(CoercingSerializeException::class)
+        assertThat(result["localDateTime"]).isEqualTo("2019-10-31T01:01:00")
+        assertValidationErrors("""query {localDateTime(l:123)}""", """query {localDateTime(l:"123")}""")
 
         assertThat {
             LOCAL_DATETIME_SCALAR.coercing.serialize(123)
@@ -192,7 +180,7 @@ class LeakyCauldronHooksTest {
 
         assertThat {
             LOCAL_DATETIME_SCALAR.coercing.serialize(LocalDateTime.of(2019, 10, 31, 1, 1))
-        }.isSuccess().isEqualTo("2019-10-31T01:01")
+        }.isSuccess().isEqualTo("2019-10-31T01:01:00")
     }
 
     @Test
@@ -202,7 +190,7 @@ class LeakyCauldronHooksTest {
                 .query("""query(${'$'}input: LocalDateTime!) {localDateTime(l:${'$'}input)}""")
                 .variables(mapOf("input" to "2019-10-30T00:01")).build()
         ).getData<Map<String, String>>()
-        assertThat(result["localDateTime"]).isEqualTo("2019-10-31T01:01")
+        assertThat(result["localDateTime"]).isEqualTo("2019-10-31T01:01:00")
     }
 
     @Test
@@ -210,28 +198,14 @@ class LeakyCauldronHooksTest {
         val result = graphQL.execute("""query {localDate(l:"2019-10-30")}""")
             .getData<Map<String, String>>()
         assertThat(result["localDate"]).isEqualTo("2019-10-31")
-        assertThat {
-            graphQL.execute("""query {localDate(l:123)}""")
-        }.isFailure().isInstanceOf(CoercingSerializeException::class)
-
-        assertThat {
-            graphQL.execute("""query {localDate(l:"123")}""")
-        }.isFailure().isInstanceOf(CoercingSerializeException::class)
-
-        assertThat {
-            LOCAL_DATE_SCALAR.coercing.serialize(123)
-        }.isFailure().isInstanceOf(CoercingSerializeException::class)
-
-        assertThat {
-            LOCAL_DATE_SCALAR.coercing.serialize(LocalDate.of(2019, 10, 31))
-        }.isSuccess().isEqualTo("2019-10-31")
+        assertValidationErrors("""query {localDate(l:123)}""", """query {localDate(l:"123")}""")
     }
 
     @Test
     fun testLocalDateVariable() {
         val result = graphQL.execute(
             ExecutionInput.newExecutionInput()
-                .query("""query(${'$'}input: LocalDate!) {localDate(l:${'$'}input)}""")
+                .query("""query(${'$'}input: Date!) {localDate(l:${'$'}input)}""")
                 .variables(mapOf("input" to "2019-10-30")).build()
         ).getData<Map<String, String>>()
         assertThat(result["localDate"]).isEqualTo("2019-10-31")
@@ -241,22 +215,8 @@ class LeakyCauldronHooksTest {
     fun testLocalTime() {
         val result = graphQL.execute("""query {localTime(l:"00:01")}""")
             .getData<Map<String, String>>()
-        assertThat(result["localTime"]).isEqualTo("01:01")
-        assertThat {
-            graphQL.execute("""query {localTime(l:123)}""")
-        }.isFailure().isInstanceOf(CoercingSerializeException::class)
-
-        assertThat {
-            graphQL.execute("""query {localTime(l:"123")}""")
-        }.isFailure().isInstanceOf(CoercingSerializeException::class)
-
-        assertThat {
-            LOCAL_TIME_SCALAR.coercing.serialize(123)
-        }.isFailure().isInstanceOf(CoercingSerializeException::class)
-
-        assertThat {
-            LOCAL_TIME_SCALAR.coercing.serialize(LocalTime.of(1, 1))
-        }.isSuccess().isEqualTo("01:01")
+        assertThat(result["localTime"]).isEqualTo("01:01:00")
+        assertValidationErrors("""query {localTime(l:123)}""", """query {localTime(l:"123")}""")
     }
 
     @Test
@@ -266,41 +226,25 @@ class LeakyCauldronHooksTest {
                 .query("""query(${'$'}input: LocalTime!) {localTime(l:${'$'}input)}""")
                 .variables(mapOf("input" to "00:01")).build()
         ).getData<Map<String, String>>()
-        assertThat(result["localTime"]).isEqualTo("01:01")
+        assertThat(result["localTime"]).isEqualTo("01:01:00")
     }
 
     @Test
     fun testOffsetDateTime() {
         val result = graphQL.execute("""query {offsetDateTime(o:"2019-10-30T00:01-07:00")}""")
             .getData<Map<String, String>>()
-        assertThat(result["offsetDateTime"]).isEqualTo("2019-10-31T07:01Z")
-        assertThat {
-            graphQL.execute("""query {offsetDateTime(o:123)}""")
-        }.isFailure().isInstanceOf(CoercingSerializeException::class)
-
-        assertThat {
-            graphQL.execute("""query {offsetDateTime(o:"123")}""")
-        }.isFailure().isInstanceOf(CoercingSerializeException::class)
-
-        assertThat {
-            OFFSET_DATETIME_SCALAR.coercing.serialize(123)
-        }.isFailure().isInstanceOf(CoercingSerializeException::class)
-
-        assertThat {
-            OFFSET_DATETIME_SCALAR.coercing.serialize(
-                OffsetDateTime.of(2019, 10, 31, 1, 1, 31, 129, ZoneOffset.ofHours(-7))
-            )
-        }.isSuccess().isEqualTo("2019-10-31T01:01:31.000000129-07:00")
+        assertThat(result["offsetDateTime"]).isEqualTo("2019-10-31T07:01:00Z")
+        assertValidationErrors("""query {offsetDateTime(o:123)}""", """query {offsetDateTime(o:"123")}""")
     }
 
     @Test
     fun testOffsetDateTimeVariable() {
         val result = graphQL.execute(
             ExecutionInput.newExecutionInput()
-                .query("""query(${'$'}input: OffsetDateTime!) {offsetDateTime(o:${'$'}input)}""")
+                .query("""query(${'$'}input: DateTime!) {offsetDateTime(o:${'$'}input)}""")
                 .variables(mapOf("input" to "2019-10-30T00:01-07:00")).build()
         ).getData<Map<String, String>>()
-        assertThat(result["offsetDateTime"]).isEqualTo("2019-10-31T07:01Z")
+        assertThat(result["offsetDateTime"]).isEqualTo("2019-10-31T07:01:00Z")
     }
 
     @Test
@@ -318,17 +262,7 @@ class LeakyCauldronHooksTest {
         val result = graphQL.execute("""query { existinguuid(uuid:"$uuid") }""")
             .getData<Map<String, String>>()
         assertThat(result["existinguuid"]).isEqualTo(uuid.toString())
-        assertThat {
-            graphQL.execute("""query {existinguuid(uuid:123)}""")
-        }.isFailure().isInstanceOf(CoercingSerializeException::class)
-
-        assertThat {
-            graphQL.execute("""query {existinguuid(uuid:"123")}""")
-        }.isFailure().isInstanceOf(CoercingSerializeException::class)
-
-        assertThat {
-            UUID_SCALAR.coercing.serialize(123)
-        }.isFailure().isInstanceOf(CoercingSerializeException::class)
+        assertValidationErrors("""query {existinguuid(uuid:123)}""", """query {existinguuid(uuid:"123")}""")
     }
 
     @Test

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.30-SNAPSHOT</version>
+        <version>1.31-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.trib3</groupId>
     <artifactId>parent-pom</artifactId>
-    <version>1.30-SNAPSHOT</version>
+    <version>1.31-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Trib3 parent pom</name>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>1.30-SNAPSHOT</version>
+        <version>1.31-SNAPSHOT</version>
         <relativePath>parent-pom/pom.xml</relativePath>
     </parent>
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.30-SNAPSHOT</version>
+        <version>1.31-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.30-SNAPSHOT</version>
+        <version>1.31-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
For UUID and date/time/datetime types, use available upstream
implementations instead of maintaining our own.  Note that
the `OffsetDateTime` GraphQL type is renamed to `DateTime`,
and the `LocalDate` GraphQL type is renamed to `Date`.  Serialized
datetimes will also better conform to ISO/RFC formats.

Also update our scalar implementations to throw the appropriate
exception type, resulting in queries that execute and return
error results instead of failing to execute.  This is compatible
with the graphql-java-extended-scalars implementations and more
in line with how GraphQL failures should be handled anyway.

Bump to version 1.31.x due to these behavioral changes.