### PR TITLE
Build with jdk17 now that elasticbeanstalk supports it [BREAKING CHANGE]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     machine:
-      image: ubuntu-2004:202107-02
+      image: ubuntu-2204:2022.04.2
 
     working_directory: ~/repo
     environment:
@@ -27,6 +27,7 @@ jobs:
       - run:
           name: Maven Setup
           command: |
+            mvn --version
             mkdir -p ~/.m2
             echo $MAVEN_SETTINGS_XML > ~/.m2/settings.xml
             if [ "$CIRCLE_BRANCH" = "main" ]; then
@@ -125,7 +126,7 @@ jobs:
 
   deploy:
     docker:
-      - image: cimg/openjdk:11.0
+      - image: cimg/openjdk:17.0
     steps:
       - attach_workspace:
           at: ~/jars

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Getting Started
 
 #### Install jdk and maven
 
-* Install openjdk 11 or newer
+* Install openjdk 17 or newer
 * Install maven 3.5 or newer
 
 #### Build and run tests

--- a/build-resources/pom.xml
+++ b/build-resources/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.trib3</groupId>
     <artifactId>build-resources</artifactId>
-    <version>1.32-SNAPSHOT</version>
+    <version>1.33-SNAPSHOT</version>
 
     <name>Build Resources</name>
     <description>Resources for use during the build process</description>

--- a/build-resources/src/main/resources/.platform/nginx/conf.d/timeouts.conf
+++ b/build-resources/src/main/resources/.platform/nginx/conf.d/timeouts.conf
@@ -1,0 +1,7 @@
+         client_header_timeout   3600;
+         client_body_timeout     3600;
+         keepalive_timeout       3600;
+         send_timeout            3600;
+         proxy_connect_timeout   3600;
+         proxy_read_timeout      3600;
+         proxy_send_timeout      3600;

