### PR TITLE
fix(pom): add name and description to published modules for Central

### DIFF
--- a/config/pom.xml
+++ b/config/pom.xml
@@ -15,6 +15,9 @@
     <groupId>com.trib3</groupId>
     <artifactId>config</artifactId>
 
+    <name>Leaky Cauldron :: Config</name>
+    <description>Config libraries for building kotlin services</description>
+
     <dependencies>
         <!-- hocon config -->
         <dependency>

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -15,6 +15,9 @@
     <groupId>com.trib3</groupId>
     <artifactId>db</artifactId>
 
+    <name>Leaky Cauldron :: DB</name>
+    <description>DB libraries for building kotlin services</description>
+
     <dependencies>
         <!-- hocon config -->
         <dependency>

--- a/graphql/pom.xml
+++ b/graphql/pom.xml
@@ -15,6 +15,9 @@
     <groupId>com.trib3</groupId>
     <artifactId>graphql</artifactId>
 
+    <name>Leaky Cauldron :: GraphQL</name>
+    <description>GraphQL libraries for building kotlin services</description>
+
     <dependencies>
         <dependency>
             <groupId>com.trib3</groupId>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -15,6 +15,9 @@
     <groupId>com.trib3</groupId>
     <artifactId>json</artifactId>
 
+    <name>Leaky Cauldron :: JSON</name>
+    <description>JSON libraries for building kotlin services</description>
+
     <dependencies>
         <!-- guice -->
         <dependency>

--- a/metrics-guice/pom.xml
+++ b/metrics-guice/pom.xml
@@ -15,6 +15,9 @@
     <groupId>com.trib3</groupId>
     <artifactId>metrics-guice</artifactId>
 
+    <name>Leaky Cauldron :: Metrics Guice</name>
+    <description>Metrics Guice libraries for building kotlin services</description>
+
     <dependencies>
         <dependency>
             <groupId>com.google.inject</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -15,6 +15,9 @@
     <groupId>com.trib3</groupId>
     <artifactId>server</artifactId>
 
+    <name>Leaky Cauldron :: Server</name>
+    <description>Server libraries for building kotlin services</description>
+
     <dependencies>
         <dependency>
             <groupId>org.jetbrains.kotlinx</groupId>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -15,6 +15,9 @@
     <groupId>com.trib3</groupId>
     <artifactId>testing</artifactId>
 
+    <name>Leaky Cauldron :: Testing</name>
+    <description>Testing libraries for building kotlin services</description>
+
     <dependencies>
         <dependency>
             <groupId>com.trib3</groupId>


### PR DESCRIPTION
Maven Central's Portal validation rejected the release with "Project name is missing" for every library module. <name> and <description> are not inherited from the parent POM, so each module needs its own. Add both to config, db, graphql, json, metrics-guice, server and testing. url/license/scm/developers are inherited from the parent and were not flagged.