### PR TITLE
add a cooldown to dep bot prs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
   schedule:
     interval: daily
     time: "07:00"
+  cooldown:
+    default-days: 30
   pull-request-branch-name:
     separator: "-"
   open-pull-requests-limit: 99


### PR DESCRIPTION
Add a cooldown to wait a while before opening a PR and running a build. Just picked 30 days out of the air willing to change it based on any preference.