### PR TITLE
Bump Logback for security issues

### DIFF
--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -102,7 +102,7 @@
         <version.kotlin.logging>3.0.5</version.kotlin.logging>
         <version.ktlint>0.50.0</version.ktlint>
         <version.leakycauldron>${project.version}</version.leakycauldron>
-        <version.logback>1.4.11</version.logback>
+        <version.logback>1.4.14</version.logback>
         <version.maven.antrun>3.1.0</version.maven.antrun>
         <version.maven.assembly>3.6.0</version.maven.assembly>
         <version.maven.buildhelper>3.5.0</version.maven.buildhelper>


### PR DESCRIPTION
Sonatype (part of the opensource system we use) alerted us to some security issues with the current version of logback since this is a minor version change I want to bump this now to be pulled in as part of the pebbles 3.0 bump.