### PR TITLE
Add metrics-guice src copy

### DIFF
--- a/metrics-guice/LICENSE.txt
+++ b/metrics-guice/LICENSE.txt
@@ -1,0 +1,36 @@
+# Copyfree Open Innovation License
+
+This is version 0.4 of the Copyfree Open Innovation License.
+
+## Terms and Conditions
+
+Redistributions, modified or unmodified, in whole or in part, must retain
+applicable copyright or other legal privilege notices, these conditions, and
+the following license terms and disclaimer.  Subject to these conditions, the
+holder(s) of copyright or other legal privileges, author(s) or assembler(s),
+and contributors of this work hereby grant to any person who obtains a copy of
+this work in any form:
+
+1. Permission to reproduce, modify, distribute, publish, sell, sublicense, use,
+and/or otherwise deal in the licensed material without restriction.
+
+2. A perpetual, worldwide, non-exclusive, royalty-free, irrevocable patent
+license to reproduce, modify, distribute, publish, sell, use, and/or otherwise
+deal in the licensed material without restriction, for any and all patents:
+
+    a. Held presently or in the future by each such holder of copyright or
+    other legal privilege, author or assembler, or contributor, necessarily
+    infringed by the contributions alone or by combination with the work, of
+    that privilege holder, author or assembler, or contributor.
+
+    b. Necessarily infringed by the work at the time that holder of copyright
+    or other privilege, author or assembler, or contributor made any
+    contribution to the work.
+
+NO WARRANTY OF ANY KIND IS IMPLIED BY, OR SHOULD BE INFERRED FROM, THIS LICENSE
+OR THE ACT OF DISTRIBUTION UNDER THE TERMS OF THIS LICENSE, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
+AND NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS, ASSEMBLERS, OR HOLDERS OF
+COPYRIGHT OR OTHER LEGAL PRIVILEGE BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+LIABILITY, WHETHER IN ACTION OF CONTRACT, TORT, OR OTHERWISE ARISING FROM, OUT
+OF, OR IN CONNECTION WITH THE WORK OR THE USE OF OR OTHER DEALINGS IN THE WORK.

