### PR TITLE
[INFOSEC-1044]Pin specific Trivy version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,12 +12,15 @@ jobs:
       - checkout
       - run:
           name: Install Trivy
+          environment:
+            TRIVY_VERSION: "0.69.3"
           command: |
             sudo apt install apt-transport-https gnupg lsb-release
             echo $TRIVY_PGP_KEY | sed 's/\$/\n/g' | sudo apt-key add -
             echo deb https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main | sudo tee -a /etc/apt/sources.list.d/trivy.list
-            sudo apt update
-            sudo apt install trivy
+            sudo apt-get update
+            sudo apt-get install -y "trivy=${TRIVY_VERSION}"
+            trivy --version
       - run:
           name: Vulnerability check
           command: |


### PR DESCRIPTION
Pin a specific Trivy version instead of the latest version due to a supply chain attack