### PR TITLE
Bump graphiql to 2.2.0

### DIFF
--- a/graphql/src/main/resources/graphiql/index.html
+++ b/graphql/src/main/resources/graphiql/index.html
@@ -1,15 +1,15 @@
 <html>
 <head>
     <title>GraphiQL</title>
-    <link href="//unpkg.com/graphiql@1.4.6/graphiql.min.css" rel="stylesheet"/>
+    <link href="//unpkg.com/graphiql@2.2.0/graphiql.min.css" rel="stylesheet"/>
 </head>
 <body style="margin: 0;">
 <div id="graphiql" style="height: 100vh;"></div>
 
-<script crossorigin src="//unpkg.com/react@17.0.2/umd/react.production.min.js"></script>
-<script crossorigin src="//unpkg.com/react-dom@17.0.2/umd/react-dom.production.min.js"></script>
-<script crossorigin src="//unpkg.com/graphiql@1.4.6/graphiql.min.js"></script>
-<script crossorigin src="//unpkg.com/graphql-ws@5.5.5/umd/graphql-ws.min.js"></script>
+<script crossorigin src="//unpkg.com/react@18.2.0/umd/react.production.min.js"></script>
+<script crossorigin src="//unpkg.com/react-dom@18.2.0/umd/react-dom.production.min.js"></script>
+<script crossorigin src="//unpkg.com/graphiql@2.2.0/graphiql.min.js"></script>
+<script crossorigin src="//unpkg.com/graphql-ws@5.11.2/umd/graphql-ws.min.js"></script>
 
 <script>
     const fetcherFactory = function (subscriptionsClient, fallbackFetcher) {

--- a/server/README.md
+++ b/server/README.md
@@ -172,8 +172,5 @@ $ mvn exec:java -Dexec.mainClass=com.trib3.server.TribeApplicationKt
 When running in [AWS Elastic Beanstalk](https://aws.amazon.com/elasticbeanstalk/), the assembly configuration
 from [build-resources](https://github.com/trib3/leakycauldron/blob/HEAD/build-resources)
 can be used to create a `.zip` distribution that configures health checks and timeout values. With the
-preconfigured `Java 8` Elastic Beanstalk platform, the `PORT` environment property should be set to `5000` in the
+preconfigured `Java 17` Elastic Beanstalk platform, the `PORT` environment property should be set to `5000` in the
 environment's software configuration.
-
-For running in [AWS Lambda](https://aws.amazon.com/lambda/),
-see [lambda](https://github.com/trib3/leakycauldron/blob/HEAD/lambda)


### PR DESCRIPTION
Update bundled graphiql, graphql-ws, and react to latest versions