### PR TITLE
[BUG] Create HeadersFilter for HTTPS Security Headers

### DIFF
--- a/server/src/main/kotlin/com/trib3/server/config/TribeApplicationConfig.kt
+++ b/server/src/main/kotlin/com/trib3/server/config/TribeApplicationConfig.kt
@@ -14,6 +14,7 @@ class TribeApplicationConfig
     val corsDomains: List<String>
     val appPort: Int
     val adminAuthToken: String?
+    val httpsHeaders: List<String>
 
     init {
         val config = loader.load()
@@ -22,5 +23,6 @@ class TribeApplicationConfig
         corsDomains = config.extract("application.domains")
         appPort = config.extract<Int>("server.connector.port")
         adminAuthToken = config.extract("application.adminAuthToken")
+        httpsHeaders = config.extract("application.httpsHeaders")
     }
 }

--- a/server/src/main/kotlin/com/trib3/server/modules/DefaultApplicationModule.kt
+++ b/server/src/main/kotlin/com/trib3/server/modules/DefaultApplicationModule.kt
@@ -21,6 +21,7 @@ import io.dropwizard.Configuration
 import io.dropwizard.auth.AuthValueFactoryProvider
 import io.dropwizard.configuration.ConfigurationFactoryFactory
 import org.eclipse.jetty.servlets.CrossOriginFilter
+import org.eclipse.jetty.servlets.HeaderFilter
 import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature
 import java.security.Principal
 import javax.inject.Provider
@@ -92,6 +93,30 @@ class DefaultApplicationModule : TribeApplicationModule() {
         return ServletFilterConfig(
             CrossOriginFilter::class.java.simpleName,
             CrossOriginFilter::class.java,
+            paramMap,
+        )
+    }
+
+    /**
+     * Enables creation of a Jersey Servlet HeaderFilter that configures HTTPS headers to turn on specified
+     * security settings, such as HSTS, content-options, frame-options, XSS options and Content Security Policy.
+     * It returns a ServletFilterConfig object that specifies the HeaderFilter and the updated HTTPS header values.
+     * Header values are supplied via the application.httpHeaders parameter in [TribeApplicationConfig.httpsHeaders].
+     * The value of application.httpHeaders can be an empty list.
+     *
+     * @param appConfig the application configuration setting, including an httpHeaders value
+     * @return a ServletFilterConfig object for configuring the Jersey Servlet HeaderFilter.
+     */
+
+    @ProvidesIntoSet
+    fun provideHeaderFilter(appConfig: TribeApplicationConfig): ServletFilterConfig {
+        val headerConfig = appConfig.httpsHeaders.map { "Set $it" }.joinToString(",")
+        val paramMap = mapOf(
+            "headerConfig" to headerConfig,
+        )
+        return ServletFilterConfig(
+            HeaderFilter::class.java.simpleName,
+            HeaderFilter::class.java,
             paramMap,
         )
     }

--- a/server/src/main/resources/reference.conf
+++ b/server/src/main/resources/reference.conf
@@ -2,6 +2,7 @@ application {
   name: "Unnamed Tribe Service"
   domains: ["localhost"]
   modules: []
+  httpsHeaders: []
 }
 
 server {
@@ -76,5 +77,25 @@ overrides {
       port: ${?SERVER_PORT}
       port: ${?PORT}
     }
+  }
+}
+
+# Additional HTTPS security headers.  You can add, modify, remove as needed to enhance
+# the security profile of our Kotlin based applications.
+https_headers: ["X-Content-Type-Options: nosniff",
+  "X-Frame-Options: DENY",
+  "X-XSS-Protection: 1; mode=block",
+  "Strict-Transport-Security: max-age=31536000; includeSubDomains; preload",
+]
+
+staging {
+  application {
+    httpsHeaders: ${https_headers}
+  }
+}
+
+prod {
+  application {
+    httpsHeaders: ${https_headers}
   }
 }

--- a/server/src/test/kotlin/com/trib3/server/modules/DefaultApplicationModuleTest.kt
+++ b/server/src/test/kotlin/com/trib3/server/modules/DefaultApplicationModuleTest.kt
@@ -15,6 +15,7 @@ import com.trib3.server.healthchecks.VersionHealthCheck
 import io.dropwizard.Configuration
 import io.dropwizard.configuration.ConfigurationFactoryFactory
 import org.eclipse.jetty.servlets.CrossOriginFilter
+import org.eclipse.jetty.servlets.HeaderFilter
 import org.testng.annotations.Guice
 import org.testng.annotations.Test
 import javax.inject.Inject
@@ -44,6 +45,7 @@ class DefaultApplicationModuleTest
         assertThat(servletFilterConfigs.map { it.name }).all {
             contains(RequestIdFilter::class.simpleName)
             contains(CrossOriginFilter::class.simpleName)
+            contains(HeaderFilter::class.simpleName)
         }
         assertThat(objectMapper.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)).isFalse()
     }


### PR DESCRIPTION
 - Create new HeadersFilter for HTTP security headers
 - Add headers to the reference.conf file
 - Add headers to the appConfig
 - Add provider for HeadersFilter that reads config, prepends "Set " and creates CSV list for Jetty HeadersFilter

Notion: https://www.notion.so/tribedynamics/Security-Vulnerability-Website-does-not-implement-X-Content-Type-Options-Best-Practices-88c12df26f2b4eb99f523c1e394b1099