### PR TITLE
Revert "Bump maven-enforcer-plugin from 3.0.0-M3 to 3.1.0"

### DIFF
--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -110,7 +110,7 @@
         <version.maven.dependency>3.1.2</version.maven.dependency>
         <version.maven.dependencyscope>0.10</version.maven.dependencyscope>
         <version.maven.deploy>3.0.0-M2</version.maven.deploy>
-        <version.maven.enforcer>3.1.0</version.maven.enforcer>
+        <version.maven.enforcer>3.0.0-M3</version.maven.enforcer>
         <version.maven.failsafe>3.0.0-M7</version.maven.failsafe>
         <version.maven.git>4.9.10</version.maven.git>
         <version.maven.gpg>3.0.1</version.maven.gpg>


### PR DESCRIPTION
This reverts commit 96d88784d87ff77f2f1a3748d36936ff4ccb5b7f.

Go back to 3.0.0-M3 since seeing spurious dependency convergence
errors when using version ranges: https://issues.apache.org/jira/browse/MENFORCER-426