--- a/metrics-guice/README.md
+++ b/metrics-guice/README.md
@@ -1,0 +1,114 @@
+This is a copy of the source of v4.0.0 of https://github.com/palominolabs/metrics-guice 
+which is no longer available in public maven repositories, relocated under the 
+following maven coordinates:
+
+```xml
+<dependency>
+  <groupId>com.trib3</groupId>
+  <artifactId>metrics-guice</artifactId>
+  <version>[the latest version]</version>
+</dependency>
+```
+
+[![Build Status](https://semaphoreci.com/api/v1/marshallpierce/metrics-guice/branches/master/badge.svg)](https://semaphoreci.com/marshallpierce/metrics-guice)
+ [ ![Download](https://api.bintray.com/packages/marshallpierce/maven/com.palominolabs.metrics%3Ametrics-guice/images/download.svg) ](https://bintray.com/marshallpierce/maven/com.palominolabs.metrics%3Ametrics-guice/_latestVersion) 
+# Quick Start
+
+### Get the artifacts
+
+Artifacts are released in [Bintray](https://bintray.com/). For gradle, use the `jcenter()` repository. For maven, [go here](https://bintray.com/bintray/jcenter?filterByPkgName=com.palominolabs.metrics%3Ametrics-guice) and click "Set me up".
+
+Maven:
+
+```xml
+<dependency>
+  <groupId>com.palominolabs.metrics</groupId>
+  <artifactId>metrics-guice</artifactId>
+  <version>[the latest version]</version>
+</dependency>
+```
+
+Gradle:
+
+```
+compile 'com.palominolabs.metrics:metrics-guice:[the latest version]'
+```
+
+### Install the Guice module
+
+```java
+// somewhere in your Guice module setup
+install(MetricsInstrumentationModule.builder().withMetricRegistry(yourFavoriteMetricRegistry).build());
+```
+
+### Use it
+
+The `MetricsInstrumentationModule` you installed above will create and appropriately invoke a [Timer](https://dropwizard.github.io/metrics/3.1.0/manual/core/#timers) for `@Timed` methods, a [Meter](https://dropwizard.github.io/metrics/3.1.0/manual/core/#meters) for `@Metered` methods, a [Counter](https://dropwizard.github.io/metrics/3.1.0/manual/core/#counters) for `@Counted` methods, and a [Gauge](https://dropwizard.github.io/metrics/3.1.0/manual/core/#gauges) for `@Gauge` methods. `@ExceptionMetered` is also supported; this creates a `Meter` that measures how often a method throws exceptions.
+
+The annotations have some configuration options available for metric name, etc. You can also provide a custom `MetricNamer` implementation if the default name scheme does not work for you.
+
+### Customizing annotation lookup
+
+By default `MetricsInstrumentationModule` will provide metrics only for annotated methods. You can also look for annotations on the enclosing classes, or both, or provide your own custom logic.  To change annotation resolution, provide an `AnnotationResolver` when building the `MetricsInstrumentationModule`. `MethodAnnotationResolver` is the default implementation. `ClassAnnotationResolver` will look for annotations on the class instead of the method. You can invoke multiple resolvers in order with `ListAnnotationResolver `, so if you wanted to look in methods first and then the class, you could do that:
+
+```java
+// somewhere in your Guice module setup
+install(
+    MetricsInstrumentationModule.builder()
+        .withMetricRegistry(yourFavoriteMetricRegistry)
+        .withAnnotationResolver(new ListAnnotationResolver(Lists.newArrayList(new ClassAnnotationResolver(), new MethodAnnotationResolver()))
+        .build()
+);
+```
+
+### Metric namer
+
+The default `MetricNamer` implementation probably does what you want out of the box, but you can also write and use your own. 
+
+#### Example
+
+If you have a method like this:
+
+```java
+class SuperCriticalFunctionality {
+    public void doSomethingImportant() {
+        // critical business logic
+    }
+}
+```
+
+and you want to use a [Timer](https://dropwizard.github.io/metrics/3.1.0/manual/core/#timers) to measure duration, etc, you could always do it by hand:
+
+```java
+public void doSomethingImportant() {
+    // timer is some Timer instance
+    Timer.Context context = timer.time();
+    try {
+        // critical business logic
+    } finally {
+        context.stop();
+    }
+}
+```
+
+However, if you're instantiating that class with Guice, you could just do this:
+
+```java
+@Timed
+public void doSomethingImportant() {
+    // critical business logic
+}
+```
+
+### Limitations
+
+Since this uses Guice AOP, instances must be created by Guice; see [the Guice wiki](https://github.com/google/guice/wiki/AOP). This means that using a Provider where you create the instance won't work, or binding a singleton to an instance, etc.
+
+Guice AOP doesn't allow us to intercept method calls to annotated methods in supertypes, so `@Counted`, etc, will not have metrics generated for them if they are in supertypes of the injectable class. One small consolation is that `@Gauge` methods can be anywhere in the type hierarchy since they work differently from the other metrics (the generated Gauge object invokes the `java.lang.reflect.Method` directly, so we can call the supertype method unambiguously).
+
+One common way users might hit this issue is if when trying to use `@Counted`, etc on a JAX-RS resource annotated with `@Path`, `@GET`, etc. This may pose problems for the JAX-RS implementation because the thing it has at runtime is now an auto-generated proxy class, not the "normal" class. A perfectly reasonable approach is instead to handle metrics generation for those classes via the hooks available in the JAX-RS implementation. For Jersey 2, might I suggest [jersey2-metrics](https://bitbucket.org/marshallpierce/jersey2-metrics)?
+
+# History
+
+This module started from the state of metrics-guice immediately before it was removed from the [main metrics repo](https://github.com/dropwizard/metrics) in [dropwizard/metrics@e058f76dabf3f805d1c220950a4f42c2ec605ecd](https://github.com/dropwizard/metrics/commit/e058f76dabf3f805d1c220950a4f42c2ec605ecd).
+

--- a/metrics-guice/RELEASE-NOTES.md
+++ b/metrics-guice/RELEASE-NOTES.md
@@ -1,0 +1,48 @@
+- 4.0.0
+    - Build system updates; update Gradle to 4.6
+    - Update to Metrics 4.0.2
+    - Update to Java 8
+- 3.3.0
+    - Change default `MetricNamer` implementation to one that is friendlier to re-using superclass gauges in multiple child classes. The previous behavior is still available as `DeclaringClassMetricNamer`.
+    - Change `MetricNamer.getNameForGauge` to take an additional parameter to support the superclass logic above.
+    - Add Animal Sniffer to build to ensure that only JDK6 types are used.
+    - Update to Gradle 4.0.1
+- 3.2.2
+    - Update to Metrics 3.2.3
+    - Update to Gradle 4.0
+- 3.2.1
+    - Update to Metrics 3.2 and SLF4J 1.7.25
+    - Update to Gradle 3.4
+- 3.2.0
+    - Update to Gradle 3.1
+    - Updated dependencies: SLF4J 1.7.21, Guice 4.1.0
+    - Allow customization in how annotations are resolved for a method. The default is the previous behavior (only looks on the method itself), but implementations for looking on the class and combining multiple resolvers are provided.
+    - `MetricsInstrumentationModule` is now constructed builder-style.
+- 3.1.4
+    - Switch to releasing in bintray
+    - Remove superclass traversal when looking for annotated methods to intercept because AOP on superclass methods doesn't appear to work anyway
+    - Switch build to Gradle
+    - License under COIL
+    - Add ability to have non-public @Gauge methods anywhere in the type hierarchy of an injected type
+    - Updated dependencies: Metrics 3.1.2, SLF4J 1.7.12, Guice 4.0
+- 3.1.3
+    - Add support for `@Counted`
+    - Move metric name creation into `MetricNamer` for easy customization
+    - Move AdminServletModule into [metrics-guice-servlet](https://github.com/palominolabs/metrics-guice-servlet)
+- 3.1.2
+    - Make injection listeners public
+    - Depend on Metrics 3.1.0
+    - Tweak metric naming to avoid duplicate names for different metrics
+- 3.1.1
+    - Allow specifying a custom matcher
+- 3.1.0
+    - Don't create MetricRegistry, HealthCheckRegistry, or JmxReporter for the user. This makes it easier to integrate with existing systems that already have instances that should be used.
+    - Rename InstrumentationModule to MetricsInstrumentationModule
+    - Update to SLF4J
+- 3.0.2
+    - Update to Metrics 3.0.2
+- 3.0.1
+    - Update to Jackson 2.0.2
+    - Update to Metrics 3.0.1
+    - Update to SLF4J 1.7.6
+    - Use javax.servlet:javax.servlet-api for servlet implementation

--- a/metrics-guice/pom.xml
+++ b/metrics-guice/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.trib3</groupId>
+        <artifactId>leakycauldron</artifactId>
+        <version>2.2-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <groupId>com.trib3</groupId>
+    <artifactId>metrics-guice</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-annotation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>aopalliance</groupId>
+            <artifactId>aopalliance</artifactId>
+            <version>1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/metrics-guice/src/main/java/com/palominolabs/metrics/guice/CountedInterceptor.java
+++ b/metrics-guice/src/main/java/com/palominolabs/metrics/guice/CountedInterceptor.java
@@ -1,0 +1,29 @@
+package com.palominolabs.metrics.guice;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.annotation.Counted;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+
+class CountedInterceptor implements MethodInterceptor {
+
+    private final Counter counter;
+    private final boolean decrementAfterMethod;
+
+    CountedInterceptor(Counter counter, Counted annotation) {
+        this.counter = counter;
+        decrementAfterMethod = !annotation.monotonic();
+    }
+
+    @Override
+    public Object invoke(MethodInvocation invocation) throws Throwable {
+        counter.inc();
+        try {
+            return invocation.proceed();
+        } finally {
+            if (decrementAfterMethod) {
+                counter.dec();
+            }
+        }
+    }
+}

--- a/metrics-guice/src/main/java/com/palominolabs/metrics/guice/CountedListener.java
+++ b/metrics-guice/src/main/java/com/palominolabs/metrics/guice/CountedListener.java
@@ -1,0 +1,36 @@
+package com.palominolabs.metrics.guice;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.annotation.Counted;
+import com.palominolabs.metrics.guice.annotation.AnnotationResolver;
+import java.lang.reflect.Method;
+import javax.annotation.Nullable;
+import org.aopalliance.intercept.MethodInterceptor;
+
+/**
+ * A listener which adds method interceptors to counted methods.
+ */
+public class CountedListener extends DeclaredMethodsTypeListener {
+    private final MetricRegistry metricRegistry;
+    private final MetricNamer metricNamer;
+    private final AnnotationResolver annotationResolver;
+
+    public CountedListener(MetricRegistry metricRegistry, MetricNamer metricNamer,
+            AnnotationResolver annotationResolver) {
+        this.metricRegistry = metricRegistry;
+        this.metricNamer = metricNamer;
+        this.annotationResolver = annotationResolver;
+    }
+
+    @Nullable
+    @Override
+    protected MethodInterceptor getInterceptor(Method method) {
+        final Counted annotation = annotationResolver.findAnnotation(Counted.class, method);
+        if (annotation != null) {
+            final Counter counter = metricRegistry.counter(metricNamer.getNameForCounted(method, annotation));
+            return new CountedInterceptor(counter, annotation);
+        }
+        return null;
+    }
+}

--- a/metrics-guice/src/main/java/com/palominolabs/metrics/guice/DeclaredMethodsTypeListener.java
+++ b/metrics-guice/src/main/java/com/palominolabs/metrics/guice/DeclaredMethodsTypeListener.java
@@ -1,0 +1,41 @@
+package com.palominolabs.metrics.guice;
+
+import com.google.inject.TypeLiteral;
+import com.google.inject.matcher.Matchers;
+import com.google.inject.spi.TypeEncounter;
+import com.google.inject.spi.TypeListener;
+import java.lang.reflect.Method;
+import javax.annotation.Nullable;
+import org.aopalliance.intercept.MethodInterceptor;
+
+/**
+ * A TypeListener which delegates to {@link DeclaredMethodsTypeListener#getInterceptor(Method)} for each method in the
+ * class's declared methods.
+ */
+abstract class DeclaredMethodsTypeListener implements TypeListener {
+
+    @Override
+    public <T> void hear(TypeLiteral<T> literal, TypeEncounter<T> encounter) {
+        Class<? super T> klass = literal.getRawType();
+
+        for (Method method : klass.getDeclaredMethods()) {
+            if (method.isSynthetic()) {
+                continue;
+            }
+
+            final MethodInterceptor interceptor = getInterceptor(method);
+            if (interceptor != null) {
+                encounter.bindInterceptor(Matchers.only(method), interceptor);
+            }
+        }
+    }
+
+    /**
+     * Called for every method on every class in the type hierarchy of the visited type
+     *
+     * @param method method to get interceptor for
+     * @return null if no interceptor should be applied, else an interceptor
+     */
+    @Nullable
+    protected abstract MethodInterceptor getInterceptor(Method method);
+}

--- a/metrics-guice/src/main/java/com/palominolabs/metrics/guice/DeclaringClassMetricNamer.java
+++ b/metrics-guice/src/main/java/com/palominolabs/metrics/guice/DeclaringClassMetricNamer.java
@@ -1,0 +1,97 @@
+package com.palominolabs.metrics.guice;
+
+import com.codahale.metrics.annotation.Counted;
+import com.codahale.metrics.annotation.ExceptionMetered;
+import com.codahale.metrics.annotation.Gauge;
+import com.codahale.metrics.annotation.Metered;
+import com.codahale.metrics.annotation.Timed;
+import java.lang.reflect.Method;
+import javax.annotation.Nonnull;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+/**
+ * Uses the name fields in the metric annotations, if present, or the method declaring class and method name.
+ */
+public class DeclaringClassMetricNamer implements MetricNamer {
+    static final String COUNTER_SUFFIX = "counter";
+    static final String COUNTER_SUFFIX_MONOTONIC = "current";
+    static final String GAUGE_SUFFIX = "gauge";
+    static final String METERED_SUFFIX = "meter";
+    static final String TIMED_SUFFIX = "timer";
+
+    @Nonnull
+    @Override
+    public String getNameForCounted(@Nonnull Method method, @Nonnull Counted counted) {
+        if (counted.absolute()) {
+            return counted.name();
+        }
+
+        if (counted.name().isEmpty()) {
+            if (counted.monotonic()) {
+                return name(method.getDeclaringClass(), method.getName(), COUNTER_SUFFIX_MONOTONIC);
+            } else {
+                return name(method.getDeclaringClass(), method.getName(), COUNTER_SUFFIX);
+            }
+        }
+
+        return name(method.getDeclaringClass(), counted.name());
+    }
+
+    @Nonnull
+    @Override
+    public String getNameForExceptionMetered(@Nonnull Method method, @Nonnull ExceptionMetered exceptionMetered) {
+        if (exceptionMetered.absolute()) {
+            return exceptionMetered.name();
+        }
+
+        if (exceptionMetered.name().isEmpty()) {
+            return
+                    name(method.getDeclaringClass(), method.getName(), ExceptionMetered.DEFAULT_NAME_SUFFIX);
+        }
+
+        return name(method.getDeclaringClass(), exceptionMetered.name());
+    }
+
+    @Nonnull
+    @Override
+    public String getNameForGauge(@Nonnull Class<?> instanceClass, @Nonnull Method method, @Nonnull Gauge gauge) {
+        if (gauge.absolute()) {
+            return gauge.name();
+        }
+
+        if (gauge.name().isEmpty()) {
+            return name(method.getDeclaringClass(), method.getName(), GAUGE_SUFFIX);
+        }
+
+        return name(method.getDeclaringClass(), gauge.name());
+    }
+
+    @Nonnull
+    @Override
+    public String getNameForMetered(@Nonnull Method method, @Nonnull Metered metered) {
+        if (metered.absolute()) {
+            return metered.name();
+        }
+
+        if (metered.name().isEmpty()) {
+            return name(method.getDeclaringClass(), method.getName(), METERED_SUFFIX);
+        }
+
+        return name(method.getDeclaringClass(), metered.name());
+    }
+
+    @Nonnull
+    @Override
+    public String getNameForTimed(@Nonnull Method method, @Nonnull Timed timed) {
+        if (timed.absolute()) {
+            return timed.name();
+        }
+
+        if (timed.name().isEmpty()) {
+            return name(method.getDeclaringClass(), method.getName(), TIMED_SUFFIX);
+        }
+
+        return name(method.getDeclaringClass(), timed.name());
+    }
+}

--- a/metrics-guice/src/main/java/com/palominolabs/metrics/guice/ExceptionMeteredInterceptor.java
+++ b/metrics-guice/src/main/java/com/palominolabs/metrics/guice/ExceptionMeteredInterceptor.java
@@ -1,0 +1,31 @@
+package com.palominolabs.metrics.guice;
+
+import com.codahale.metrics.Meter;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+
+/**
+ * A method interceptor which measures the rate at which the annotated method throws exceptions of a given type.
+ */
+class ExceptionMeteredInterceptor implements MethodInterceptor {
+
+    private final Meter meter;
+    private final Class<? extends Throwable> klass;
+
+    ExceptionMeteredInterceptor(Meter meter, Class<? extends Throwable> klass) {
+        this.meter = meter;
+        this.klass = klass;
+    }
+
+    @Override
+    public Object invoke(MethodInvocation invocation) throws Throwable {
+        try {
+            return invocation.proceed();
+        } catch (Throwable t) {
+            if (klass.isAssignableFrom(t.getClass())) {
+                meter.mark();
+            }
+            throw t;
+        }
+    }
+}

--- a/metrics-guice/src/main/java/com/palominolabs/metrics/guice/ExceptionMeteredListener.java
+++ b/metrics-guice/src/main/java/com/palominolabs/metrics/guice/ExceptionMeteredListener.java
@@ -1,0 +1,36 @@
+package com.palominolabs.metrics.guice;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.annotation.ExceptionMetered;
+import com.palominolabs.metrics.guice.annotation.AnnotationResolver;
+import java.lang.reflect.Method;
+import javax.annotation.Nullable;
+import org.aopalliance.intercept.MethodInterceptor;
+
+/**
+ * A listener which adds method interceptors to methods that should be instrumented for exceptions
+ */
+public class ExceptionMeteredListener extends DeclaredMethodsTypeListener {
+    private final MetricRegistry metricRegistry;
+    private final MetricNamer metricNamer;
+    private final AnnotationResolver annotationResolver;
+
+    public ExceptionMeteredListener(MetricRegistry metricRegistry, MetricNamer metricNamer,
+            final AnnotationResolver annotationResolver) {
+        this.metricRegistry = metricRegistry;
+        this.metricNamer = metricNamer;
+        this.annotationResolver = annotationResolver;
+    }
+
+    @Nullable
+    @Override
+    protected MethodInterceptor getInterceptor(Method method) {
+        final ExceptionMetered annotation = annotationResolver.findAnnotation(ExceptionMetered.class, method);
+        if (annotation != null) {
+            final Meter meter = metricRegistry.meter(metricNamer.getNameForExceptionMetered(method, annotation));
+            return new ExceptionMeteredInterceptor(meter, annotation.cause());
+        }
+        return null;
+    }
+}

--- a/metrics-guice/src/main/java/com/palominolabs/metrics/guice/GaugeInjectionListener.java
+++ b/metrics-guice/src/main/java/com/palominolabs/metrics/guice/GaugeInjectionListener.java
@@ -1,0 +1,34 @@
+package com.palominolabs.metrics.guice;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+import com.google.inject.spi.InjectionListener;
+
+import java.lang.reflect.Method;
+
+/**
+ * An injection listener which creates a gauge for the declaring class with the given name (or the method's name, if
+ * none was provided) which returns the value returned by the annotated method.
+ */
+public class GaugeInjectionListener<I> implements InjectionListener<I> {
+    private final MetricRegistry metricRegistry;
+    private final String metricName;
+    private final Method method;
+
+    public GaugeInjectionListener(MetricRegistry metricRegistry, String metricName, Method method) {
+        this.metricRegistry = metricRegistry;
+        this.metricName = metricName;
+        this.method = method;
+    }
+
+    @Override
+    public void afterInjection(final I i) {
+        metricRegistry.register(metricName, (Gauge<Object>) () -> {
+            try {
+                return method.invoke(i);
+            } catch (Exception e) {
+                return new RuntimeException(e);
+            }
+        });
+    }
+}

--- a/metrics-guice/src/main/java/com/palominolabs/metrics/guice/GaugeInstanceClassMetricNamer.java
+++ b/metrics-guice/src/main/java/com/palominolabs/metrics/guice/GaugeInstanceClassMetricNamer.java
@@ -1,0 +1,31 @@
+package com.palominolabs.metrics.guice;
+
+import com.codahale.metrics.annotation.Gauge;
+import java.lang.reflect.Method;
+import javax.annotation.Nonnull;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+/**
+ * For gauges (which can reside in superclasses of the type being instantiated), this will use the instantiated type for
+ * the resulting metric name no matter what superclass declares the gauge method. This allows for a gauge located in a
+ * superclass to be used by multiple inheritors without causing a duplicate metric name clash.
+ *
+ * For other metric types, which are not available on superclass methods, the declaring class (which would be the same
+ * as the instantiated class) is used, as in {@link DeclaringClassMetricNamer}.
+ */
+public class GaugeInstanceClassMetricNamer extends DeclaringClassMetricNamer {
+    @Nonnull
+    @Override
+    public String getNameForGauge(@Nonnull Class<?> instanceClass, @Nonnull Method method, @Nonnull Gauge gauge) {
+        if (gauge.absolute()) {
+            return gauge.name();
+        }
+
+        if (gauge.name().isEmpty()) {
+            return name(instanceClass, method.getName(), GAUGE_SUFFIX);
+        }
+
+        return name(instanceClass, gauge.name());
+    }
+}

--- a/metrics-guice/src/main/java/com/palominolabs/metrics/guice/GaugeListener.java
+++ b/metrics-guice/src/main/java/com/palominolabs/metrics/guice/GaugeListener.java
@@ -1,0 +1,56 @@
+package com.palominolabs.metrics.guice;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.annotation.Gauge;
+import com.google.inject.TypeLiteral;
+import com.google.inject.spi.TypeEncounter;
+import com.google.inject.spi.TypeListener;
+import com.palominolabs.metrics.guice.annotation.AnnotationResolver;
+import java.lang.reflect.Method;
+
+/**
+ * A listener which adds gauge injection listeners to classes with gauges.
+ */
+public class GaugeListener implements TypeListener {
+    private final MetricRegistry metricRegistry;
+    private final MetricNamer metricNamer;
+    private final AnnotationResolver annotationResolver;
+
+    public GaugeListener(MetricRegistry metricRegistry, MetricNamer metricNamer,
+            final AnnotationResolver annotationResolver) {
+        this.metricRegistry = metricRegistry;
+        this.metricNamer = metricNamer;
+        this.annotationResolver = annotationResolver;
+    }
+
+    @Override
+    public <I> void hear(final TypeLiteral<I> literal, TypeEncounter<I> encounter) {
+        Class<? super I> klass = literal.getRawType();
+        final Class<?> instanceType = klass;
+
+        do {
+            for (Method method : klass.getDeclaredMethods()) {
+                if (method.isSynthetic()) {
+                    continue;
+                }
+
+                final Gauge annotation = annotationResolver.findAnnotation(Gauge.class, method);
+                if (annotation != null) {
+                    if (method.getParameterTypes().length == 0) {
+                        final String metricName = metricNamer.getNameForGauge(instanceType, method, annotation);
+
+                        // deprecated method in java 9, but replacement is not available in java 8
+                        if (!method.isAccessible()) {
+                            method.setAccessible(true);
+                        }
+
+                        encounter.register(new GaugeInjectionListener<>(metricRegistry, metricName, method));
+                    } else {
+                        encounter.addError("Method %s is annotated with @Gauge but requires parameters.",
+                                method);
+                    }
+                }
+            }
+        } while ((klass = klass.getSuperclass()) != null);
+    }
+}

--- a/metrics-guice/src/main/java/com/palominolabs/metrics/guice/MeteredInterceptor.java
+++ b/metrics-guice/src/main/java/com/palominolabs/metrics/guice/MeteredInterceptor.java
@@ -1,0 +1,24 @@
+package com.palominolabs.metrics.guice;
+
+import com.codahale.metrics.Meter;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+
+/**
+ * A method interceptor which creates a meter for the declaring class with the given name (or the method's name, if none
+ * was provided), and which measures the rate at which the annotated method is invoked.
+ */
+class MeteredInterceptor implements MethodInterceptor {
+
+    private final Meter meter;
+
+    MeteredInterceptor(Meter meter) {
+        this.meter = meter;
+    }
+
+    @Override
+    public Object invoke(MethodInvocation invocation) throws Throwable {
+        meter.mark();
+        return invocation.proceed();
+    }
+}

--- a/metrics-guice/src/main/java/com/palominolabs/metrics/guice/MeteredListener.java
+++ b/metrics-guice/src/main/java/com/palominolabs/metrics/guice/MeteredListener.java
@@ -1,0 +1,36 @@
+package com.palominolabs.metrics.guice;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.annotation.Metered;
+import com.palominolabs.metrics.guice.annotation.AnnotationResolver;
+import java.lang.reflect.Method;
+import javax.annotation.Nullable;
+import org.aopalliance.intercept.MethodInterceptor;
+
+/**
+ * A listener which adds method interceptors to metered methods.
+ */
+public class MeteredListener extends DeclaredMethodsTypeListener {
+    private final MetricRegistry metricRegistry;
+    private final MetricNamer metricNamer;
+    private final AnnotationResolver annotationResolver;
+
+    public MeteredListener(MetricRegistry metricRegistry, MetricNamer metricNamer,
+            AnnotationResolver annotationResolver) {
+        this.metricRegistry = metricRegistry;
+        this.metricNamer = metricNamer;
+        this.annotationResolver = annotationResolver;
+    }
+
+    @Nullable
+    @Override
+    protected MethodInterceptor getInterceptor(Method method) {
+        final Metered annotation = annotationResolver.findAnnotation(Metered.class, method);
+        if (annotation != null) {
+            final Meter meter = metricRegistry.meter(metricNamer.getNameForMetered(method, annotation));
+            return new MeteredInterceptor(meter);
+        }
+        return null;
+    }
+}

--- a/metrics-guice/src/main/java/com/palominolabs/metrics/guice/MetricNamer.java
+++ b/metrics-guice/src/main/java/com/palominolabs/metrics/guice/MetricNamer.java
@@ -1,0 +1,41 @@
+package com.palominolabs.metrics.guice;
+
+import com.codahale.metrics.annotation.Counted;
+import com.codahale.metrics.annotation.ExceptionMetered;
+import com.codahale.metrics.annotation.Gauge;
+import com.codahale.metrics.annotation.Metered;
+import com.codahale.metrics.annotation.Timed;
+
+import javax.annotation.Nonnull;
+import java.lang.reflect.Method;
+
+/**
+ * Generates for the metrics corresponding to the various metric annotations.
+ */
+public interface MetricNamer {
+
+    @Nonnull
+    String getNameForCounted(@Nonnull Method method, @Nonnull Counted counted);
+
+    @Nonnull
+    String getNameForExceptionMetered(@Nonnull Method method, @Nonnull ExceptionMetered exceptionMetered);
+
+    /**
+     * For AOP-wrapped method invocations (which is how all metrics other than Gauges have to be handled), there isn't a
+     * way to handle annotated methods defined in superclasses since we can't AOP superclass methods. Gauges, however,
+     * are invoked without requiring AOP, so gauges from superclasses are available.
+     *
+     * @param instanceClass the type being instantiated
+     * @param method       the annotated method (which may belong to a supertype)
+     * @param gauge        the annotation
+     * @return a name
+     */
+    @Nonnull
+    String getNameForGauge(@Nonnull Class<?> instanceClass, @Nonnull Method method, @Nonnull Gauge gauge);
+
+    @Nonnull
+    String getNameForMetered(@Nonnull Method method, @Nonnull Metered metered);
+
+    @Nonnull
+    String getNameForTimed(@Nonnull Method method, @Nonnull Timed timed);
+}

--- a/metrics-guice/src/main/java/com/palominolabs/metrics/guice/MetricsInstrumentationModule.java
+++ b/metrics-guice/src/main/java/com/palominolabs/metrics/guice/MetricsInstrumentationModule.java
@@ -1,0 +1,124 @@
+package com.palominolabs.metrics.guice;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.annotation.Counted;
+import com.codahale.metrics.annotation.ExceptionMetered;
+import com.codahale.metrics.annotation.Gauge;
+import com.codahale.metrics.annotation.Metered;
+import com.codahale.metrics.annotation.Timed;
+import com.google.common.base.Preconditions;
+import com.google.inject.AbstractModule;
+import com.google.inject.TypeLiteral;
+import com.google.inject.matcher.Matcher;
+import com.google.inject.matcher.Matchers;
+import com.palominolabs.metrics.guice.annotation.AnnotationResolver;
+import com.palominolabs.metrics.guice.annotation.MethodAnnotationResolver;
+import javax.annotation.Nonnull;
+
+/**
+ * A Guice module which instruments methods annotated with the {@link Metered}, {@link Timed}, {@link Gauge}, {@link
+ * Counted}, and {@link ExceptionMetered} annotations.
+ *
+ * @see Gauge
+ * @see Metered
+ * @see Timed
+ * @see ExceptionMetered
+ * @see Counted
+ * @see MeteredInterceptor
+ * @see TimedInterceptor
+ * @see GaugeInjectionListener
+ */
+public class MetricsInstrumentationModule extends AbstractModule {
+    private final MetricRegistry metricRegistry;
+    private final Matcher<? super TypeLiteral<?>> matcher;
+    private final MetricNamer metricNamer;
+    private final AnnotationResolver annotationResolver;
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * @param metricRegistry     The registry to use when creating meters, etc. for annotated methods.
+     * @param matcher            The matcher to determine which types to look for metrics in
+     * @param metricNamer        The metric namer to use when creating names for metrics for annotated methods
+     * @param annotationResolver The annotation provider
+     */
+    private MetricsInstrumentationModule(MetricRegistry metricRegistry, Matcher<? super TypeLiteral<?>> matcher,
+            MetricNamer metricNamer, AnnotationResolver annotationResolver) {
+        this.metricRegistry = metricRegistry;
+        this.matcher = matcher;
+        this.metricNamer = metricNamer;
+        this.annotationResolver = annotationResolver;
+    }
+
+    @Override
+    protected void configure() {
+        bindListener(matcher, new MeteredListener(metricRegistry, metricNamer, annotationResolver));
+        bindListener(matcher, new TimedListener(metricRegistry, metricNamer, annotationResolver));
+        bindListener(matcher, new GaugeListener(metricRegistry, metricNamer, annotationResolver));
+        bindListener(matcher, new ExceptionMeteredListener(metricRegistry, metricNamer, annotationResolver));
+        bindListener(matcher, new CountedListener(metricRegistry, metricNamer, annotationResolver));
+    }
+
+    public static class Builder {
+        private MetricRegistry metricRegistry;
+        private Matcher<? super TypeLiteral<?>> matcher = Matchers.any();
+        private MetricNamer metricNamer = new GaugeInstanceClassMetricNamer();
+        private AnnotationResolver annotationResolver = new MethodAnnotationResolver();
+
+        /**
+         * @param metricRegistry The registry to use when creating meters, etc. for annotated methods.
+         * @return this
+         */
+        @Nonnull
+        public Builder withMetricRegistry(@Nonnull MetricRegistry metricRegistry) {
+            this.metricRegistry = metricRegistry;
+
+            return this;
+        }
+
+        /**
+         * @param matcher The matcher to determine which types to look for metrics in
+         * @return this
+         */
+        @Nonnull
+        public Builder withMatcher(@Nonnull Matcher<? super TypeLiteral<?>> matcher) {
+            this.matcher = matcher;
+
+            return this;
+        }
+
+        /**
+         * @param metricNamer The metric namer to use when creating names for metrics for annotated methods
+         * @return this
+         */
+        @Nonnull
+        public Builder withMetricNamer(@Nonnull MetricNamer metricNamer) {
+            this.metricNamer = metricNamer;
+
+            return this;
+        }
+
+        /**
+         * @param annotationResolver Annotation resolver to use
+         * @return this
+         */
+        @Nonnull
+        public Builder withAnnotationMatcher(@Nonnull AnnotationResolver annotationResolver) {
+            this.annotationResolver = annotationResolver;
+
+            return this;
+        }
+
+        @Nonnull
+        public MetricsInstrumentationModule build() {
+            return new MetricsInstrumentationModule(
+                    Preconditions.checkNotNull(metricRegistry),
+                    Preconditions.checkNotNull(matcher),
+                    Preconditions.checkNotNull(metricNamer),
+                    Preconditions.checkNotNull(annotationResolver)
+            );
+        }
+    }
+}

--- a/metrics-guice/src/main/java/com/palominolabs/metrics/guice/TimedInterceptor.java
+++ b/metrics-guice/src/main/java/com/palominolabs/metrics/guice/TimedInterceptor.java
@@ -1,0 +1,31 @@
+package com.palominolabs.metrics.guice;
+
+import com.codahale.metrics.Timer;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A method interceptor which times the execution of the annotated method.
+ */
+class TimedInterceptor implements MethodInterceptor {
+
+    private final Timer timer;
+
+    TimedInterceptor(Timer timer) {
+        this.timer = timer;
+    }
+
+    @Override
+    public Object invoke(MethodInvocation invocation) throws Throwable {
+        // Since these timers are always created via the default ctor (via MetricRegister#timer), they always use
+        // nanoTime, so we can save an allocation here by not using Context.
+        long start = System.nanoTime();
+        try {
+            return invocation.proceed();
+        } finally {
+            timer.update(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+        }
+    }
+}

--- a/metrics-guice/src/main/java/com/palominolabs/metrics/guice/TimedListener.java
+++ b/metrics-guice/src/main/java/com/palominolabs/metrics/guice/TimedListener.java
@@ -1,0 +1,36 @@
+package com.palominolabs.metrics.guice;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.codahale.metrics.annotation.Timed;
+import com.palominolabs.metrics.guice.annotation.AnnotationResolver;
+import java.lang.reflect.Method;
+import javax.annotation.Nullable;
+import org.aopalliance.intercept.MethodInterceptor;
+
+/**
+ * A listener which adds method interceptors to timed methods.
+ */
+public class TimedListener extends DeclaredMethodsTypeListener {
+    private final MetricRegistry metricRegistry;
+    private final MetricNamer metricNamer;
+    private final AnnotationResolver annotationResolver;
+
+    public TimedListener(MetricRegistry metricRegistry, MetricNamer metricNamer,
+            final AnnotationResolver annotationResolver) {
+        this.metricRegistry = metricRegistry;
+        this.metricNamer = metricNamer;
+        this.annotationResolver = annotationResolver;
+    }
+
+    @Nullable
+    @Override
+    protected MethodInterceptor getInterceptor(Method method) {
+        final Timed annotation = annotationResolver.findAnnotation(Timed.class, method);
+        if (annotation != null) {
+            final Timer timer = metricRegistry.timer(metricNamer.getNameForTimed(method, annotation));
+            return new TimedInterceptor(timer);
+        }
+        return null;
+    }
+}

--- a/metrics-guice/src/main/java/com/palominolabs/metrics/guice/annotation/AnnotationResolver.java
+++ b/metrics-guice/src/main/java/com/palominolabs/metrics/guice/annotation/AnnotationResolver.java
@@ -1,0 +1,20 @@
+package com.palominolabs.metrics.guice.annotation;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Finds annotations, if any, pertaining to a particular Method. Extension point for customizing annotation lookup.
+ */
+public interface AnnotationResolver {
+    /**
+     * @param annotationClass Metrics annotation to look for
+     * @param method          method that the corresponding metric may be applied to
+     * @param <T>             annotation type
+     * @return a T instance, if found, else null
+     */
+    @Nullable
+    <T extends Annotation> T findAnnotation(@Nonnull Class<T> annotationClass, @Nonnull Method method);
+}

--- a/metrics-guice/src/main/java/com/palominolabs/metrics/guice/annotation/ClassAnnotationResolver.java
+++ b/metrics-guice/src/main/java/com/palominolabs/metrics/guice/annotation/ClassAnnotationResolver.java
@@ -1,0 +1,18 @@
+package com.palominolabs.metrics.guice.annotation;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Looks for annotations on the enclosing class of the method.
+ */
+public class ClassAnnotationResolver implements AnnotationResolver {
+    @Override
+    @Nullable
+    public <T extends Annotation> T findAnnotation(@Nonnull final Class<T> annotationClass,
+            @Nonnull final Method method) {
+        return method.getDeclaringClass().getAnnotation(annotationClass);
+    }
+}

--- a/metrics-guice/src/main/java/com/palominolabs/metrics/guice/annotation/ListAnnotationResolver.java
+++ b/metrics-guice/src/main/java/com/palominolabs/metrics/guice/annotation/ListAnnotationResolver.java
@@ -1,0 +1,31 @@
+package com.palominolabs.metrics.guice.annotation;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Delegates to the provided list of resolvers, applying each resolver in turn.
+ */
+public class ListAnnotationResolver implements AnnotationResolver {
+    private final List<AnnotationResolver> resolvers;
+
+    public ListAnnotationResolver(List<AnnotationResolver> resolvers) {
+        this.resolvers = resolvers;
+    }
+
+    @Nullable
+    @Override
+    public <T extends Annotation> T findAnnotation(@Nonnull Class<T> annotationClass, @Nonnull Method method) {
+        for (AnnotationResolver resolver : resolvers) {
+            T result = resolver.findAnnotation(annotationClass, method);
+            if (result != null) {
+                return result;
+            }
+        }
+
+        return null;
+    }
+}

--- a/metrics-guice/src/main/java/com/palominolabs/metrics/guice/annotation/MethodAnnotationResolver.java
+++ b/metrics-guice/src/main/java/com/palominolabs/metrics/guice/annotation/MethodAnnotationResolver.java
@@ -1,0 +1,19 @@
+package com.palominolabs.metrics.guice.annotation;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Looks for annotations on the method itself.
+ */
+public class MethodAnnotationResolver implements AnnotationResolver {
+
+    @Override
+    @Nullable
+    public <T extends Annotation> T findAnnotation(@Nonnull final Class<T> annotationClass,
+            @Nonnull final Method method) {
+        return method.getAnnotation(annotationClass);
+    }
+}

--- a/metrics-guice/src/test/java/com/palominolabs/metrics/guice/CountInvocationGenericSubtypeTest.java
+++ b/metrics-guice/src/test/java/com/palominolabs/metrics/guice/CountInvocationGenericSubtypeTest.java
@@ -1,0 +1,36 @@
+package com.palominolabs.metrics.guice;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.codahale.metrics.MetricRegistry.name;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class CountInvocationGenericSubtypeTest {
+
+    private GenericThing<String> instance;
+    private MetricRegistry registry;
+
+    @Before
+    public void setup() {
+        this.registry = new MetricRegistry();
+        final Injector injector = Guice.createInjector(MetricsInstrumentationModule.builder().withMetricRegistry(registry).build());
+        this.instance = injector.getInstance(StringThing.class);
+    }
+
+    @Test
+    public void testCountsInvocationOfGenericOverride() {
+        instance.doThing("foo");
+
+        final Counter metric = registry.getCounters().get(name("stringThing"));
+
+        assertNotNull(metric);
+
+        assertEquals(1, metric.getCount());
+    }
+}

--- a/metrics-guice/src/test/java/com/palominolabs/metrics/guice/CountedTest.java
+++ b/metrics-guice/src/test/java/com/palominolabs/metrics/guice/CountedTest.java
@@ -1,0 +1,118 @@
+package com.palominolabs.metrics.guice;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.codahale.metrics.MetricRegistry.name;
+import static com.palominolabs.metrics.guice.DeclaringClassMetricNamer.COUNTER_SUFFIX;
+import static com.palominolabs.metrics.guice.DeclaringClassMetricNamer.COUNTER_SUFFIX_MONOTONIC;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+public class CountedTest {
+    private InstrumentedWithCounter instance;
+    private MetricRegistry registry;
+
+    @Before
+    public void setup() {
+        this.registry = new MetricRegistry();
+        final Injector injector = Guice.createInjector(MetricsInstrumentationModule.builder().withMetricRegistry(registry).build());
+        this.instance = injector.getInstance(InstrumentedWithCounter.class);
+    }
+
+    @Test
+    public void aCounterAnnotatedMethod() throws Exception {
+        instance.doAThing();
+
+        final Counter metric = registry.getCounters().get(name(InstrumentedWithCounter.class, "things"));
+
+        assertThat("Guice creates a metric",
+            metric,
+            is(notNullValue()));
+
+        assertThat("Guice creates a counter with the given value",
+            metric.getCount(),
+            is((long) 1));
+    }
+
+    @Test
+    public void aCounterAnnotatedMethodWithDefaultName() throws Exception {
+        instance.doAnotherThing();
+
+        final Counter metric = registry.getCounters().get(name(InstrumentedWithCounter.class,
+            "doAnotherThing", COUNTER_SUFFIX_MONOTONIC));
+
+        assertThat("Guice creates a metric",
+            metric,
+            is(notNullValue()));
+
+        assertThat("Guice creates a counter with the given value",
+            metric.getCount(),
+            is((long) 1));
+    }
+
+    @Test
+    public void aCounterAnnotatedMethodWithDefaultNameAndMonotonicFalse() throws Exception {
+        instance.doYetAnotherThing();
+
+        final Counter metric = registry.getCounters().get(name(InstrumentedWithCounter.class,
+            "doYetAnotherThing", COUNTER_SUFFIX));
+
+        assertThat("Guice creates a metric",
+            metric,
+            is(notNullValue()));
+
+        // if things are working well then this should still be zero...
+        assertThat("Guice creates a counter with the given value",
+            metric.getCount(),
+            is((long) 0));
+    }
+
+    @Test
+    public void aCounterAnnotatedMethodWithAbsoluteName() throws Exception {
+        instance.doAThingWithAbsoluteName();
+
+        final Counter metric = registry.getCounters().get(name("absoluteName"));
+
+        assertThat("Guice creates a metric",
+            metric,
+            is(notNullValue()));
+
+        assertThat("Guice creates a counter with the given value",
+            metric.getCount(),
+            is((long) 1));
+    }
+
+    /**
+     * Test to document the current (correct but regrettable) behavior.
+     *
+     * Crawling the injected class's supertype hierarchy doesn't really accomplish anything because AOPing supertype
+     * methods doesn't work.
+     *
+     * In certain cases (e.g. a public type that inherits a public method from a non-public supertype), a synthetic
+     * bridge method is generated in the subtype that invokes the supertype method, and this does copy the annotations
+     * of the supertype method. However, we can't allow intercepting synthetic bridge methods in general: when a subtype
+     * overrides a generic supertype's method with a more specifically typed method that would not override the
+     * type-erased supertype method, a bridge method matching the supertype's erased signature is generated, but with
+     * the subtype's method's annotation. It's not OK to intercept that synthetic method because that would lead to
+     * double-counting, etc, since we also would intercept the regular non-synthetic method.
+     *
+     * Thus, we cannot intercept synthetic methods to maintain correctness, so we also lose out on one small way that we
+     * could intercept annotated methods in superclasses.
+     */
+    @Test
+    public void aCounterForSuperclassMethod() {
+        instance.counterParent();
+
+        final Counter metric = registry.getCounters().get(name("counterParent"));
+
+        // won't be created because we don't bother looking for supertype methods
+        assertNull(metric);
+    }
+}

--- a/metrics-guice/src/test/java/com/palominolabs/metrics/guice/DeclaringClassNamerGaugeTest.java
+++ b/metrics-guice/src/test/java/com/palominolabs/metrics/guice/DeclaringClassNamerGaugeTest.java
@@ -1,0 +1,27 @@
+package com.palominolabs.metrics.guice;
+
+import com.codahale.metrics.Gauge;
+import org.junit.Test;
+
+import static com.codahale.metrics.MetricRegistry.name;
+import static com.palominolabs.metrics.guice.DeclaringClassMetricNamer.GAUGE_SUFFIX;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class DeclaringClassNamerGaugeTest extends GaugeTestBase {
+    @Override
+    MetricNamer getMetricNamer() {
+        return new DeclaringClassMetricNamer();
+    }
+
+    @Test
+    public void aGaugeWithoutNameInSuperclass() throws Exception {
+        // named for the declaring class
+        final Gauge<?> metric =
+                registry.getGauges().get(name(InstrumentedWithGaugeParent.class, "justAGaugeFromParent",
+                        GAUGE_SUFFIX));
+
+        assertNotNull(metric);
+        assertEquals("justAGaugeFromParent", metric.getValue());
+    }
+}

--- a/metrics-guice/src/test/java/com/palominolabs/metrics/guice/ExceptionMeteredTest.java
+++ b/metrics-guice/src/test/java/com/palominolabs/metrics/guice/ExceptionMeteredTest.java
@@ -1,0 +1,403 @@
+package com.palominolabs.metrics.guice;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.codahale.metrics.MetricRegistry.name;
+import static com.codahale.metrics.annotation.ExceptionMetered.DEFAULT_NAME_SUFFIX;
+import static com.palominolabs.metrics.guice.DeclaringClassMetricNamer.METERED_SUFFIX;
+import static com.palominolabs.metrics.guice.DeclaringClassMetricNamer.TIMED_SUFFIX;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class ExceptionMeteredTest {
+    private InstrumentedWithExceptionMetered instance;
+    private MetricRegistry registry;
+
+    @Before
+    public void setup() {
+        this.registry = new MetricRegistry();
+        final Injector injector = Guice.createInjector(MetricsInstrumentationModule.builder().withMetricRegistry(registry).build());
+        this.instance = injector.getInstance(InstrumentedWithExceptionMetered.class);
+    }
+
+    @Test
+    public void anExceptionMeteredAnnotatedMethodWithPublicScope() throws Exception {
+
+        final Meter metric = registry.getMeters().get(name(InstrumentedWithExceptionMetered.class, "exceptionCounter"));
+        assertMetricIsSetup(metric);
+
+        assertThat("Metric intialises to zero",
+            metric.getCount(),
+            is(0L));
+
+        try {
+            instance.explodeWithPublicScope(true);
+            fail("Expected an exception to be thrown");
+        } catch (RuntimeException e) {
+            // Swallow the expected exception
+        }
+
+        assertThat("Metric is marked",
+            metric.getCount(),
+            is(1L));
+    }
+
+    @Test
+    public void anExceptionMeteredAnnotatedMethod_WithNoMetricName() throws Exception {
+
+        final Meter metric = registry.getMeters().get(name(InstrumentedWithExceptionMetered.class,
+            "explodeForUnnamedMetric", DEFAULT_NAME_SUFFIX));
+        assertMetricIsSetup(metric);
+
+        assertThat("Metric intialises to zero",
+            metric.getCount(),
+            is(0L));
+
+        try {
+            instance.explodeForUnnamedMetric();
+            fail("Expected an exception to be thrown");
+        } catch (RuntimeException e) {
+            // Swallow the expected exception
+        }
+
+        assertThat("Metric is marked",
+            metric.getCount(),
+            is(1L));
+    }
+
+    @Test
+    public void anExceptionMeteredAnnotatedMethod_WithName() throws Exception {
+
+        final Meter metric = registry.getMeters().get(name(InstrumentedWithExceptionMetered.class, "n"));
+        assertMetricIsSetup(metric);
+
+        assertThat("Metric intialises to zero",
+            metric.getCount(),
+            is(0L));
+
+        try {
+            instance.explodeForMetricWithName();
+            fail("Expected an exception to be thrown");
+        } catch (RuntimeException e) {
+            // Swallow the expected exception
+        }
+
+        assertThat("Metric is marked",
+            metric.getCount(),
+            is(1L));
+    }
+
+    @Test
+    public void anExceptionMeteredAnnotatedMethod_WithAbsoluteName() throws Exception {
+
+        final Meter metric = registry.getMeters().get(name("absoluteName"));
+        assertMetricIsSetup(metric);
+
+        assertThat("Metric intialises to zero",
+            metric.getCount(),
+            is(0L));
+
+        try {
+            instance.explodeForMetricWithAbsoluteName();
+            fail("Expected an exception to be thrown");
+        } catch (RuntimeException e) {
+            // Swallow the expected exception
+        }
+
+        assertThat("Metric is marked",
+            metric.getCount(),
+            is(1L));
+    }
+
+    @Test
+    public void anExceptionMeteredAnnotatedMethod_WithPublicScopeButNoExceptionThrown() throws Exception {
+
+        final Meter metric = registry.getMeters().get(name(InstrumentedWithExceptionMetered.class,
+            "exceptionCounter"));
+        assertMetricIsSetup(metric);
+
+        assertThat("Metric intialises to zero",
+            metric.getCount(),
+            is(0L));
+
+        instance.explodeWithPublicScope(false);
+
+        assertThat("Metric should remain at zero if no exception is thrown",
+            metric.getCount(),
+            is(0L));
+    }
+
+    @Test
+    public void anExceptionMeteredAnnotatedMethod_WithDefaultScope() throws Exception {
+
+        final Meter metric = registry.getMeters().get(name(InstrumentedWithExceptionMetered.class,
+            "explodeWithDefaultScope", DEFAULT_NAME_SUFFIX));
+        assertMetricIsSetup(metric);
+
+        assertThat("Metric intialises to zero",
+            metric.getCount(),
+            is(0L));
+
+        try {
+            instance.explodeWithDefaultScope();
+            fail("Expected an exception to be thrown");
+        } catch (RuntimeException ignored) {
+        }
+
+        assertThat("Metric is marked",
+            metric.getCount(),
+            is(1L));
+    }
+
+    @Test
+    public void anExceptionMeteredAnnotatedMethod_WithProtectedScope() throws Exception {
+
+        final Meter metric = registry.getMeters().get(name(InstrumentedWithExceptionMetered.class,
+            "explodeWithProtectedScope", DEFAULT_NAME_SUFFIX));
+
+        assertMetricIsSetup(metric);
+
+        assertThat("Metric intialises to zero",
+            metric.getCount(),
+            is(0L));
+
+        try {
+            instance.explodeWithProtectedScope();
+            fail("Expected an exception to be thrown");
+        } catch (RuntimeException ignored) {
+        }
+
+        assertThat("Metric is marked",
+            metric.getCount(),
+            is(1L));
+    }
+
+    @Test
+    public void anExceptionMeteredAnnotatedMethod_WithPublicScope_AndSpecificTypeOfException() throws Exception {
+
+        final Meter metric = registry.getMeters().get(name(InstrumentedWithExceptionMetered.class,
+            "failures"));
+        assertMetricIsSetup(metric);
+
+        assertThat("Metric intialises to zero",
+            metric.getCount(),
+            is(0L));
+        try {
+            instance.errorProneMethod(new MyException());
+            fail("Expected an exception to be thrown");
+        } catch (MyException ignored) {
+        }
+
+        assertThat("Metric should be marked when the specified exception type is thrown",
+            metric.getCount(),
+            is(1L));
+    }
+
+    @Test
+    public void anExceptionMeteredAnnotatedMethod_WithPublicScope_AndSubclassesOfSpecifiedException() throws Exception {
+
+        final Meter metric = registry.getMeters().get(name(InstrumentedWithExceptionMetered.class,
+            "failures"));
+        assertMetricIsSetup(metric);
+
+        assertThat("Metric intialises to zero",
+            metric.getCount(),
+            is(0L));
+        try {
+            instance.errorProneMethod(new MySpecialisedException());
+            fail("Expected an exception to be thrown");
+        } catch (MyException ignored) {
+        }
+
+        assertThat(
+            "Metric should be marked when a subclass of the specified exception type is thrown",
+            metric.getCount(),
+            is(1L));
+    }
+
+    @Test
+    public void anExceptionMeteredAnnotatedMethod_WithPublicScope_ButDifferentTypeOfException() throws Exception {
+
+        final Meter metric = registry.getMeters().get(name(InstrumentedWithExceptionMetered.class,
+            "failures"));
+        assertMetricIsSetup(metric);
+
+        assertThat("Metric intialises to zero",
+            metric.getCount(),
+            is(0L));
+        try {
+            instance.errorProneMethod(new MyOtherException());
+            fail("Expected an exception to be thrown");
+        } catch (MyOtherException ignored) {
+        }
+
+        assertThat("Metric should not be marked if the exception is a different type",
+            metric.getCount(),
+            is(0L));
+    }
+
+    @Test
+    public void anExceptionMeteredAnnotatedMethod_WithExtraOptions() throws Exception {
+
+        try {
+            instance.causeAnOutOfBoundsException();
+        } catch (ArrayIndexOutOfBoundsException ignored) {
+
+        }
+
+        final Meter metric = registry.getMeters().get(name(InstrumentedWithExceptionMetered.class,
+            "things"));
+
+        assertMetricIsSetup(metric);
+
+        assertThat("Guice creates a meter which gets marked",
+            metric.getCount(),
+            is(1L));
+    }
+
+    @Test
+    public void aMethodAnnotatedWithBothATimerAndAnExceptionCounter() throws Exception {
+
+        final Timer timedMetric = registry.getTimers().get(name(InstrumentedWithExceptionMetered.class,
+            "timedAndException", TIMED_SUFFIX));
+
+        final Meter errorMetric = registry.getMeters().get(name(InstrumentedWithExceptionMetered.class,
+            "timedAndException", DEFAULT_NAME_SUFFIX));
+
+        assertThat("Guice creates a metric",
+            timedMetric,
+            is(notNullValue()));
+
+        assertThat("Guice creates a timer",
+            timedMetric,
+            is(instanceOf(Timer.class)));
+
+        assertThat("Guice creates a metric",
+            errorMetric,
+            is(notNullValue()));
+
+        assertThat("Guice creates a meter",
+            errorMetric,
+            is(instanceOf(Meter.class)));
+
+        // Counts should start at zero        
+        assertThat("Timer Metric should be zero when initialised",
+            timedMetric.getCount(),
+            is(0L));
+
+        assertThat("Error Metric should be zero when initialised",
+            errorMetric.getCount(),
+            is(0L));
+
+        // Invoke, but don't throw an exception
+        instance.timedAndException(null);
+
+        assertThat("Expected the meter metric to be marked on invocation",
+            timedMetric.getCount(),
+            is(1L));
+
+        assertThat("Expected the exception metric to be zero since no exceptions thrown",
+            errorMetric.getCount(),
+            is(0L));
+
+        // Invoke and throw an exception
+        try {
+            instance.timedAndException(new RuntimeException());
+            fail("Should have thrown an exception");
+        } catch (Exception ignored) {
+        }
+
+        assertThat("Expected a count of 2, one for each invocation",
+            timedMetric.getCount(),
+            is(2L));
+
+        assertThat("Expected exception count to be 1 as one (of two) invocations threw an exception",
+            errorMetric.getCount(),
+            is(1L));
+    }
+
+    @Test
+    public void aMethodAnnotatedWithBothAMeteredAndAnExceptionCounter() throws Exception {
+
+        final Metric meteredMetric = registry.getMeters().get(name(InstrumentedWithExceptionMetered.class,
+            "meteredAndException", METERED_SUFFIX));
+
+        final Metric errorMetric = registry.getMeters().get(name(InstrumentedWithExceptionMetered.class,
+            "meteredAndException", DEFAULT_NAME_SUFFIX));
+
+        assertThat("Guice creates a metric",
+            meteredMetric,
+            is(notNullValue()));
+
+        assertThat("Guice creates a meter",
+            meteredMetric,
+            is(instanceOf(Meter.class)));
+
+        assertThat("Guice creates a metric",
+            errorMetric,
+            is(notNullValue()));
+
+        assertThat("Guice creates an exception meter",
+            errorMetric,
+            is(instanceOf(Meter.class)));
+
+        // Counts should start at zero        
+        assertThat("Meter Metric should be zero when initialised",
+            ((Meter) meteredMetric).getCount(),
+            is(0L));
+
+        assertThat("Error Metric should be zero when initialised",
+            ((Meter) errorMetric).getCount(),
+            is(0L));
+
+        // Invoke, but don't throw an exception
+        instance.meteredAndException(null);
+
+        assertThat("Expected the meter metric to be marked on invocation",
+            ((Meter) meteredMetric).getCount(),
+            is(1L));
+
+        assertThat("Expected the exception metric to be zero since no exceptions thrown",
+            ((Meter) errorMetric).getCount(),
+            is(0L));
+
+        // Invoke and throw an exception
+        try {
+            instance.meteredAndException(new RuntimeException());
+            fail("Should have thrown an exception");
+        } catch (Exception ignored) {
+        }
+
+        assertThat("Expected a count of 2, one for each invocation",
+            ((Meter) meteredMetric).getCount(),
+            is(2L));
+
+        assertThat("Expected exception count to be 1 as one (of two) invocations threw an exception",
+            ((Meter) errorMetric).getCount(),
+            is(1L));
+    }
+
+    private void assertMetricIsSetup(final Meter metric) {
+        assertThat("Guice creates a metric",
+            metric,
+            is(notNullValue()));
+    }
+
+    @SuppressWarnings("serial")
+    private static class MyOtherException extends RuntimeException {
+    }
+
+    @SuppressWarnings("serial")
+    private static class MySpecialisedException extends MyException {
+    }
+}

--- a/metrics-guice/src/test/java/com/palominolabs/metrics/guice/GaugeInheritanceTest.java
+++ b/metrics-guice/src/test/java/com/palominolabs/metrics/guice/GaugeInheritanceTest.java
@@ -1,0 +1,60 @@
+package com.palominolabs.metrics.guice;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.junit.Test;
+
+import static com.codahale.metrics.MetricRegistry.name;
+import static org.junit.Assert.assertEquals;
+
+public class GaugeInheritanceTest {
+
+    @Test
+    public void testInheritance() {
+        MetricRegistry registry = new MetricRegistry();
+        final Injector injector = Guice
+                .createInjector(MetricsInstrumentationModule.builder().withMetricRegistry(registry).build());
+        Parent parent = injector.getInstance(Parent.class);
+        Child1 child1 = injector.getInstance(Child1.class);
+        Child2 child2 = injector.getInstance(Child2.class);
+
+        // gauge in parent class is registered separately for each
+
+        assertEquals(0,
+                registry.getGauges().get(name(Parent.class, "aGauge", DeclaringClassMetricNamer.GAUGE_SUFFIX))
+                        .getValue());
+        assertEquals(1,
+                registry.getGauges().get(name(Child1.class, "aGauge", DeclaringClassMetricNamer.GAUGE_SUFFIX))
+                        .getValue());
+        assertEquals(2,
+                registry.getGauges().get(name(Child2.class, "aGauge", DeclaringClassMetricNamer.GAUGE_SUFFIX))
+                        .getValue());
+    }
+
+    static class Parent {
+
+        @com.codahale.metrics.annotation.Gauge
+        int aGauge() {
+            return complexInternalCalculation();
+        }
+
+        int complexInternalCalculation() {
+            return 0;
+        }
+    }
+
+    static class Child1 extends Parent {
+        @Override
+        int complexInternalCalculation() {
+            return 1;
+        }
+    }
+
+    static class Child2 extends Parent {
+        @Override
+        int complexInternalCalculation() {
+            return 2;
+        }
+    }
+}

--- a/metrics-guice/src/test/java/com/palominolabs/metrics/guice/GaugeInstanceClassNamerTest.java
+++ b/metrics-guice/src/test/java/com/palominolabs/metrics/guice/GaugeInstanceClassNamerTest.java
@@ -1,0 +1,27 @@
+package com.palominolabs.metrics.guice;
+
+import com.codahale.metrics.Gauge;
+import org.junit.Test;
+
+import static com.codahale.metrics.MetricRegistry.name;
+import static com.palominolabs.metrics.guice.DeclaringClassMetricNamer.GAUGE_SUFFIX;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class GaugeInstanceClassNamerTest extends GaugeTestBase {
+    @Override
+    MetricNamer getMetricNamer() {
+        return new GaugeInstanceClassMetricNamer();
+    }
+
+    @Test
+    public void aGaugeWithoutNameInSuperclass() throws Exception {
+        // named for the instantiated class
+        final Gauge<?> metric =
+                registry.getGauges().get(name(InstrumentedWithGauge.class, "justAGaugeFromParent",
+                        GAUGE_SUFFIX));
+
+        assertNotNull(metric);
+        assertEquals("justAGaugeFromParent", metric.getValue());
+    }
+}

--- a/metrics-guice/src/test/java/com/palominolabs/metrics/guice/GaugeTestBase.java
+++ b/metrics-guice/src/test/java/com/palominolabs/metrics/guice/GaugeTestBase.java
@@ -1,0 +1,105 @@
+package com.palominolabs.metrics.guice;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.codahale.metrics.MetricRegistry.name;
+import static com.palominolabs.metrics.guice.DeclaringClassMetricNamer.GAUGE_SUFFIX;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+@SuppressWarnings("unchecked")
+public abstract class GaugeTestBase {
+    private InstrumentedWithGauge instance;
+    MetricRegistry registry;
+
+    @Before
+    public void setup() {
+        this.registry = new MetricRegistry();
+        final Injector injector =
+                Guice.createInjector(MetricsInstrumentationModule.builder()
+                        .withMetricRegistry(registry)
+                        .withMetricNamer(getMetricNamer())
+                        .build());
+        this.instance = injector.getInstance(InstrumentedWithGauge.class);
+    }
+
+    abstract MetricNamer getMetricNamer();
+
+    @Test
+    public void aGaugeAnnotatedMethod() throws Exception {
+        instance.doAThing();
+
+        final Gauge metric = registry.getGauges().get(name(InstrumentedWithGauge.class, "things"));
+
+        assertThat("Guice creates a metric",
+                metric,
+                is(notNullValue()));
+
+        assertThat("Guice creates a gauge with the given value",
+                ((Gauge<String>) metric).getValue(),
+                is("poop"));
+    }
+
+    @Test
+    public void aGaugeAnnotatedMethodWithDefaultName() throws Exception {
+        instance.doAnotherThing();
+
+        final Gauge metric = registry.getGauges().get(name(InstrumentedWithGauge.class,
+                "doAnotherThing", GAUGE_SUFFIX));
+
+        assertThat("Guice creates a metric",
+                metric,
+                is(notNullValue()));
+
+        assertThat("Guice creates a gauge with the given value",
+                ((Gauge<String>) metric).getValue(),
+                is("anotherThing"));
+    }
+
+    @Test
+    public void aGaugeAnnotatedMethodWithAbsoluteName() throws Exception {
+        instance.doAThingWithAbsoluteName();
+
+        final Gauge metric = registry.getGauges().get(name("absoluteName"));
+
+        assertThat("Guice creates a metric",
+                metric,
+                is(notNullValue()));
+
+        assertThat("Guice creates a gauge with the given value",
+                ((Gauge<String>) metric).getValue(),
+                is("anotherThingWithAbsoluteName"));
+    }
+
+    @Test
+    public void aGaugeInSuperclass() throws Exception {
+        final Gauge<?> metric = registry.getGauges().get(name("gaugeParent"));
+
+        assertNotNull(metric);
+        assertEquals("gaugeParent", metric.getValue());
+    }
+
+    @Test
+    public void aPrivateGaugeInSuperclass() throws Exception {
+        final Gauge<?> metric = registry.getGauges().get(name("gaugeParentPrivate"));
+
+        assertNotNull(metric);
+        assertEquals("gaugeParentPrivate", metric.getValue());
+    }
+
+    @Test
+    public void aPrivateGauge() throws Exception {
+        final Gauge<?> metric = registry.getGauges().get(name(InstrumentedWithGauge.class, "gaugePrivate"));
+
+        assertNotNull(metric);
+        assertEquals("gaugePrivate", metric.getValue());
+    }
+}

--- a/metrics-guice/src/test/java/com/palominolabs/metrics/guice/GenericThing.java
+++ b/metrics-guice/src/test/java/com/palominolabs/metrics/guice/GenericThing.java
@@ -1,0 +1,8 @@
+package com.palominolabs.metrics.guice;
+
+class GenericThing<T> {
+
+    void doThing(T t) {
+
+    }
+}

--- a/metrics-guice/src/test/java/com/palominolabs/metrics/guice/InstrumentedWithCounter.java
+++ b/metrics-guice/src/test/java/com/palominolabs/metrics/guice/InstrumentedWithCounter.java
@@ -1,0 +1,26 @@
+package com.palominolabs.metrics.guice;
+
+import com.codahale.metrics.annotation.Counted;
+
+public class InstrumentedWithCounter extends InstrumentedWithCounterParent {
+    @Counted(name = "things", monotonic = true)
+    public String doAThing() {
+        return "poop";
+    }
+
+    @Counted(monotonic = true)
+    public String doAnotherThing() {
+        return "anotherThing";
+    }
+
+    @Counted(monotonic = false)
+    public String doYetAnotherThing() {
+        return "anotherThing";
+    }
+
+    @Counted(name = "absoluteName", absolute = true, monotonic = true)
+    public String doAThingWithAbsoluteName() {
+        return "anotherThingWithAbsoluteName";
+    }
+
+}

--- a/metrics-guice/src/test/java/com/palominolabs/metrics/guice/InstrumentedWithCounterParent.java
+++ b/metrics-guice/src/test/java/com/palominolabs/metrics/guice/InstrumentedWithCounterParent.java
@@ -1,0 +1,11 @@
+package com.palominolabs.metrics.guice;
+
+import com.codahale.metrics.annotation.Counted;
+
+public class InstrumentedWithCounterParent {
+
+    @Counted(name = "counterParent", absolute = true)
+    public String counterParent() {
+        return "counterParent";
+    }
+}

--- a/metrics-guice/src/test/java/com/palominolabs/metrics/guice/InstrumentedWithExceptionMetered.java
+++ b/metrics-guice/src/test/java/com/palominolabs/metrics/guice/InstrumentedWithExceptionMetered.java
@@ -1,0 +1,70 @@
+package com.palominolabs.metrics.guice;
+
+import com.codahale.metrics.annotation.ExceptionMetered;
+import com.codahale.metrics.annotation.Metered;
+import com.codahale.metrics.annotation.Timed;
+
+public class InstrumentedWithExceptionMetered {
+
+    @ExceptionMetered(name = "exceptionCounter")
+    String explodeWithPublicScope(boolean explode) {
+        if (explode) {
+            throw new RuntimeException("Boom!");
+        } else {
+            return "calm";
+        }
+    }
+
+    @ExceptionMetered
+    String explodeForUnnamedMetric() {
+        throw new RuntimeException("Boom!");
+    }
+
+    @ExceptionMetered(name = "n")
+    String explodeForMetricWithName() {
+        throw new RuntimeException("Boom!");
+    }
+
+    @ExceptionMetered(name = "absoluteName", absolute = true)
+    String explodeForMetricWithAbsoluteName() {
+        throw new RuntimeException("Boom!");
+    }
+
+    @ExceptionMetered
+    String explodeWithDefaultScope() {
+        throw new RuntimeException("Boom!");
+    }
+
+    @ExceptionMetered
+    protected String explodeWithProtectedScope() {
+        throw new RuntimeException("Boom!");
+    }
+
+    @ExceptionMetered(name = "failures", cause = MyException.class)
+    public void errorProneMethod(RuntimeException e) {
+        throw e;
+    }
+
+    @ExceptionMetered(name = "things",
+        cause = ArrayIndexOutOfBoundsException.class)
+    public Object causeAnOutOfBoundsException() {
+        final Object[] arr = {};
+        return arr[1];
+    }
+
+    @Timed
+    @ExceptionMetered
+    public void timedAndException(RuntimeException e) {
+        if (e != null) {
+            throw e;
+        }
+    }
+
+    @Metered
+    @ExceptionMetered
+    public void meteredAndException(RuntimeException e) {
+        if (e != null) {
+            throw e;
+        }
+    }
+}

--- a/metrics-guice/src/test/java/com/palominolabs/metrics/guice/InstrumentedWithGauge.java
+++ b/metrics-guice/src/test/java/com/palominolabs/metrics/guice/InstrumentedWithGauge.java
@@ -1,0 +1,25 @@
+package com.palominolabs.metrics.guice;
+
+import com.codahale.metrics.annotation.Gauge;
+
+public class InstrumentedWithGauge extends InstrumentedWithGaugeParent {
+    @Gauge(name = "things")
+    public String doAThing() {
+        return "poop";
+    }
+
+    @Gauge
+    public String doAnotherThing() {
+        return "anotherThing";
+    }
+
+    @Gauge(name = "absoluteName", absolute = true)
+    public String doAThingWithAbsoluteName() {
+        return "anotherThingWithAbsoluteName";
+    }
+
+    @Gauge(name = "gaugePrivate")
+    private String gaugePrivate() {
+        return "gaugePrivate";
+    }
+}

--- a/metrics-guice/src/test/java/com/palominolabs/metrics/guice/InstrumentedWithGaugeParent.java
+++ b/metrics-guice/src/test/java/com/palominolabs/metrics/guice/InstrumentedWithGaugeParent.java
@@ -1,0 +1,20 @@
+package com.palominolabs.metrics.guice;
+
+import com.codahale.metrics.annotation.Gauge;
+
+class InstrumentedWithGaugeParent {
+    @Gauge(name = "gaugeParent", absolute = true)
+    public String gaugeParent() {
+        return "gaugeParent";
+    }
+
+    @Gauge(name = "gaugeParentPrivate", absolute = true)
+    private String gaugeParentPrivate() {
+        return "gaugeParentPrivate";
+    }
+
+    @Gauge
+    public String justAGaugeFromParent() {
+        return "justAGaugeFromParent";
+    }
+}

--- a/metrics-guice/src/test/java/com/palominolabs/metrics/guice/InstrumentedWithMetered.java
+++ b/metrics-guice/src/test/java/com/palominolabs/metrics/guice/InstrumentedWithMetered.java
@@ -1,0 +1,30 @@
+package com.palominolabs.metrics.guice;
+
+import com.codahale.metrics.annotation.Metered;
+
+public class InstrumentedWithMetered {
+    @Metered(name = "things")
+    public String doAThing() {
+        return "poop";
+    }
+
+    @Metered
+    String doAThingWithDefaultScope() {
+        return "defaultResult";
+    }
+
+    @Metered
+    protected String doAThingWithProtectedScope() {
+        return "defaultProtected";
+    }
+
+    @Metered(name = "n")
+    protected String doAThingWithName() {
+        return "withName";
+    }
+
+    @Metered(name = "nameAbs", absolute = true)
+    protected String doAThingWithAbsoluteName() {
+        return "absoluteName";
+    }
+}

--- a/metrics-guice/src/test/java/com/palominolabs/metrics/guice/InstrumentedWithTimed.java
+++ b/metrics-guice/src/test/java/com/palominolabs/metrics/guice/InstrumentedWithTimed.java
@@ -1,0 +1,26 @@
+package com.palominolabs.metrics.guice;
+
+import com.codahale.metrics.annotation.Timed;
+
+public class InstrumentedWithTimed {
+    @Timed(name = "things")
+    public String doAThing() throws InterruptedException {
+        Thread.sleep(10);
+        return "poop";
+    }
+
+    @Timed
+    String doAThingWithDefaultScope() {
+        return "defaultResult";
+    }
+
+    @Timed
+    protected String doAThingWithProtectedScope() {
+        return "defaultProtected";
+    }
+
+    @Timed(name = "absoluteName", absolute = true)
+    protected String doAThingWithAbsoluteName() {
+        return "defaultProtected";
+    }
+}

--- a/metrics-guice/src/test/java/com/palominolabs/metrics/guice/MatcherTest.java
+++ b/metrics-guice/src/test/java/com/palominolabs/metrics/guice/MatcherTest.java
@@ -1,0 +1,67 @@
+package com.palominolabs.metrics.guice;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.TypeLiteral;
+import com.google.inject.matcher.AbstractMatcher;
+import com.google.inject.matcher.Matcher;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.codahale.metrics.MetricRegistry.name;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class MatcherTest {
+    private InstrumentedWithTimed timedInstance;
+    private InstrumentedWithMetered meteredInstance;
+    private MetricRegistry registry;
+
+    @Before
+    public void setup() {
+        this.registry = new MetricRegistry();
+        final Matcher<? super TypeLiteral<?>> matcher = new AbstractMatcher<TypeLiteral<?>>() {
+            @Override
+            public boolean matches(final TypeLiteral<?> typeLiteral) {
+                return InstrumentedWithMetered.class.isAssignableFrom(typeLiteral.getRawType());
+            }
+        };
+        final Injector injector = Guice.createInjector(MetricsInstrumentationModule.builder().withMetricRegistry(registry).withMatcher(matcher).build());
+        this.timedInstance = injector.getInstance(InstrumentedWithTimed.class);
+        this.meteredInstance = injector.getInstance(InstrumentedWithMetered.class);
+    }
+
+    @Test
+    public void aTimedAnnotatedMethod() throws Exception {
+
+        timedInstance.doAThing();
+
+        final Timer metric = registry.getTimers().get(name(InstrumentedWithTimed.class,
+            "things"));
+
+        assertThat("Guice did not create a metric for timed",
+            metric,
+            is(nullValue()));
+    }
+
+    @Test
+    public void aMeteredAnnotatedMethod() throws Exception {
+
+        meteredInstance.doAThing();
+
+        final Meter metric = registry.getMeters().get(name(InstrumentedWithMetered.class, "things"));
+
+        assertThat("Guice creates a metric",
+            metric,
+            is(notNullValue()));
+
+        assertThat("Guice creates a meter which gets marked",
+            metric.getCount(),
+            is(1L));
+    }
+}

--- a/metrics-guice/src/test/java/com/palominolabs/metrics/guice/MeteredTest.java
+++ b/metrics-guice/src/test/java/com/palominolabs/metrics/guice/MeteredTest.java
@@ -1,0 +1,118 @@
+package com.palominolabs.metrics.guice;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.codahale.metrics.MetricRegistry.name;
+import static com.palominolabs.metrics.guice.DeclaringClassMetricNamer.METERED_SUFFIX;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class MeteredTest {
+    private InstrumentedWithMetered instance;
+    private MetricRegistry registry;
+
+    @Before
+    public void setup() {
+        this.registry = new MetricRegistry();
+        final Injector injector = Guice.createInjector(MetricsInstrumentationModule.builder().withMetricRegistry(registry).build());
+        this.instance = injector.getInstance(InstrumentedWithMetered.class);
+    }
+
+    @Test
+    public void aMeteredAnnotatedMethod() throws Exception {
+
+        instance.doAThing();
+
+        final Meter metric = registry.getMeters().get(name(InstrumentedWithMetered.class, "things"));
+
+        assertMetricIsSetup(metric);
+
+        assertThat("Guice creates a meter which gets marked",
+            metric.getCount(),
+            is(1L));
+    }
+
+    @Test
+    public void aMeteredAnnotatedMethodWithDefaultScope() throws Exception {
+
+        final Meter metric = registry.getMeters().get(name(InstrumentedWithMetered.class, "doAThingWithDefaultScope",
+            METERED_SUFFIX));
+        assertMetricIsSetup(metric);
+
+        assertThat("Metric initialises to zero",
+            metric.getCount(),
+            is(0L));
+
+        instance.doAThingWithDefaultScope();
+
+        assertThat("Metric is marked",
+            metric.getCount(),
+            is(1L));
+    }
+
+    @Test
+    public void aMeteredAnnotatedMethodWithProtectedScope() throws Exception {
+
+        final Meter metric = registry.getMeters().get(name(InstrumentedWithMetered.class, "doAThingWithProtectedScope",
+            METERED_SUFFIX));
+
+        assertMetricIsSetup(metric);
+
+        assertThat("Metric initialises to zero",
+            metric.getCount(),
+            is(0L));
+
+        instance.doAThingWithProtectedScope();
+
+        assertThat("Metric is marked",
+            metric.getCount(),
+            is(1L));
+    }
+
+    @Test
+    public void aMeteredAnnotatedMethodWithName() throws Exception {
+
+        final Meter metric = registry.getMeters().get(name(InstrumentedWithMetered.class, "n"));
+
+        assertMetricIsSetup(metric);
+
+        assertThat("Metric initialises to zero",
+            metric.getCount(),
+            is(0L));
+
+        instance.doAThingWithName();
+
+        assertThat("Metric is marked",
+            metric.getCount(),
+            is(1L));
+    }
+
+    @Test
+    public void aMeteredAnnotatedMethodWithAbsoluteName() {
+        final Meter metric = registry.getMeters().get(name("nameAbs"));
+
+        assertMetricIsSetup(metric);
+
+        assertThat("Metric initialises to zero",
+            metric.getCount(),
+            is(0L));
+
+        instance.doAThingWithAbsoluteName();
+
+        assertThat("Metric is marked",
+            metric.getCount(),
+            is(1L));
+    }
+
+    private void assertMetricIsSetup(final Meter metric) {
+        assertThat("Guice creates a metric",
+            metric,
+            is(notNullValue()));
+    }
+}

--- a/metrics-guice/src/test/java/com/palominolabs/metrics/guice/MyException.java
+++ b/metrics-guice/src/test/java/com/palominolabs/metrics/guice/MyException.java
@@ -1,0 +1,5 @@
+package com.palominolabs.metrics.guice;
+
+public class MyException extends RuntimeException {
+
+}

--- a/metrics-guice/src/test/java/com/palominolabs/metrics/guice/StringThing.java
+++ b/metrics-guice/src/test/java/com/palominolabs/metrics/guice/StringThing.java
@@ -1,0 +1,11 @@
+package com.palominolabs.metrics.guice;
+
+import com.codahale.metrics.annotation.Counted;
+
+class StringThing extends GenericThing<String> {
+
+    @Override
+    @Counted(name = "stringThing", absolute = true, monotonic = true)
+    void doThing(String s) {
+    }
+}

--- a/metrics-guice/src/test/java/com/palominolabs/metrics/guice/TimedTest.java
+++ b/metrics-guice/src/test/java/com/palominolabs/metrics/guice/TimedTest.java
@@ -1,0 +1,91 @@
+package com.palominolabs.metrics.guice;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.codahale.metrics.MetricRegistry.name;
+import static com.palominolabs.metrics.guice.DeclaringClassMetricNamer.TIMED_SUFFIX;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class TimedTest {
+    private InstrumentedWithTimed instance;
+    private MetricRegistry registry;
+
+    @Before
+    public void setup() {
+        this.registry = new MetricRegistry();
+        final Injector injector = Guice.createInjector(MetricsInstrumentationModule.builder().withMetricRegistry(registry).build());
+        this.instance = injector.getInstance(InstrumentedWithTimed.class);
+    }
+
+    @Test
+    public void aTimedAnnotatedMethod() throws Exception {
+
+        instance.doAThing();
+
+        final Timer metric = registry.getTimers().get(name(InstrumentedWithTimed.class,
+            "things"));
+
+        assertMetricSetup(metric);
+
+        assertThat("Guice creates a timer which records invocation length",
+            metric.getCount(),
+            is(1L));
+
+        assertThat("Guice creates a timer which records invocation duration without underestimating too much",
+            metric.getSnapshot().getMax(),
+            is(greaterThan(NANOSECONDS.convert(5, MILLISECONDS))));
+
+        assertThat("Guice creates a timer which records invocation duration without overestimating too much",
+            metric.getSnapshot().getMax(),
+            is(lessThan(NANOSECONDS.convert(15, MILLISECONDS))));
+    }
+
+    @Test
+    public void aTimedAnnotatedMethodWithDefaultScope() throws Exception {
+
+        instance.doAThingWithDefaultScope();
+
+        final Timer metric = registry.getTimers().get(name(InstrumentedWithTimed.class,
+            "doAThingWithDefaultScope", TIMED_SUFFIX));
+
+        assertMetricSetup(metric);
+    }
+
+    @Test
+    public void aTimedAnnotatedMethodWithProtectedScope() throws Exception {
+
+        instance.doAThingWithProtectedScope();
+
+        final Timer metric = registry.getTimers().get(name(InstrumentedWithTimed.class,
+            "doAThingWithProtectedScope", TIMED_SUFFIX));
+
+        assertMetricSetup(metric);
+    }
+
+    @Test
+    public void aTimedAnnotatedMethodWithAbsoluteName() throws Exception {
+
+        instance.doAThingWithAbsoluteName();
+
+        final Timer metric = registry.getTimers().get(name("absoluteName"));
+
+        assertMetricSetup(metric);
+    }
+
+    private void assertMetricSetup(final Timer metric) {
+        assertThat("Guice creates a metric",
+            metric,
+            is(notNullValue()));
+    }
+}

--- a/metrics-guice/src/test/java/com/palominolabs/metrics/guice/annotation/ClassAnnotationResolverTest.java
+++ b/metrics-guice/src/test/java/com/palominolabs/metrics/guice/annotation/ClassAnnotationResolverTest.java
@@ -1,0 +1,48 @@
+package com.palominolabs.metrics.guice.annotation;
+
+import com.codahale.metrics.annotation.Counted;
+import com.codahale.metrics.annotation.Metered;
+import com.codahale.metrics.annotation.Timed;
+import java.lang.reflect.Method;
+
+import static junit.framework.TestCase.assertNotNull;
+
+import org.junit.Test;
+
+public class ClassAnnotationResolverTest {
+
+    @Test
+    public void testTypeLevelAnnotations() throws Exception {
+        AnnotationResolver matcher = new ClassAnnotationResolver();
+        Class<TypeLevelAnnotatedClass> klass = TypeLevelAnnotatedClass.class;
+        Method publicMethod = klass.getDeclaredMethod("publicMethod");
+        Method protectedMethod = klass.getDeclaredMethod("protectedMethod");
+        Method packagePrivateMethod = klass.getDeclaredMethod("packagePrivateMethod");
+
+        assertNotNull(matcher.findAnnotation(Timed.class, publicMethod));
+        assertNotNull(matcher.findAnnotation(Metered.class, publicMethod));
+        assertNotNull(matcher.findAnnotation(Counted.class, publicMethod));
+
+        assertNotNull(matcher.findAnnotation(Timed.class, protectedMethod));
+        assertNotNull(matcher.findAnnotation(Metered.class, protectedMethod));
+        assertNotNull(matcher.findAnnotation(Counted.class, protectedMethod));
+
+        assertNotNull(matcher.findAnnotation(Timed.class, packagePrivateMethod));
+        assertNotNull(matcher.findAnnotation(Metered.class, packagePrivateMethod));
+        assertNotNull(matcher.findAnnotation(Counted.class, packagePrivateMethod));
+    }
+
+    @Timed
+    @Metered
+    @Counted
+    private static class TypeLevelAnnotatedClass {
+        public void publicMethod() {
+        }
+
+        protected void protectedMethod() {
+        }
+
+        void packagePrivateMethod() {
+        }
+    }
+}

--- a/metrics-guice/src/test/java/com/palominolabs/metrics/guice/annotation/ListAnnotationResolverTest.java
+++ b/metrics-guice/src/test/java/com/palominolabs/metrics/guice/annotation/ListAnnotationResolverTest.java
@@ -1,0 +1,62 @@
+package com.palominolabs.metrics.guice.annotation;
+
+import com.codahale.metrics.annotation.Counted;
+import com.codahale.metrics.annotation.Metered;
+import com.codahale.metrics.annotation.Timed;
+import com.google.common.collect.Lists;
+import java.lang.reflect.Method;
+
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertNull;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class ListAnnotationResolverTest {
+
+    @Test
+    public void testMixedAnnotations() throws Exception {
+        ListAnnotationResolver annotationProvider = new ListAnnotationResolver(
+                Lists.newArrayList(
+                        new MethodAnnotationResolver(),
+                        new ClassAnnotationResolver()
+                )
+        );
+
+        Class<MixedAnnotatedClass> klass = MixedAnnotatedClass.class;
+        Method publicMethod = klass.getDeclaredMethod("publicMethod");
+        Method protectedMethod = klass.getDeclaredMethod("protectedMethod");
+        Method packagePrivateMethod = klass.getDeclaredMethod("packagePrivateMethod");
+
+        Timed classTimed = annotationProvider.findAnnotation(Timed.class, publicMethod);
+        assertNotNull(classTimed);
+        assertFalse(classTimed.absolute());
+        assertNull(annotationProvider.findAnnotation(Metered.class, publicMethod));
+        assertNull(annotationProvider.findAnnotation(Counted.class, publicMethod));
+
+        assertNotNull(annotationProvider.findAnnotation(Timed.class, protectedMethod));
+        assertNotNull(annotationProvider.findAnnotation(Metered.class, protectedMethod));
+        assertNull(annotationProvider.findAnnotation(Counted.class, protectedMethod));
+
+        Timed methodTimed = annotationProvider.findAnnotation(Timed.class, packagePrivateMethod);
+        assertNotNull(methodTimed);
+        assertTrue(methodTimed.absolute());
+        assertNull(annotationProvider.findAnnotation(Metered.class, packagePrivateMethod));
+        assertNull(annotationProvider.findAnnotation(Counted.class, packagePrivateMethod));
+    }
+
+    @Timed
+    private static class MixedAnnotatedClass {
+        public void publicMethod() {
+        }
+
+        @Metered
+        protected void protectedMethod() {
+        }
+
+        @Timed(absolute = true)
+        void packagePrivateMethod() {
+        }
+    }
+}

--- a/metrics-guice/src/test/java/com/palominolabs/metrics/guice/annotation/MethodAnnotationResolverTest.java
+++ b/metrics-guice/src/test/java/com/palominolabs/metrics/guice/annotation/MethodAnnotationResolverTest.java
@@ -1,0 +1,44 @@
+package com.palominolabs.metrics.guice.annotation;
+
+import com.codahale.metrics.annotation.Counted;
+import com.codahale.metrics.annotation.Metered;
+import com.codahale.metrics.annotation.Timed;
+import java.lang.reflect.Method;
+
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertNull;
+
+import org.junit.Test;
+
+public class MethodAnnotationResolverTest {
+    @Test
+    public void testMethodAnnotations() throws Exception {
+        AnnotationResolver matcher = new MethodAnnotationResolver();
+        Class<MethodAnnotatedClass> klass = MethodAnnotatedClass.class;
+        Method publicMethod = klass.getDeclaredMethod("publicMethod");
+        Method protectedMethod = klass.getDeclaredMethod("protectedMethod");
+        Method packagePrivateMethod = klass.getDeclaredMethod("packagePrivateMethod");
+
+        assertNotNull(matcher.findAnnotation(Timed.class, publicMethod));
+        assertNotNull(matcher.findAnnotation(Metered.class, protectedMethod));
+        assertNotNull(matcher.findAnnotation(Counted.class, packagePrivateMethod));
+
+        assertNull(matcher.findAnnotation(Timed.class, packagePrivateMethod));
+        assertNull(matcher.findAnnotation(Counted.class, protectedMethod));
+        assertNull(matcher.findAnnotation(Metered.class, publicMethod));
+    }
+
+    private static class MethodAnnotatedClass {
+        @Timed
+        public void publicMethod() {
+        }
+
+        @Metered
+        protected void protectedMethod() {
+        }
+
+        @Counted
+        void packagePrivateMethod() {
+        }
+    }
+}

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -64,7 +64,6 @@
         <version.dropwizard.hocon>0.5.1</version.dropwizard.hocon>
         <version.dropwizard.metrics>4.2.19</version.dropwizard.metrics>
         <version.dropwizard.metrics.cloudwatch>2.0.8</version.dropwizard.metrics.cloudwatch>
-        <version.dropwizard.metrics.guice>4.0.0</version.dropwizard.metrics.guice>
         <version.easymock>5.1.0</version.easymock>
         <version.flyway>9.20.0</version.flyway>
         <version.graphql-kotlin>6.5.2</version.graphql-kotlin>
@@ -480,11 +479,6 @@
                 <groupId>jakarta.servlet</groupId>
                 <artifactId>jakarta.servlet-api</artifactId>
                 <version>${version.servlet}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.palominolabs.metrics</groupId>
-                <artifactId>metrics-guice</artifactId>
-                <version>${version.dropwizard.metrics.guice}</version>
             </dependency>
             <dependency>
                 <groupId>org.hibernate.validator</groupId>
@@ -1332,6 +1326,8 @@
                                     <exclude>jakarta.activation:jakarta.activation-api</exclude>
                                     <!-- use org.glassfish.jaxb:jaxb-runtime -->
                                     <exclude>com.sun.xml.bind:jaxb-impl</exclude>
+                                    <!-- use com.trib3:metrics-guice since no longer available -->
+                                    <exclude>com.palominolabs.metrics:metrics-guice</exclude>
                                 </excludes>
                             </bannedDependencies>
                         </rules>

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
     </scm>
 
     <modules>
+        <module>metrics-guice</module>
         <module>build-resources</module>
         <module>parent-pom</module>
         <module>testing</module>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -118,8 +118,9 @@
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.palominolabs.metrics</groupId>
+            <groupId>com.trib3</groupId>
             <artifactId>metrics-guice</artifactId>
+            <version>${version.leakycauldron}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
v4 of metrics-guice is no longer available via jcenter. Add its source here and wrap a minimal pom around it so we can build it and still use it under a different maven coordinate.