### PR TITLE
Include AWS STS jar at runtime

### DIFF
--- a/config/pom.xml
+++ b/config/pom.xml
@@ -51,6 +51,11 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
+            <scope>runtime</scope> <!-- ensure sts is on classpath so that profiles work -->
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
             <artifactId>kms</artifactId>
         </dependency>
         <dependency>

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -873,6 +873,17 @@
                 </exclusions>
             </dependency>
             <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>sts</artifactId>
+                <version>${version.aws.java}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.httpcomponents.core5</groupId>
                 <artifactId>httpcore5</artifactId>
                 <version>${version.httpcomponents.core}</version>


### PR DESCRIPTION
Using role based authentication with profiles
requires this jar included at runtime.