### PR TITLE
Fix coroutine requestId propogation

### DIFF
--- a/graphql/src/main/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketConsumer.kt
+++ b/graphql/src/main/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketConsumer.kt
@@ -364,15 +364,14 @@ class GraphQLWebSocketConsumer(
         } else if (socketPrincipal == null && graphQLConfig.checkAuthorization) {
             adapter.session?.close(GraphQLWebSocketCloseReason.UNAUTHORIZED)
         } else {
-            val context = getGraphQLContextMap(adapter, socketPrincipal)
-            val queryCoroutine = QueryCoroutine(
-                graphQL,
-                channel,
-                message.id,
-                message.payload.toExecutionInput(dataLoaderRegistryFactoryProvider, context)
-            )
-
             val job = scope.launch(MDCContext()) {
+                val context = getGraphQLContextMap(this, socketPrincipal)
+                val queryCoroutine = QueryCoroutine(
+                    graphQL,
+                    channel,
+                    message.id,
+                    message.payload.toExecutionInput(dataLoaderRegistryFactoryProvider, context)
+                )
                 queryCoroutine.run()
             }
             queries[messageId] = job

--- a/graphql/src/test/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketTest.kt
+++ b/graphql/src/test/kotlin/com/trib3/graphql/websocket/GraphQLWebSocketTest.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.yield
 import org.easymock.EasyMock
 import org.eclipse.jetty.websocket.api.Session
 import org.eclipse.jetty.websocket.api.StatusCode
@@ -47,7 +48,8 @@ import javax.ws.rs.core.MultivaluedHashMap
 import javax.ws.rs.core.UriInfo
 
 class SocketQuery {
-    fun q(): List<String> {
+    suspend fun q(): List<String> {
+        yield()
         return listOf("1", "2", "3")
     }
 
@@ -187,7 +189,8 @@ class GraphQLWebSocketTest {
                 LeakyMock.and(
                     LeakyMock.contains(""""q" : [ "1", "2", "3" ]"""),
                     LeakyMock.contains(""""type" : "data""""),
-                    LeakyMock.contains(""""id" : "simplequery"""")
+                    LeakyMock.contains(""""id" : "simplequery""""),
+                    LeakyMock.contains(""""RequestId" : "simplequery"""")
                 )
             )
         ).once()


### PR DESCRIPTION
When executing a query over the websocket transport, we were not getting requestIds back because things were executing in the CoroutineScope of the connection, which didn't yet have the requestId set on it.  Changing to execute in a child CoroutineScope that does have the requestId set via MDCContext() fixes the issue.

Modify the existing query-over-websocket test to
validate the query id gets set as the requestId.