--- a/build-resources/src/main/resources/assemblies/elasticbeanstalk.xml
+++ b/build-resources/src/main/resources/assemblies/elasticbeanstalk.xml
@@ -18,6 +18,7 @@
             <unpackOptions>
                 <includes>
                     <include>.ebextensions/**</include>
+                    <include>.platform/**</include>
                 </includes>
             </unpackOptions>
             <outputDirectory></outputDirectory>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.32-SNAPSHOT</version>
+        <version>1.33-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.32-SNAPSHOT</version>
+        <version>1.33-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/graphql/pom.xml
+++ b/graphql/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.32-SNAPSHOT</version>
+        <version>1.33-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/graphql/src/test/kotlin/com/trib3/graphql/execution/LeakyCauldronHooksTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/execution/LeakyCauldronHooksTest.kt
@@ -96,7 +96,7 @@ class LeakyCauldronHooksTest {
     fun testYear() {
         val result = graphQL.execute("""query {year(y:"2019")}""").getData<Map<String, String>>()
         assertThat(result["year"]).isEqualTo("2020")
-        assertValidationErrors("""query {year(y:123)}""", """query {year(y:"123")}""")
+        assertValidationErrors("""query {year(y:123)}""", """query {year(y:"123-45")}""")
 
         assertThat {
             YEAR_SCALAR.coercing.serialize(123)

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.32-SNAPSHOT</version>
+        <version>1.33-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.trib3</groupId>
     <artifactId>parent-pom</artifactId>
-    <version>1.32-SNAPSHOT</version>
+    <version>1.33-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Trib3 parent pom</name>
@@ -84,7 +84,7 @@
         <version.jackson.hocon>1.1.0</version.jackson.hocon>
         <version.jacoco>0.8.8</version.jacoco>
         <version.jakarta.inject>1.0.5</version.jakarta.inject>
-        <version.java.release>11</version.java.release>
+        <version.java.release>17</version.java.release>
         <version.jaxb>2.3.3</version.jaxb>
         <version.jaxrs>2.1.6</version.jaxrs>
         <version.jersey>2.36</version.jersey>
@@ -107,7 +107,7 @@
         <version.maven.buildhelper>3.3.0</version.maven.buildhelper>
         <version.maven.clean>3.2.0</version.maven.clean>
         <version.maven.compiler>3.10.1</version.maven.compiler>
-        <version.maven.dependency>3.1.2</version.maven.dependency>
+        <version.maven.dependency>3.3.0</version.maven.dependency>
         <version.maven.dependencyscope>0.10</version.maven.dependencyscope>
         <version.maven.deploy>3.0.0</version.maven.deploy>
         <version.maven.enforcer>3.0.0-M3</version.maven.enforcer>
@@ -116,7 +116,6 @@
         <version.maven.gpg>3.0.1</version.maven.gpg>
         <version.maven.install>3.0.1</version.maven.install>
         <version.maven.jar>3.2.2</version.maven.jar>
-        <version.maven.ktlint>1.13.1</version.maven.ktlint>
         <version.maven.properties>1.1.0</version.maven.properties>
         <version.maven.resources>3.3.0</version.maven.resources>
         <version.maven.shade>3.3.0</version.maven.shade>
@@ -1436,55 +1435,6 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>com.github.gantsign.maven</groupId>
-                    <artifactId>ktlint-maven-plugin</artifactId>
-                    <version>${version.maven.ktlint}</version>
-                    <executions>
-                        <execution>
-                            <id>format-and-check</id>
-                            <goals>
-                                <goal>format</goal>
-                                <goal>check</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                    <dependencies>
-                        <dependency>
-                            <groupId>com.pinterest.ktlint</groupId>
-                            <artifactId>ktlint-core</artifactId>
-                            <version>${version.ktlint}</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>com.pinterest.ktlint</groupId>
-                            <artifactId>ktlint-reporter-checkstyle</artifactId>
-                            <version>${version.ktlint}</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>com.pinterest.ktlint</groupId>
-                            <artifactId>ktlint-reporter-json</artifactId>
-                            <version>${version.ktlint}</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>com.pinterest.ktlint</groupId>
-                            <artifactId>ktlint-reporter-plain</artifactId>
-                            <version>${version.ktlint}</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>com.pinterest.ktlint</groupId>
-                            <artifactId>ktlint-ruleset-experimental</artifactId>
-                            <version>${version.ktlint}</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>com.pinterest.ktlint</groupId>
-                            <artifactId>ktlint-ruleset-standard</artifactId>
-                            <version>${version.ktlint}</version>
-                        </dependency>
-                    </dependencies>
-                    <configuration>
-                        <skip>${skip.checks}</skip>
-                    </configuration>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-antrun-plugin</artifactId>
                     <version>${version.maven.antrun}</version>
@@ -1520,6 +1470,32 @@
                                 </target>
                             </configuration>
                         </execution>
+                        <!--
+                        run ktlint through antrun plugin to allow setting add-opens
+                        without setting it on the full build.  This works around
+                        https://github.com/pinterest/ktlint/issues/1391
+                        -->
+                        <execution>
+                            <id>ktlint</id>
+                            <phase>process-sources</phase>
+                            <goals>
+                                <goal>run</goal>
+                            </goals>
+                            <configuration>
+                                <skip>${skip.checks}</skip>
+                                <target name="ktlint">
+                                    <property name="compile_classpath" refid="maven.compile.classpath"/>
+                                    <java taskname="ktlint" dir="${basedir}"
+                                          fork="true"
+                                          failonerror="true"
+                                          classname="com.pinterest.ktlint.Main"
+                                          classpathref="maven.plugin.classpath">
+                                        <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED"/>
+                                        <arg value="-F"/>
+                                    </java>
+                                </target>
+                            </configuration>
+                        </execution>
                     </executions>
                     <dependencies>
                         <dependency>
@@ -1541,6 +1517,11 @@
                             <groupId>org.apache.ant</groupId>
                             <artifactId>ant</artifactId>
                             <version>${version.ant}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>com.pinterest</groupId>
+                            <artifactId>ktlint</artifactId>
+                            <version>${version.ktlint}</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -1862,6 +1843,10 @@
                                 io.github.microutils:kotlin-logging-jvm
                             </ignoredUnusedDeclaredDependency>
                         </ignoredUnusedDeclaredDependencies>
+                        <!-- workaround for https://issues.apache.org/jira/browse/MDEP-791 -->
+                        <ignoredNonTestScopedDependencies>
+                            <ignoredNonTestScopedDependency>*</ignoredNonTestScopedDependency>
+                        </ignoredNonTestScopedDependencies>
                     </configuration>
                     <executions>
                         <execution>
@@ -1979,10 +1964,6 @@
             </activation>
             <build>
                 <plugins>
-                    <plugin>
-                        <groupId>com.github.gantsign.maven</groupId>
-                        <artifactId>ktlint-maven-plugin</artifactId>
-                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-antrun-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>1.32-SNAPSHOT</version>
+        <version>1.33-SNAPSHOT</version>
         <relativePath>parent-pom/pom.xml</relativePath>
     </parent>
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.32-SNAPSHOT</version>
+        <version>1.33-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -255,8 +255,7 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlinx</groupId>
-            <!-- just so we have a Main dispatcher for tests -->
-            <artifactId>kotlinx-coroutines-swing</artifactId>
+            <artifactId>kotlinx-coroutines-test-jvm</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.trib3</groupId>
         <artifactId>leakycauldron</artifactId>
-        <version>1.32-SNAPSHOT</version>
+        <version>1.33-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Build on circle using jdk17 (ubuntu 22.04 image).
Update tests for minor changes (eg java.time.Year validation,
coroutine main dispatcher replacement).

Update nginx config to support timeouts using amazon linux2
mechanism of .platform directory.

Bump version to 1.33.x.